### PR TITLE
Add the ability to add validators at runtime

### DIFF
--- a/app/controllers/RulesController.scala
+++ b/app/controllers/RulesController.scala
@@ -18,7 +18,7 @@ class RulesController(cc: ControllerComponents, validatorPool: ValidatorPool, la
       errorsByCategory = addValidatorToPool(rulesByCategory)
       rules <- validatorPool.getCurrentRules
     } yield {
-      val errors = errorsByCategory.map(_._2).flatten ::: ruleErrors
+      val errors = errorsByCategory.flatMap(_._2) ::: ruleErrors
       val rulesIngested = rulesByCategory.map { _._2.size }.sum
       Ok(views.html.rules(sheetId, rules, Some(rulesIngested), errors))
     }

--- a/app/services/LanguageToolFactory.scala
+++ b/app/services/LanguageToolFactory.scala
@@ -7,9 +7,8 @@ import org.languagetool.rules.{Rule => LTRule}
 import org.languagetool.rules.spelling.morfologik.suggestions_ordering.SuggestionsOrdererConfig
 
 import collection.JavaConverters._
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import play.api.Logger
-
 import model.RuleMatch
 import model.Rule
 import org.languagetool.rules.CategoryId
@@ -55,8 +54,8 @@ class LanguageToolFactory(
 class LanguageTool(category: String, instance: JLanguageTool)(implicit ec: ExecutionContext) extends Validator {
   def getCategory = category
 
-  def check(request: ValidatorRequest): List[RuleMatch] = {
-    instance.check(request.text).asScala.map(RuleMatch.fromLT).toList
+  def check(request: ValidatorRequest): Future[List[RuleMatch]] = {
+    Future.successful(instance.check(request.text).asScala.map(RuleMatch.fromLT).toList)
   }
 
   def getRules: List[Rule] = {

--- a/app/utils/Validator.scala
+++ b/app/utils/Validator.scala
@@ -3,12 +3,14 @@ package utils
 import model.{Rule, RuleMatch}
 import services.ValidatorRequest
 
+import scala.concurrent.Future
+
 object Validator {
   type ValidatorResponse = List[RuleMatch]
 }
 
 trait Validator {
-  def check(request: ValidatorRequest): Validator.ValidatorResponse
+  def check(request: ValidatorRequest): Future[Validator.ValidatorResponse]
   def getRules(): List[Rule]
   def getCategory(): String
 }


### PR DESCRIPTION
~Greetings, traveller! Please direct your attention to #10 before reviewing this PR, as this work is downstream 😁~ This is now ready for review.

This PR adds the ability to add validators at runtime. Previously, the validators that were available to a validationPool were bound at the point of instantiation. Now, they're added as and when, after instantiation, on a per-category basis. This lets us use more than one kind of validator per pool, and also means we could potentially mount/unmount validators at runtime as needed.
