### PR TITLE
Add ELK logging and switch to SSM for config

### DIFF
--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -1,12 +1,21 @@
-import play.api._
+import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
+import com.gu.{AppIdentity, AwsIdentity}
 import play.api.ApplicationLoader.Context
-import play.filters.HttpFiltersComponents
+import play.api._
 
 class AppLoader extends ApplicationLoader {
   def load(context: Context): Application = {
     LoggerConfigurator(context.environment.classLoader).foreach {
       _.configure(context.environment, context.initialConfiguration, Map.empty)
     }
-    new AppComponents(context).application
+    val identity = AppIdentity.whoAmI(defaultAppName = "typerighter")
+    val loadedConfig = ConfigurationLoader.load(identity) {
+      case identity: AwsIdentity => SSMConfigurationLocation.default(identity)
+    }
+
+    new AppComponents(
+      context.copy(initialConfiguration = context.initialConfiguration ++ Configuration(loadedConfig)),
+      identity
+    ).application
   }
 }

--- a/app/services/ElkLogging.scala
+++ b/app/services/ElkLogging.scala
@@ -1,0 +1,106 @@
+package services
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.{AsyncAppender, Logger, LoggerContext}
+import ch.qos.logback.core.Appender
+import ch.qos.logback.core.joran.spi.JoranException
+import ch.qos.logback.core.util.StatusPrinter
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.gu.AwsIdentity
+import com.gu.logback.appender.kinesis.KinesisAppender
+import net.logstash.logback.layout.LogstashLayout
+import org.slf4j.{LoggerFactory, Logger => SLFLogger}
+import play.api.inject.ApplicationLifecycle
+import play.api.libs.json.{Json => PlayJson}
+import typerighter.BuildInfo
+import utils.Loggable
+
+import scala.util.control.NonFatal
+
+class ElkLogging(identity: AwsIdentity,
+                 maybeLoggingStreamName: Option[String],
+                 awsCredentialsProvider: AWSCredentialsProvider,
+                 applicationLifecycle: ApplicationLifecycle) extends Loggable {
+  def getContextTags(identity: AwsIdentity): Map[String, String] = {
+    val effective = Map(
+      "app" -> identity.app,
+      "stage" -> identity.stage,
+      "stack" -> identity.stack,
+      "region" -> identity.region,
+      "buildNumber" -> BuildInfo.buildNumber
+    )
+    log.info(s"Logging with context map: $effective")
+    effective
+  }
+
+  // initialise immediately, but ensure we don't blow anything up if we fail
+  try {
+    init()
+  } catch {
+    case NonFatal(e) => log.error("Failed to initialise log shipping", e)
+  }
+
+  def makeCustomFields(customFields: Map[String, String]): String = {
+    PlayJson.stringify(PlayJson.toJson(customFields))
+  }
+
+  private def makeLayout(customFields: String) = {
+    val l = new LogstashLayout()
+    l.setCustomFields(customFields)
+    l
+  }
+
+  private def makeKinesisAppender(layout: LogstashLayout, context: LoggerContext, streamName: String, bufferSize: Int, region: String): KinesisAppender[ILoggingEvent] = {
+    val a = new KinesisAppender[ILoggingEvent]()
+    a.setStreamName(streamName)
+    a.setRegion(region)
+    a.setCredentialsProvider(awsCredentialsProvider)
+    a.setBufferSize(bufferSize)
+
+    a.setContext(context)
+    a.setLayout(layout)
+
+    layout.start()
+    a.start()
+    a
+  }
+
+  private def wrapWithAsyncAppender(context: LoggerContext, appender: Appender[ILoggingEvent], bufferSize: Int): AsyncAppender = {
+    val a = new AsyncAppender()
+    a.addAppender(appender)
+    a.setNeverBlock(true)
+    a.setQueueSize(bufferSize)
+    a.setIncludeCallerData(true)
+    a.setContext(context)
+    a.start()
+    a
+  }
+
+  // assume SLF4J is bound to logback in the current environment
+  private def getLoggerContext = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+
+  private def getRootLogger = LoggerFactory.getLogger(SLFLogger.ROOT_LOGGER_NAME).asInstanceOf[Logger]
+
+  def init() {
+    if (maybeLoggingStreamName.isEmpty) log.info("Not configuring log shipping as stream not configured")
+
+    val bufferSize = 1000
+
+    maybeLoggingStreamName.foreach { streamName =>
+      log.info("Configuring logging to ship to ELK")
+
+      try {
+        val layout = makeLayout(makeCustomFields(getContextTags(identity)))
+        val appender = makeKinesisAppender(layout, getLoggerContext, streamName, bufferSize, identity.region)
+        val asyncAppender = wrapWithAsyncAppender(getLoggerContext, appender, bufferSize)
+        val rootLogger = getRootLogger
+        rootLogger.addAppender(asyncAppender)
+      } catch {
+        case e: JoranException => // ignore, errors will be printed below
+      }
+
+      StatusPrinter.printInCaseOfErrorsOrWarnings(getLoggerContext)
+      log.info("Log shipping configuration completed")
+    }
+  }
+}

