### PR TITLE
Queue validation jobs

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -38,7 +38,7 @@ class AppComponents(context: Context, identity: AppIdentity)
 
   val ngramPath: Option[File] = configuration.getOptional[String]("typerighter.ngramPath").map(new File(_))
   val languageToolFactory = new LanguageToolFactory(ngramPath)
-  val validatorPoolDispatcher = actorSystem.dispatchers.lookup("validation-pool-dispatcher")
+  val validatorPoolDispatcher = actorSystem.dispatchers.lookup("validator-pool-dispatcher")
   val validatorPool = new ValidatorPool()(validatorPoolDispatcher, materializer)
 
   val credentials = configuration.get[String]("typerighter.google.credentials")

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -55,7 +55,7 @@ class AppComponents(context: Context, identity: AppIdentity)
   } yield {
     rules.foreach { case (category, rules) => {
       val (validator, _) = languageToolFactory.createInstance(category.name, ValidatorConfig(rules))
-      validatorPool.addValidator(category.name, validator)
+      validatorPool.addValidator(category, validator)
     }}
   }
 

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,5 +1,6 @@
 import java.io.File
 
+import akka.stream.ActorAttributes
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
 import com.gu.{AppIdentity, AwsIdentity}
@@ -37,8 +38,8 @@ class AppComponents(context: Context, identity: AppIdentity)
 
   val ngramPath: Option[File] = configuration.getOptional[String]("typerighter.ngramPath").map(new File(_))
   val languageToolFactory = new LanguageToolFactory(ngramPath)
-  val validatorPool = new ValidatorPool
-
+  val validatorPoolDispatcher = actorSystem.dispatchers.lookup("validation-pool-dispatcher")
+  val validatorPool = new ValidatorPool()(validatorPoolDispatcher, materializer)
 
   val credentials = configuration.get[String]("typerighter.google.credentials")
   val spreadsheetId = configuration.get[String]("typerighter.sheetId")