--- a/app/services/SheetsRuleResource.scala
+++ b/app/services/SheetsRuleResource.scala
@@ -32,28 +32,24 @@ object SheetsRuleResource {
     * @param credentialsFilePath A string containing the credentials file path.
     *                            These can be generated in Google Platform at
     *                            https://console.cloud.google.com/apis/credentials.
-    * @param HTTP_TRANSPORT The network HTTP Transport.
     * @return An authorized Credential object.
     * @throws IOException If the credentials.json file cannot be found.
     */
-  private def getCredentials(credentialsFilePath: String, HTTP_TRANSPORT: NetHttpTransport) = {
-    val in = new FileInputStream(credentialsFilePath)
-    if (in == null) throw new FileNotFoundException("Resource not found: " + credentialsFilePath)
-    val credential = GoogleCredential
+  private def getCredentials(credentials: String) = {
+    val in = new ByteArrayInputStream(credentials.getBytes)
+    GoogleCredential
       .fromStream(in)
       .createScoped(Collections.singleton(SheetsScopes.SPREADSHEETS))
-    in.close
-    credential
   }
 
   def getDictionariesFromSheet(configuration: Configuration): (List[PatternRule], List[String]) = { // Build a new authorized API client service.
     val HTTP_TRANSPORT = GoogleNetHttpTransport.newTrustedTransport
     val maybeResult = for {
-      credentialsPath <- configuration.getOptional[String]("typerighter.google.credentials.filePath")
+      credentialsData <- configuration.getOptional[String]("typerighter.google.credentials")
       spreadsheetId <- configuration.getOptional[String]("typerighter.sheetId")
       range <- configuration.getOptional[String]("typerighter.sheetRange")
     } yield {
-      val credentials = getCredentials(credentialsPath, HTTP_TRANSPORT)
+      val credentials = getCredentials(credentialsData)
       val service = new Sheets.Builder(
         HTTP_TRANSPORT,
         JSON_FACTORY,

--- a/app/utils/Loggable.scala
+++ b/app/utils/Loggable.scala
@@ -3,5 +3,5 @@ package utils
 import org.slf4j.{Logger, LoggerFactory}
 
 trait Loggable {
-  implicit val logger: Logger = LoggerFactory.getLogger(getClass)
+  implicit val log: Logger = LoggerFactory.getLogger(getClass)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,12 @@
+import com.gu.riffraff.artifact.BuildInfo
+
 name := """typerighter"""
 organization := "com.gu"
 
 version := "1.0-SNAPSHOT"
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin, GatlingPlugin)
+lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin,
+  GatlingPlugin, BuildInfoPlugin)
 
 riffRaffArtifactResources := Seq(
   (packageBin in Debian).value -> s"${name.value}/${name.value}.deb",
@@ -23,17 +26,39 @@ javaOptions in Universal ++= Seq(
   "-Dconfig.file=/etc/gu/typerighter.conf"
 )
 
-val languageToolVersion = "4.3"
+buildInfoPackage := "typerighter"
+
+buildInfoKeys := {
+  lazy val buildInfo = BuildInfo(baseDirectory.value)
+  Seq[BuildInfoKey](
+    BuildInfoKey.constant("buildNumber", buildInfo.buildIdentifier),
+    // so this next one is constant to avoid it always recompiling on dev machines.
+    // we only really care about build time on teamcity, when a constant based on when
+    // it was loaded is just fine
+    BuildInfoKey.constant("buildTime", System.currentTimeMillis),
+    BuildInfoKey.constant("gitCommitId", buildInfo.revision)
+  )
+}
 
 resolvers += "Spring IO" at "https://repo.spring.io/plugins-release/"
+resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
+
+val languageToolVersion = "4.3"
+val awsSdkVersion = "1.11.571"
 
 libraryDependencies ++= Seq(
+  "com.gu" %% "simple-configuration-ssm" % "1.5.0",
   "org.languagetool" % "languagetool-core" % languageToolVersion,
   "org.languagetool" % "language-en" % languageToolVersion,
-  "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
+  "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
+  "com.amazonaws" % "aws-java-sdk-ssm" % awsSdkVersion,
+  "com.amazonaws" % "aws-java-sdk-kinesis" % awsSdkVersion,
   "com.google.api-client" % "google-api-client" % "1.23.0",
   "com.google.oauth-client" % "google-oauth-client-jetty" % "1.23.0",
-  "com.google.apis" % "google-api-services-sheets" % "v4-rev516-1.23.0"
+  "com.google.apis" % "google-api-services-sheets" % "v4-rev516-1.23.0",
+  "net.logstash.logback" % "logstash-logback-encoder" % "6.0",
+  "com.gu" % "kinesis-logback-appender" % "1.4.4",
+  "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
 )
 
 scalaVersion := "2.12.8"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,3 +1,5 @@
 play.application.loader=AppLoader
-typerighter.sheetRange="A:G"
-typerighter.google.credentials.filePath="/etc/gu/typerighter.google.credentials.conf"
+typerighter {
+  sheetRange="A:G"
+  defaultAwsProfile = "composer"
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,9 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.8")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
 addSbtPlugin("io.gatling" % "gatling-sbt" % "3.0.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.7" artifacts Artifact("jdeb", "jar", "jar")

--- a/typerighter.cfn.yaml
+++ b/typerighter.cfn.yaml
@@ -32,16 +32,10 @@ Parameters:
     Description: The CIDR block of the dig dev bubble
     Type: String
     Default: 10.249.0.0/18
-  PlaySecret:
-    Description: The secret used by the play framework for cryptographic functions
-    Type: String
-    NoEcho: true
-  SheetId:
-    Type: 'AWS::SSM::Parameter::Value<String>'
-    Default: /typerighter/CODE/sheet.id
-  GoogleApiClientCredentials:
-    Type: 'AWS::SSM::Parameter::Value<String>'
-    Default: /typerighter/CODE/google.api.client.credentials
+  KinesisLoggingStream:
+    Description: Name of the ELK logging stream in this account
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /accountServices/elkLoggingStreamArn
 Mappings:
   StageVariables:
     CODE:
@@ -103,13 +97,7 @@ Resources:
 
           cat > /etc/gu/typerighter.conf << 'EOF'
           include "application"
-          play.http.secret.key="${PlaySecret}"
           typerighter.ngramPath="/opt/ngram-data"
-          typerighter.sheetId="${SheetId}"
-          EOF
-
-          cat > /etc/gu/typerighter.google.credentials.conf << 'EOF'
-          ${GoogleApiClientCredentials}
           EOF
 
           aws --quiet --region ${AWS::Region} s3 cp s3://composer-dist/${Stack}/${Stage}/${App}/${App}.deb /tmp/package.deb
@@ -129,16 +117,56 @@ Resources:
             - ec2.amazonaws.com
           Action:
           - sts:AssumeRole
-      Policies:
-      - PolicyName: GetDistributablesPolicy
-        PolicyDocument:
-          Version: 2012-10-17
-          Statement:
+
+  GetDistributablesPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: GetDistributablesPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Action:
+          - s3:GetObject
+          Resource:
+          - arn:aws:s3:::composer-dist/*
+      Roles:
+      - !Ref AppRole
+
+  SimpleConfigPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: SimpleConfigPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Action:
+          - autoscaling:DescribeAutoScalingInstances
+          - autoscaling:DescribeAutoScalingGroups
+          - ec2:DescribeTags
+          Resource: "*"
+        - Effect: Allow
+          Action:
+          - ssm:GetParametersByPath
+          Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Stage}/${Stack}/${App}
+      Roles:
+      - !Ref AppRole
+
+  LoggingPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: LoggingPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
           - Effect: Allow
             Action:
-            - s3:GetObject
-            Resource:
-            - arn:aws:s3:::composer-dist/*
+              - kinesis:DescribeStream
+              - kinesis:PutRecord
+            Resource: !Ref KinesisLoggingStream
+      Roles:
+        - !Ref AppRole
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile


### PR DESCRIPTION
Two main updates:
 - enable log shipping to ELK
 - adopt simple configuration via SSM for all config and simplify the launch config user data

Before merging/deploying to PROD
 - [ ] Create new SSM params under `/PROD/flexible/typerighter`
 - [ ] Delete old SSM params under `/typerighter`