--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -15,8 +15,7 @@ class ApiController(cc: ControllerComponents, validatorPool: ValidatorPool, rule
   def check: Action[JsValue] = Action.async(parse.json) { request =>
     request.body.validate[CheckQuery].asEither match {
       case Right(checkQuery) =>
-        val categoryIds = checkQuery.categoryIds.getOrElse(validatorPool.getCurrentCategories.map { _.id })
-        validatorPool.check(checkQuery.text, categoryIds).map(results => {
+        validatorPool.check(checkQuery.text, checkQuery.categoryIds).map(results => {
           val json = Json.obj(
             "input" -> checkQuery.text,
             "results" -> Json.toJson(results)
@@ -27,7 +26,7 @@ class ApiController(cc: ControllerComponents, validatorPool: ValidatorPool, rule
     }
   }
 
-  def getCurrentCategories: Action[AnyContent] = Action { request: Request[AnyContent] =>
-    Ok(Json.toJson(validatorPool.getCurrentCategories))
+  def getCurrentCategories: Action[AnyContent] = Action.async { request: Request[AnyContent] =>
+    validatorPool.getCurrentCategories.map { categories => Ok(Json.toJson(categories)) }
   }
 }

--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -15,7 +15,8 @@ class ApiController(cc: ControllerComponents, validatorPool: ValidatorPool, rule
   def check: Action[JsValue] = Action.async(parse.json) { request =>
     request.body.validate[CheckQuery].asEither match {
       case Right(checkQuery) =>
-        validatorPool.checkAllCategories(checkQuery.text).map(results => {
+        val categoryIds = checkQuery.categoryIds.getOrElse(validatorPool.getCurrentCategories.map { _.id })
+        validatorPool.check(checkQuery.text, categoryIds).map(results => {
           val json = Json.obj(
             "input" -> checkQuery.text,
             "results" -> Json.toJson(results)

--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -15,7 +15,7 @@ class ApiController(cc: ControllerComponents, validatorPool: ValidatorPool, rule
   def check: Action[JsValue] = Action.async(parse.json) { request =>
     request.body.validate[CheckQuery].asEither match {
       case Right(checkQuery) =>
-        validatorPool.check(checkQuery.text, checkQuery.categoryIds).map(results => {
+        validatorPool.check(checkQuery.id, checkQuery.text, checkQuery.categoryIds).map(results => {
           val json = Json.obj(
             "input" -> checkQuery.text,
             "results" -> Json.toJson(results)

--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -25,4 +25,8 @@ class ApiController(cc: ControllerComponents, validatorPool: ValidatorPool, rule
       case Left(error) => Future.successful(BadRequest(s"Invalid request: $error"))
     }
   }
+
+  def getCurrentCategories: Action[AnyContent] = Action { request: Request[AnyContent] =>
+    Ok(Json.toJson(validatorPool.getCurrentCategories))
+  }
 }

--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -26,7 +26,7 @@ class ApiController(cc: ControllerComponents, validatorPool: ValidatorPool, rule
     }
   }
 
-  def getCurrentCategories: Action[AnyContent] = Action.async { request: Request[AnyContent] =>
-    validatorPool.getCurrentCategories.map { categories => Ok(Json.toJson(categories)) }
+  def getCurrentCategories: Action[AnyContent] = Action { request: Request[AnyContent] =>
+    Ok(Json.toJson(validatorPool.getCurrentCategories))
   }
 }

--- a/app/controllers/RulesController.scala
+++ b/app/controllers/RulesController.scala
@@ -17,16 +17,20 @@ class RulesController(cc: ControllerComponents, validatorPool: ValidatorPool, la
       (rulesByCategory, ruleErrors) <- ruleResource.fetchRulesByCategory()
       errorsByCategory = addValidatorToPool(rulesByCategory)
       rules <- validatorPool.getCurrentRules
+      categories <- validatorPool.getCurrentCategories
     } yield {
       val errors = errorsByCategory.flatMap(_._2) ::: ruleErrors
       val rulesIngested = rulesByCategory.map { _._2.size }.sum
-      Ok(views.html.rules(sheetId, rules, Some(rulesIngested), errors))
+      Ok(views.html.rules(sheetId, rules, categories, Some(rulesIngested), errors))
     }
   }
 
   def rules = Action.async { implicit request: Request[AnyContent] =>
-    validatorPool.getCurrentRules.map { rules =>
-      Ok(views.html.rules(sheetId, rules))
+    for {
+      rules <- validatorPool.getCurrentRules
+      categories <- validatorPool.getCurrentCategories
+    } yield {
+      Ok(views.html.rules(sheetId, rules, categories))
     }
   }
 

--- a/app/controllers/RulesController.scala
+++ b/app/controllers/RulesController.scala
@@ -18,7 +18,7 @@ class RulesController(cc: ControllerComponents, validatorPool: ValidatorPool, la
       errorsByCategory = addValidatorToPool(rulesByCategory)
       rules <- validatorPool.getCurrentRules
     } yield {
-      val errors = errorsByCategory.map(_._2).flatten ::: ruleErrors
+      val errors = errorsByCategory.flatMap(_._2) ::: ruleErrors
       val rulesIngested = rulesByCategory.map { _._2.size }.sum
       Ok(views.html.rules(sheetId, rules, Some(rulesIngested), errors))
     }

--- a/app/controllers/RulesController.scala
+++ b/app/controllers/RulesController.scala
@@ -16,22 +16,25 @@ class RulesController(cc: ControllerComponents, validatorPool: ValidatorPool, la
     for {
       (rulesByCategory, ruleErrors) <- ruleResource.fetchRulesByCategory()
       errorsByCategory = addValidatorToPool(rulesByCategory)
-      rules <- validatorPool.getCurrentRules
-      categories <- validatorPool.getCurrentCategories
     } yield {
       val errors = errorsByCategory.flatMap(_._2) ::: ruleErrors
       val rulesIngested = rulesByCategory.map { _._2.size }.sum
-      Ok(views.html.rules(sheetId, rules, categories, Some(rulesIngested), errors))
+      Ok(views.html.rules(
+        sheetId,
+        validatorPool.getCurrentRules,
+        validatorPool.getCurrentCategories,
+        Some(rulesIngested),
+        errors
+      ))
     }
   }
 
-  def rules = Action.async { implicit request: Request[AnyContent] =>
-    for {
-      rules <- validatorPool.getCurrentRules
-      categories <- validatorPool.getCurrentCategories
-    } yield {
-      Ok(views.html.rules(sheetId, rules, categories))
-    }
+  def rules = Action { implicit request: Request[AnyContent] =>
+    Ok(views.html.rules(
+      sheetId,
+      validatorPool.getCurrentRules,
+      validatorPool.getCurrentCategories
+    ))
   }
 
   private def addValidatorToPool(rulesByCategory: Map[Category, List[Rule]]) = {

--- a/app/controllers/RulesController.scala
+++ b/app/controllers/RulesController.scala
@@ -33,7 +33,7 @@ class RulesController(cc: ControllerComponents, validatorPool: ValidatorPool, la
   private def addValidatorToPool(rulesByCategory: Map[Category, List[Rule]]) = {
     rulesByCategory.map { case (category, rules) => {
       val (validator, errors) = languageToolFactory.createInstance(category.name, ValidatorConfig(rules))
-      validatorPool.addValidator(category.name, validator)
+      validatorPool.addValidator(category, validator)
       (category.name, errors)
     }}.toList
   }

--- a/app/model/CheckQuery.scala
+++ b/app/model/CheckQuery.scala
@@ -2,7 +2,7 @@ package model
 
 import play.api.libs.json.{Json, Reads}
 
-case class CheckQuery(text: String, categoryIds: Option[List[String]])
+case class CheckQuery(id: String, text: String, categoryIds: Option[List[String]])
 
 object CheckQuery {
   implicit val reads: Reads[CheckQuery] = Json.reads[CheckQuery]

--- a/app/model/CheckQuery.scala
+++ b/app/model/CheckQuery.scala
@@ -2,7 +2,7 @@ package model
 
 import play.api.libs.json.{Json, Reads}
 
-case class CheckQuery(text: String)
+case class CheckQuery(text: String, categoryIds: Option[List[String]])
 
 object CheckQuery {
   implicit val reads: Reads[CheckQuery] = Json.reads[CheckQuery]

--- a/app/model/RuleMatch.scala
+++ b/app/model/RuleMatch.scala
@@ -9,8 +9,8 @@ case class RuleMatch(rule: ResponseRule,
                      fromPos: Int,
                      toPos: Int,
                      message: String,
-                     shortMessage: Option[String],
-                     suggestedReplacements: List[String])
+                     shortMessage: Option[String] = None,
+                     suggestedReplacements: List[String] = List.empty)
 
 object RuleMatch {
   def fromLT(lt: LTRuleMatch): RuleMatch = {

--- a/app/services/LanguageToolFactory.scala
+++ b/app/services/LanguageToolFactory.scala
@@ -57,7 +57,9 @@ class LanguageTool(category: String, instance: JLanguageTool)(implicit ec: Execu
   def getCategory = category
 
   def check(request: ValidatorRequest): Future[List[RuleMatch]] = {
-    Future.successful(instance.check(request.text).asScala.map(RuleMatch.fromLT).toList)
+    Future {
+      instance.check(request.text).asScala.map(RuleMatch.fromLT).toList
+    }
   }
 
   def getRules: List[Rule] = {

--- a/app/services/LanguageToolFactory.scala
+++ b/app/services/LanguageToolFactory.scala
@@ -7,9 +7,8 @@ import org.languagetool.rules.{Rule => LTRule}
 import org.languagetool.rules.spelling.morfologik.suggestions_ordering.SuggestionsOrdererConfig
 
 import collection.JavaConverters._
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import play.api.Logger
-
 import model.RuleMatch
 import model.Rule
 import org.languagetool.rules.CategoryId
@@ -55,8 +54,8 @@ class LanguageToolFactory(
 class LanguageTool(category: String, instance: JLanguageTool)(implicit ec: ExecutionContext) extends Validator {
   def getCategory = category
 
-  def check(request: ValidatorRequest): List[RuleMatch] = {
-    instance.check(request.text).asScala.map(RuleMatch.fromLT).toList
+  def check(request: ValidatorRequest): Future[List[RuleMatch]] = {
+    Future.successful(instance.check(request.text).asScala.map(RuleMatch.fromLT).toList)
   }
 
   def getRules: List[Rule] = {

--- a/app/services/LanguageToolFactory.scala
+++ b/app/services/LanguageToolFactory.scala
@@ -52,6 +52,8 @@ class LanguageToolFactory(
 }
 
 class LanguageTool(category: String, instance: JLanguageTool)(implicit ec: ExecutionContext) extends Validator {
+  def getId = "language-tool"
+
   def getCategory = category
 
   def check(request: ValidatorRequest): Future[List[RuleMatch]] = {

--- a/app/services/LanguageToolFactory.scala
+++ b/app/services/LanguageToolFactory.scala
@@ -16,7 +16,7 @@ import utils.Validator
 
 class LanguageToolFactory(
                            maybeLanguageModelDir: Option[File],
-                           useLanguageModelRules: Boolean = false) extends ValidatorFactory {
+                           useLanguageModelRules: Boolean = false) {
 
   def createInstance(category: String, config: ValidatorConfig)(implicit ec: ExecutionContext): (Validator, List[String]) = {
     val language: Language = Languages.getLanguageForShortCode("en")

--- a/app/services/ValidatorPool.scala
+++ b/app/services/ValidatorPool.scala
@@ -1,6 +1,6 @@
 package services
 
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedQueue}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future, Promise, blocking}
@@ -8,6 +8,8 @@ import play.api.Logger
 import model.{Category, Rule, RuleMatch}
 import utils.Validator
 import utils.Validator._
+
+import scala.collection.mutable.{ Queue, ListBuffer }
 
 case class ValidatorConfig(rules: List[Rule])
 
@@ -18,72 +20,103 @@ trait ValidatorFactory {
 }
 
 class ValidatorPool(implicit ec: ExecutionContext) {
-
-  private val validators = new ConcurrentHashMap[String, (Category, Promise[Validator])]().asScala
+  type TValidateCallback = () => Future[Promise[ValidatorResponse]]
+  private val maxConcurrentValidations = 4
+  private val maxPendingValidations = 100
+  private val pendingQueue = new ConcurrentLinkedQueue[(Promise[ValidatorResponse], TValidateCallback)]()
+  private val currentValidations = new ConcurrentLinkedQueue[Promise[ValidatorResponse]]()
+  private val validators = new ConcurrentHashMap[String, (Category, Validator)]().asScala
 
   /**
     * Check the text with validators assigned to the given category ids.
     * If no ids are assigned, use all the currently available validators.
     */
   def check(text: String, maybeCategoryIds: Option[List[String]] = None): Future[List[RuleMatch]] = {
-    val eventuallyCategories = maybeCategoryIds match {
-      case None => getCurrentCategories.map { _.map { case (_, category) => category.id }}
-      case Some(categoryIds) => Future.successful(categoryIds)
+    val categoryIds = maybeCategoryIds match {
+      case None => getCurrentCategories.map { case (_, category) => category.id }
+      case Some(categoryIds) => categoryIds
     }
 
-    eventuallyCategories.flatMap { categoryIds =>
+    val eventualChecks = categoryIds.map { categoryId =>
       Logger.info(s"Checking categories ${categoryIds.mkString(", ")}")
-      val eventualChecks = categoryIds.map { categoryId =>
-        checkRequest(ValidatorRequest(categoryId, text))
-      }
-      Future.sequence(eventualChecks).map {
-        _.flatten
-      }
+      checkRequest(ValidatorRequest(categoryId, text))
     }
-  }
 
-  private def checkRequest(request: ValidatorRequest): Future[ValidatorResponse] = {
-    validators.get(request.category) match {
-      case Some((_, validator)) =>
-        Logger.info(s"Validator for category ${request.category} is processing")
-        validator.future.flatMap { validator =>
-          blocking {
-            val result = validator.check(request)
-            Logger.info(s"Validator for category ${request.category} is done")
-            result
-          }
-        }
-      case None =>
-        Future.failed(new IllegalStateException(s"Unknown category ${request.category}"))
+    Future.sequence(eventualChecks).map {
+      _.flatten
     }
   }
 
   /**
     * Add a validator to the pool of validators for the given category.
+    * Replaces a validator that's already present for that category, returning
+    * the replaced validator.
     */
-  def addValidator(category: Category, validator: Validator): Option[(Category, Promise[Validator])] = {
+  def addValidator(category: Category, validator: Validator): Option[(Category, Validator)] = {
     Logger.info(s"New instance of validator available with rules for category ${category}")
-    validators.put(category.id, (category, Promise.successful(validator)))
+    validators.put(category.id, (category, validator))
   }
 
-  def getCurrentCategories: Future[List[(String, Category)]] = {
-    val eventuallyValidatorRules = validators.values.map {
-      case (category, validatorPromise) => {
-        validatorPromise.future.map { validator =>
-          (validator.getId, category)
+  def getCurrentCategories: List[(String, Category)] = {
+    val validatorsAndCategories = validators.values.map {
+      case (category, validator) => (validator.getId, category)
+    }.toList
+    validatorsAndCategories
+  }
+
+  def getCurrentRules: List[Rule] = {
+    validators.values.flatMap {
+      case (_, validator) =>  validator.getRules
+    }.toList
+  }
+
+  private def checkRequest(request: ValidatorRequest): Future[ValidatorResponse] = {
+    val promise = Promise[ValidatorResponse]()
+    val future = promise.future
+
+    // Wrap our request in a lambda and add it to the queue, ready for processing
+    val validate: TValidateCallback = () => validators.get(request.category) match {
+      case Some((_, validator)) =>
+        Logger.info(s"Validator for category ${request.category} is processing")
+        blocking {
+          val eventualResult = validator.check(request)
+          Logger.info(s"Validator for category ${request.category} is done")
+          eventualResult.map { result =>
+            // If it exists, begin the next queued validation
+            completeValidationWork(promise)
+            promise.success(result)
+          }
         }
-      }
-    }.toList
+      case None =>
+        completeValidationWork(promise)
+        Future.failed(new IllegalStateException(s"Could not validate: unknown category ${request.category}"))
+    }
 
-    Future.sequence(eventuallyValidatorRules)
+    scheduleValidationWork(promise, validate)
+
+    future
   }
 
-  def getCurrentRules: Future[List[Rule]] = {
-    val eventuallyValidatorRules = validators.values.map { 
-      case (_, validatorPromise) => {
-        validatorPromise.future.map { _.getRules }
-      }
-    }.toList
-    Future.sequence(eventuallyValidatorRules).map(_.flatten)
+  private def completeValidationWork(promise: Promise[ValidatorResponse]) = {
+    currentValidations.remove(promise)
+    if (pendingQueue.size > 0) {
+      val (promise, validate) = pendingQueue.remove()
+      Logger.info(s"Scheduling new work. Items in queue remain, which is now of size: ${pendingQueue.size}")
+      scheduleValidationWork(promise, validate)
+    }
+  }
+
+  private def scheduleValidationWork(promise: Promise[ValidatorResponse], validate: TValidateCallback) = {
+    if (currentValidations.size <= maxConcurrentValidations) {
+      currentValidations.add(promise)
+      validate()
+    } else if (pendingQueue.size <= maxPendingValidations) {
+      pendingQueue.add((promise, validate))
+      Logger.info(s"Validation stack full. Adding job to queue, which is now of size: ${pendingQueue.size}")
+    } else {
+      val errorMessage = s"Validation queue full. Cannot accept new validation as queue is already of size: ${pendingQueue.size}"
+      Logger.warn(errorMessage)
+      promise.failure(new Exception(errorMessage))
+    }
   }
 }

--- a/app/services/ValidatorPool.scala
+++ b/app/services/ValidatorPool.scala
@@ -9,10 +9,7 @@ import model.{Category, Rule, RuleMatch}
 import utils.Validator
 import utils.Validator._
 
-import scala.collection.mutable.{ Queue, ListBuffer }
-
 case class ValidatorConfig(rules: List[Rule])
-
 case class ValidatorRequest(category: String, text: String)
 
 trait ValidatorFactory {
@@ -21,25 +18,29 @@ trait ValidatorFactory {
 
 class ValidatorPool(implicit ec: ExecutionContext) {
   type TValidateCallback = () => Future[Promise[ValidatorResponse]]
+
+  case class ValidationJob(id: String, promise: Promise[ValidatorResponse], validate: TValidateCallback)
+
   private val maxConcurrentValidations = 4
   private val maxPendingValidations = 100
-  private val pendingQueue = new ConcurrentLinkedQueue[(Promise[ValidatorResponse], TValidateCallback)]()
-  private val currentValidations = new ConcurrentLinkedQueue[Promise[ValidatorResponse]]()
+  private val pendingQueue = new ConcurrentLinkedQueue[ValidationJob]()
+  private val currentValidations = new ConcurrentLinkedQueue[ValidationJob]()
   private val validators = new ConcurrentHashMap[String, (Category, Validator)]().asScala
 
   /**
     * Check the text with validators assigned to the given category ids.
     * If no ids are assigned, use all the currently available validators.
     */
-  def check(text: String, maybeCategoryIds: Option[List[String]] = None): Future[List[RuleMatch]] = {
+  def check(id: String, text: String, maybeCategoryIds: Option[List[String]] = None): Future[List[RuleMatch]] = {
     val categoryIds = maybeCategoryIds match {
       case None => getCurrentCategories.map { case (_, category) => category.id }
       case Some(categoryIds) => categoryIds
     }
 
+    Logger.info(s"Validation request received with id ${id}. Checking categories: ${categoryIds.mkString(", ")}")
+
     val eventualChecks = categoryIds.map { categoryId =>
-      Logger.info(s"Checking categories ${categoryIds.mkString(", ")}")
-      checkRequest(ValidatorRequest(categoryId, text))
+      checkForCategory(id, text, categoryId)
     }
 
     Future.sequence(eventualChecks).map {
@@ -53,7 +54,7 @@ class ValidatorPool(implicit ec: ExecutionContext) {
     * the replaced validator.
     */
   def addValidator(category: Category, validator: Validator): Option[(Category, Validator)] = {
-    Logger.info(s"New instance of validator available with rules for category ${category}")
+    Logger.info(s"New instance of validator available of id: ${validator.getId} for category: ${category}")
     validators.put(category.id, (category, validator))
   }
 
@@ -70,53 +71,51 @@ class ValidatorPool(implicit ec: ExecutionContext) {
     }.toList
   }
 
-  private def checkRequest(request: ValidatorRequest): Future[ValidatorResponse] = {
+  private def checkForCategory(id: String, text: String, categoryId: String): Future[ValidatorResponse] = {
     val promise = Promise[ValidatorResponse]()
     val future = promise.future
 
     // Wrap our request in a lambda and add it to the queue, ready for processing
-    val validate: TValidateCallback = () => validators.get(request.category) match {
+    val validate = () => validators.get(categoryId) match {
       case Some((_, validator)) =>
-        Logger.info(s"Validator for category ${request.category} is processing")
+        Logger.info(s"Validation job with id: ${id} for category: ${categoryId} is processing")
         blocking {
-          val eventualResult = validator.check(request)
-          Logger.info(s"Validator for category ${request.category} is done")
-          eventualResult.map { result =>
-            // If it exists, begin the next queued validation
-            completeValidationWork(promise)
-            promise.success(result)
-          }
+          val eventualResult = validator.check(ValidatorRequest(categoryId, text))
+          Logger.info(s"Validation job with id: ${id} for category: ${categoryId} is done")
+          eventualResult.map { promise.success }
         }
       case None =>
-        completeValidationWork(promise)
-        Future.failed(new IllegalStateException(s"Could not validate: unknown category ${request.category}"))
+        Future.failed(new IllegalStateException(s"Could not run validation job with id: ${id} -- unknown category for id: ${categoryId}"))
     }
 
-    scheduleValidationWork(promise, validate)
+    scheduleValidationJob(ValidationJob(id, promise, validate))
 
     future
   }
 
-  private def completeValidationWork(promise: Promise[ValidatorResponse]) = {
-    currentValidations.remove(promise)
+  private def completeValidationJob(job: ValidationJob): Unit = {
+    currentValidations.remove(job)
     if (pendingQueue.size > 0) {
-      val (promise, validate) = pendingQueue.remove()
-      Logger.info(s"Scheduling new work. Items in queue remain, which is now of size: ${pendingQueue.size}")
-      scheduleValidationWork(promise, validate)
+      val newJob = pendingQueue.remove()
+      Logger.info(s"Scheduling new validation job with id: ${job.id}. Jobs in queue remain, which is now of size: ${pendingQueue.size}")
+      scheduleValidationJob(newJob)
     }
+    Unit
   }
 
-  private def scheduleValidationWork(promise: Promise[ValidatorResponse], validate: TValidateCallback) = {
+  private def scheduleValidationJob(job: ValidationJob) = {
     if (currentValidations.size <= maxConcurrentValidations) {
-      currentValidations.add(promise)
-      validate()
+      currentValidations.add(job)
+      job.validate().map { _ =>
+        completeValidationJob(job)
+      }
     } else if (pendingQueue.size <= maxPendingValidations) {
-      pendingQueue.add((promise, validate))
-      Logger.info(s"Validation stack full. Adding job to queue, which is now of size: ${pendingQueue.size}")
+      pendingQueue.add(job)
+      Logger.info(s"Validation job stack full. Adding job with id: ${job.id} to queue, which is now of size: ${pendingQueue.size}")
     } else {
-      val errorMessage = s"Validation queue full. Cannot accept new validation as queue is already of size: ${pendingQueue.size}"
+      val errorMessage = s"Validation job queue full. Cannot accept new job with id: ${job.id} as queue is already of size: ${pendingQueue.size}"
       Logger.warn(errorMessage)
-      promise.failure(new Exception(errorMessage))
+      job.promise.failure(new Exception(errorMessage))
     }
   }
 }

--- a/app/services/ValidatorPool.scala
+++ b/app/services/ValidatorPool.scala
@@ -4,13 +4,10 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future, Promise, blocking}
-
 import play.api.Logger
-
-import model.Rule
+import model.{Category, Rule, RuleMatch}
 import utils.Validator
 import utils.Validator._
-import model.Category
 
 case class ValidatorConfig(rules: List[Rule])
 
@@ -24,13 +21,24 @@ class ValidatorPool(implicit ec: ExecutionContext) {
 
   private val validators = new ConcurrentHashMap[String, (Category, Promise[Validator])]().asScala
 
-  def check(text: String, categoryIds: List[String]) = {
-    Logger.info(s"Checking categories ${categoryIds.mkString(", ")}")
-    val eventualChecks = categoryIds.map { categoryId =>
-      checkRequest(ValidatorRequest(categoryId, text))
+  /**
+    * Check the text with validators assigned to the given category ids.
+    * If no ids are assigned, use all the currently available validators.
+    */
+  def check(text: String, maybeCategoryIds: Option[List[String]] = None): Future[List[RuleMatch]] = {
+    val eventuallyCategories = maybeCategoryIds match {
+      case None => getCurrentCategories.map { _.map { case (_, category) => category.id }}
+      case Some(categoryIds) => Future.successful(categoryIds)
     }
-    Future.sequence(eventualChecks).map {
-      _.flatten
+
+    eventuallyCategories.flatMap { categoryIds =>
+      Logger.info(s"Checking categories ${categoryIds.mkString(", ")}")
+      val eventualChecks = categoryIds.map { categoryId =>
+        checkRequest(ValidatorRequest(categoryId, text))
+      }
+      Future.sequence(eventualChecks).map {
+        _.flatten
+      }
     }
   }
 
@@ -50,23 +58,30 @@ class ValidatorPool(implicit ec: ExecutionContext) {
     }
   }
 
-  def addValidator(category: Category, validator: Validator) = {
+  /**
+    * Add a validator to the pool of validators for the given category.
+    */
+  def addValidator(category: Category, validator: Validator): Option[(Category, Promise[Validator])] = {
     Logger.info(s"New instance of validator available with rules for category ${category}")
     validators.put(category.id, (category, Promise.successful(validator)))
   }
 
-  def getCurrentCategories: List[Category] = {
-    validators.values.map { 
-      case (category, _) => category
+  def getCurrentCategories: Future[List[(String, Category)]] = {
+    val eventuallyValidatorRules = validators.values.map {
+      case (category, validatorPromise) => {
+        validatorPromise.future.map { validator =>
+          (validator.getId, category)
+        }
+      }
     }.toList
+
+    Future.sequence(eventuallyValidatorRules)
   }
 
   def getCurrentRules: Future[List[Rule]] = {
     val eventuallyValidatorRules = validators.values.map { 
       case (_, validatorPromise) => {
-        validatorPromise.future.map { validator =>
-          validator.getRules.toList
-        }
+        validatorPromise.future.map { _.getRules }
       }
     }.toList
     Future.sequence(eventuallyValidatorRules).map(_.flatten)

--- a/app/services/ValidatorPool.scala
+++ b/app/services/ValidatorPool.scala
@@ -1,34 +1,35 @@
 package services
 
-import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedQueue}
+import java.util.concurrent.{ConcurrentHashMap}
 
 import scala.collection.JavaConverters._
-import scala.concurrent.{ExecutionContext, Future, Promise, blocking}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import play.api.Logger
 import model.{Category, Rule, RuleMatch}
 import utils.Validator
 import utils.Validator._
 
 import scala.util.{Failure, Success}
+import akka.stream.QueueOfferResult.{Dropped, Failure => QueueFailure, QueueClosed}
+import akka.stream._
+import akka.stream.scaladsl.{Sink, Source}
 
 case class ValidatorConfig(rules: List[Rule])
 case class ValidatorRequest(category: String, text: String)
 
-class ValidatorPool(implicit ec: ExecutionContext) {
+class ValidatorPool(val maxCurrentJobs: Int = 4, val maxQueuedJobs: Int = 100)(implicit ec: ExecutionContext, implicit val mat: Materializer) {
   type TValidateCallback = () => Future[ValidatorResponse]
 
-  case class ValidationJob(id: String, categoryId: String, promise: Promise[ValidatorResponse], validate: TValidateCallback)
+  case class ValidationJob(id: String, categoryId: String, text: String, promise: Promise[ValidatorResponse])
 
-  private val maxCurrentJobs = 4
-  private val maxQueuedJobs = 100
-  private val queuedJobs = new ConcurrentLinkedQueue[ValidationJob]()
-  private val currentJobs = new ConcurrentLinkedQueue[ValidationJob]()
   private val validators = new ConcurrentHashMap[String, (Category, Validator)]().asScala
+  private val flow = Source.queue[ValidationJob](maxQueuedJobs, OverflowStrategy.dropNew)
+    .mapAsyncUnordered(maxCurrentJobs)(runValidationJob)
+    .to(Sink.ignore)
+    .run()
 
   def getMaxCurrentValidations: Int = maxCurrentJobs
   def getMaxQueuedValidations: Int = maxQueuedJobs
-  def getQueuedJobCount: Int = queuedJobs.size
-  def getCurrentJobCount: Int = currentJobs.size
 
   /**
     * Check the text with validators assigned to the given category ids.
@@ -40,7 +41,7 @@ class ValidatorPool(implicit ec: ExecutionContext) {
       case Some(ids) => ids
     }
 
-    Logger.info(s"Validation job with id: ${id} received. Checking categories: ${categoryIds.mkString(", ")}.")
+    Logger.info(s"Validation job with id: ${id} received. Checking categories: ${categoryIds.mkString(", ")}")
 
     val eventualChecks = categoryIds.map { categoryId =>
       checkForCategory(id, text, categoryId)
@@ -49,7 +50,7 @@ class ValidatorPool(implicit ec: ExecutionContext) {
     Future.sequence(eventualChecks).map {
       _.flatten
     }.map { matches =>
-      Logger.info(s"Validation job with id: ${id} complete.")
+      Logger.info(s"Validation job with id: $id complete")
       matches
     }
   }
@@ -79,56 +80,40 @@ class ValidatorPool(implicit ec: ExecutionContext) {
 
   private def checkForCategory(id: String, text: String, categoryId: String): Future[ValidatorResponse] = {
     val promise = Promise[ValidatorResponse]()
-    val future = promise.future
-    // Wrap our request in a lambda and add it to the queue, ready to be called.
-    val validate: () => Future[ValidatorResponse] = () => validators.get(categoryId) match {
+    val job = ValidationJob(id, categoryId, text, promise)
+
+    Logger.info(s"Job ${getJobMessage(job)} has been offered to the queue")
+
+    flow.offer(job).collect {
+      case Dropped =>
+        promise.failure(new Throwable(s"Job ${getJobMessage(job)} was dropped from the queue, as the queue is full"))
+      case QueueClosed =>
+        promise.failure(new Throwable(s"Job ${getJobMessage(job)} failed because the queue is closed"))
+      case QueueFailure(err) =>
+        promise.failure(new Throwable(s"Job ${getJobMessage(job)} failed, reason: ${err.getMessage}"))
+    }
+
+    promise.future
+  }
+
+  private def runValidationJob(job: ValidationJob): Future[ValidatorResponse] = {
+    Logger.info(s"Job ${getJobMessage(job)} has begun")
+
+    validators.get(job.categoryId) match {
       case Some((_, validator)) =>
-        val eventualResult = validator.check(ValidatorRequest(categoryId, text))
+        val eventualResult = validator.check(ValidatorRequest(job.categoryId, job.text))
         eventualResult.andThen {
           case Success(result) => {
-            promise.success(result)}
+            Logger.info(s"Job ${getJobMessage(job)} is complete")
+            job.promise.success(result)
+          }
           case Failure(err) => {
-            promise.failure(err)
+            Logger.info(s"Job ${getJobMessage(job)} has failed with reason: $err")
+            job.promise.failure(err)
           }
         }
       case None =>
-        Future.failed(new IllegalStateException(s"Could not run validation job with id: $id -- unknown category for id: $categoryId"))
-    }
-
-    scheduleValidationJob(ValidationJob(id, categoryId, promise, validate))
-
-    future
-  }
-
-  private def completeValidationJob(job: ValidationJob): Unit = {
-    if (!currentJobs.remove(job)) {
-      Logger.warn(s"Validation job ${getJobMessage(job)} has completed, but was not present in current jobs.")
-    }
-    if (queuedJobs.size > 0) {
-      val newJob = queuedJobs.remove()
-      Logger.info(s"Starting new validation job ${getJobMessage(job)} from queue. Remaining items in queue: ${queuedJobs.size}")
-      scheduleValidationJob(newJob)
-    }
-    Logger.info(s"Validation job ${getJobMessage(job)} is done. Current jobs: ${currentJobs.toArray.map{ _.toString }.mkString }")
-    Unit
-  }
-
-  private def scheduleValidationJob(job: ValidationJob) = {
-    if (currentJobs.size < maxCurrentJobs) {
-      currentJobs.add(job)
-      job.validate().andThen {
-        case _ => {
-          completeValidationJob(job)
-        }
-      }
-      Logger.info(s"Validation job ${getJobMessage(job)} has been called")
-    } else if (queuedJobs.size < maxQueuedJobs) {
-      queuedJobs.add(job)
-      Logger.info(s"Validation job stack full. Added job ${getJobMessage(job)} to queue, which is now of size: ${queuedJobs.size}")
-    } else {
-      val errorMessage = s"Validation job queue full. Cannot accept new job ${getJobMessage(job)} as queue is already of size: ${queuedJobs.size}"
-      Logger.warn(errorMessage)
-      job.promise.failure(new Exception(errorMessage))
+        Future.failed(new IllegalStateException(s"Could not run validation job with id: ${job.id} -- unknown category for id: ${job.categoryId}"))
     }
   }
 

--- a/app/utils/Validator.scala
+++ b/app/utils/Validator.scala
@@ -3,12 +3,14 @@ package utils
 import model.{Rule, RuleMatch}
 import services.ValidatorRequest
 
+import scala.concurrent.Future
+
 object Validator {
   type ValidatorResponse = List[RuleMatch]
 }
 
 trait Validator {
-  def check(request: ValidatorRequest): Validator.ValidatorResponse
+  def check(request: ValidatorRequest): Future[Validator.ValidatorResponse]
   def getRules(): List[Rule]
   def getCategory(): String
 }

--- a/app/utils/Validator.scala
+++ b/app/utils/Validator.scala
@@ -11,6 +11,7 @@ object Validator {
 
 trait Validator {
   def check(request: ValidatorRequest): Future[Validator.ValidatorResponse]
+  def getId(): String
   def getRules(): List[Rule]
   def getCategory(): String
 }

--- a/app/views/rules.scala.html
+++ b/app/views/rules.scala.html
@@ -1,7 +1,8 @@
 @import model.Rule
+@import model.Category
 @import helper._
 
-@(sheetId: String, rules: scala.List[Rule], rulesIngested: Option[Int] = None, errors: List[String] = List.empty)(implicit req: RequestHeader)
+@(sheetId: String, rules: scala.List[Rule], categories: scala.List[(String, Category)], rulesIngested: Option[Int] = None, errors: List[String] = List.empty)(implicit req: RequestHeader)
 @main(title = "Typerighter", breadcrumbsList = List("Rules")) {
     @form(CSRF(routes.RulesController.refresh())) {
         @CSRF.formField
@@ -20,35 +21,35 @@
     }
     <hr />
     <div class="row">
-        <div class="col-sm-4">
-            @defining(rules.groupBy(_.category).keys) { categories =>
-                <h5>Categories (@categories.size)</h5>
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th scope="col">Id</th>
-                            <th scope="col">Colour</th>
-                            <th scope="col">Name</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                    @for(category <- rules.groupBy(_.category).keys) {
-                        <tr>
-                            <td>@category.name</td>
-                            <td>
-                                <span class="badge" style="background-color: #@category.colour;
-                                    color: white">
-                                    #@category.colour
-                                </span>
-                            </td>
-                            <td>@category.name</td>
-                        </tr>
-                    }
-                    </tbody>
-                </table>
-            }
+        <div class="col-sm-5">
+            <h5>Categories (@categories.size)</h5>
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th scope="col">Id</th>
+                        <th scope="col">Colour</th>
+                        <th scope="col">Name</th>
+                        <th scope="col">Handler</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @for((handler, category) <- categories) {
+                    <tr>
+                        <td>@category.name</td>
+                        <td>
+                            <span class="badge" style="background-color: #@category.colour;
+                                color: white">
+                                #@category.colour
+                            </span>
+                        </td>
+                        <td>@category.name</td>
+                        <td>@handler</td>
+                    </tr>
+                }
+                </tbody>
+            </table>
         </div>
-        <div class="col-sm-8">
+        <div class="col-sm-7">
             <h5>Rules (@rules.length)</h5>
             <table class="table">
                 <thead>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -4,7 +4,15 @@ play.assets {
   path = "/public"
   urlPrefix = "/assets"
 }
+
 typerighter {
   sheetRange="A:G"
   defaultAwsProfile = "composer"
+}
+
+validator-pool-dispatcher {
+  fork-join-executor {
+    parallelism-factor = 1
+    parallelism-max = 24
+  }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -13,3 +13,4 @@ GET     /rules                      controllers.RulesController.rules
 
 + NOCSRF
 POST    /check                      controllers.ApiController.check
+GET     /categories                 controllers.ApiController.getCurrentCategories

--- a/test/scala/services/ValidatorPoolTest.scala
+++ b/test/scala/services/ValidatorPoolTest.scala
@@ -1,0 +1,157 @@
+package services
+
+import model.{Category, ResponseRule, RuleMatch}
+import org.scalatest._
+import org.scalatest.concurrent.PatienceConfiguration.{Timeout}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.SpanSugar._
+import utils.Validator
+import utils.Validator.ValidatorResponse
+
+import scala.concurrent.{ExecutionContext, Promise}
+
+/**
+  * A mock validator to test the pool implementation. Doesn't
+  * complete work until markAsComplete is called, to test
+  * queue behaviour.
+  */
+class MockValidator(id: Int) extends Validator {
+  private var currentWork: Option[Promise[ValidatorResponse]] = None
+  private var currentResponses:  Option[ValidatorResponse] = None
+  def getId = s"mock-validator-$id"
+  def getCategory = "mock-validator-cat"
+  def getRules = List.empty
+
+  def check(request: ValidatorRequest) = {
+    val promise = Promise[ValidatorResponse]()
+    val future = promise.future
+    currentWork = Some(promise)
+    maybeComplete()
+    future
+  }
+
+  def markAsComplete(responses: ValidatorResponse): Unit = {
+    currentResponses = Some(responses)
+    maybeComplete()
+  }
+
+  def maybeComplete(): Unit = {
+    for {
+      response <- currentResponses
+      promise <- currentWork
+    } yield {
+      promise.success(response)
+    }
+  }
+
+  def fail(message: String) = {
+    for {
+      promise <- currentWork
+    } yield {
+      promise.failure(new Exception(message))
+    }
+  }
+}
+
+class ValidatorPoolTest extends AsyncFlatSpec with Matchers {
+  def timeLimit = 1 second
+  private implicit val ec = ExecutionContext.global
+  private val responseRule = ResponseRule(
+    id = "test-rule",
+    description = "test-description",
+    category = getCategory(0),
+    url = "test-url"
+  )
+  private val responses = getResponses(List((0, 5, "test-response")))
+
+  private def getValidators(count: Int): List[MockValidator] = {
+    (1 to count).map { id =>
+      new MockValidator(id)
+    }.toList
+  }
+
+  private def getCategory(id: Int) = Category(s"mock-category-$id", "Mock category", "Puce")
+
+  private def getPool(validators: List[Validator]): ValidatorPool = {
+    val pool = new ValidatorPool()
+    validators.zipWithIndex.foreach {
+      case (validator, index) => pool.addValidator(getCategory(index), validator)
+    }
+    pool
+  }
+
+  private def getResponses(ruleSpec: List[(Int, Int, String)]) = {
+    ruleSpec.map {
+      case (from, to, message) =>
+        RuleMatch(
+          rule = responseRule,
+          fromPos = from,
+          toPos = to,
+          message = message
+        )
+    }
+  }
+
+  "getCurrentCategories" should "report current categories" in {
+    val validators = getValidators(1)
+    val pool = getPool(validators)
+    pool.getCurrentCategories should be(List(("mock-validator-1", getCategory(0))))
+  }
+
+  "check" should "return a list of ValidatorResponses" in {
+    val validators = getValidators(1)
+    val pool = getPool(validators)
+    val eventuallyResult = pool.check("test-1", "Example text")
+    validators.head.markAsComplete(responses)
+    eventuallyResult.map { result =>
+      result shouldBe responses
+    }
+  }
+
+  "check" should "queue work that exceeds its concurrent validation limit" in {
+    val validators = getValidators(6)
+    val pool = getPool(validators)
+    pool.check("test-1", "Example text")
+    pool.getCurrentJobCount shouldBe pool.getMaxCurrentValidations
+    pool.getQueuedJobCount shouldBe validators.size - pool.getMaxCurrentValidations
+  }
+
+  "check" should "draw queued jobs in as jobs complete" in {
+    val validators = getValidators(6)
+    val pool = getPool(validators)
+    pool.check("test-1", "Example text")
+
+    validators(0).markAsComplete(responses)
+    Thread.sleep(5)
+    pool.getCurrentJobCount shouldBe pool.getMaxCurrentValidations
+    pool.getQueuedJobCount shouldBe validators.size - pool.getMaxCurrentValidations - 1
+
+    validators(1).markAsComplete(responses)
+    Thread.sleep(5)
+    pool.getCurrentJobCount shouldBe pool.getMaxCurrentValidations
+    pool.getQueuedJobCount shouldBe validators.size - pool.getMaxCurrentValidations - 2
+  }
+
+  "check" should "complete queued works" in {
+    val validators = getValidators(24)
+    val pool = getPool(validators)
+    val checkFuture = pool.check("test-1", "Example text")
+    validators.foreach(_.markAsComplete(responses))
+    ScalaFutures.whenReady(checkFuture, Timeout(1 second)) { result =>
+      pool.getCurrentJobCount shouldBe 0
+      pool.getQueuedJobCount shouldBe 0
+    }
+  }
+
+  "check" should "handle validation failures" in {
+    val validators = getValidators(2)
+    val pool = getPool(validators)
+    val eventuallyFails = pool.check("test-1", "Example text")
+    val errorMessage = "Something went wrong"
+    validators(0).markAsComplete(responses)
+    validators(1).fail(errorMessage)
+    ScalaFutures.whenReady(eventuallyFails.failed) { e =>
+      e.getMessage shouldBe errorMessage
+    }
+  }
+}

--- a/test/scala/services/ValidatorPoolTest.scala
+++ b/test/scala/services/ValidatorPoolTest.scala
@@ -145,4 +145,13 @@ class ValidatorPoolTest extends AsyncFlatSpec with Matchers {
       e.getMessage shouldBe errorMessage
     }
   }
+
+  "check" should "handle requests for categories that do not exist" in {
+    val validators = getValidators(2)
+    val pool = getPool(validators)
+    val eventuallyFails = pool.check("test-1", "Example text", Some(List("category-does-not-exist")))
+    ScalaFutures.whenReady(eventuallyFails.failed) { e =>
+      e.getMessage should include("unknown category")
+    }
+  }
 }

--- a/test/scala/simulation/CheckPermutationsSimulation.scala
+++ b/test/scala/simulation/CheckPermutationsSimulation.scala
@@ -11,10 +11,14 @@ class CheckPermutationsSimulation extends Simulation {
 
   val scn = scenario("CheckPermutationsSimulation")
     .exec(http("checkRequest")
-    .post("/check").body(StringBody(_ => s"""{\"text\": \"$getRandomArticle\"}""")))
+    .post("/check").body(StringBody(_ =>
+      s"""{
+         |\"text\": \"$getRandomArticle\",
+         |\"id\": \"${java.util.UUID.randomUUID.toString}\"
+         |}""".stripMargin)))
 
   setUp(
-    scn.inject(constantUsersPerSec(10) during (10 seconds))
+    scn.inject(atOnceUsers(100))
   ).protocols(httpConf)
 
   val articleFragments = List("Michel Barnier has warned that the move led by Labour MP Yvette Cooper to block the prime minister from delivering a no-deal Brexit is doomed to fail unless a majority for an alternative agreement is found",


### PR DESCRIPTION
Please see #11 before reviewing this PR -- it's upstream from this work.

## What's changed?

At the moment, there's no limit to the number of concurrent validation jobs, and sending large numbers of validations simultaneously can cause boxes to fall over. This PR adds a queue to the `ValidatorPool` to limit the number of validation jobs that can be performed concurrently. We can adjust this figure to establish sensible defaults.

### Implementation details

I tried a few ways of queuing work before settling on the current Akka streams implementation, including rolling my own queue and using Actors to managing distributing work:
- Rolling my own queue worked and tested well, but I couldn't help but feel there was a solution that was more concise and less surprising
- Actors were quite verbose, and that was before I'd implemented backpressure behaviour

The current stream-based implementation seems to work well and is definitely the most concise and arguably the least surprising of the three. I'd be really interested in any feedback.