### PR TITLE
Support multiple suggestion types

### DIFF
--- a/app/model/RuleMatch.scala
+++ b/app/model/RuleMatch.scala
@@ -10,7 +10,7 @@ case class RuleMatch(rule: ResponseRule,
                      toPos: Int,
                      message: String,
                      shortMessage: Option[String] = None,
-                     suggestedReplacements: List[String] = List.empty)
+                     suggestions: List[Suggestion] = List.empty)
 
 object RuleMatch {
   def fromLT(lt: LTRuleMatch): RuleMatch = {
@@ -20,7 +20,7 @@ object RuleMatch {
       toPos = lt.getToPos,
       message = lt.getMessage,
       shortMessage = Some(lt.getMessage),
-      suggestedReplacements = lt.getSuggestedReplacements.asScala.toList
+      suggestions = lt.getSuggestedReplacements.asScala.toList.map { TextSuggestion(_) }
     )
   }
 

--- a/app/model/Suggestion.scala
+++ b/app/model/Suggestion.scala
@@ -1,0 +1,30 @@
+package model
+
+import play.api.libs.json.{Json, Reads, Writes}
+
+object Suggestion {
+  implicit val writes: Writes[Suggestion] = {
+    case textSuggestion: TextSuggestion =>
+      TextSuggestion.writes.writes(textSuggestion)
+  }
+}
+
+sealed trait Suggestion {
+  val `type`: String
+  val text: String
+}
+
+object TextSuggestion {
+  implicit val reads: Reads[TextSuggestion] = Json.reads[TextSuggestion]
+  implicit val writes = new Writes[TextSuggestion] {
+    def writes(suggestion: TextSuggestion) = Json.obj(
+      "type" -> suggestion.`type`,
+      "text" -> suggestion.text
+    )
+  }
+}
+
+case class TextSuggestion(text: String) extends Suggestion {
+  val `type` = "TEXT_SUGGESTION"
+}
+

--- a/app/model/Suggestion.scala
+++ b/app/model/Suggestion.scala
@@ -18,9 +18,8 @@ object TextSuggestion {
   implicit val reads: Reads[TextSuggestion] = Json.reads[TextSuggestion]
   implicit val writes = new Writes[TextSuggestion] {
     def writes(suggestion: TextSuggestion) = Json.obj(
-      "type" -> suggestion.`type`,
-      "text" -> suggestion.text
-    )
+      "type" -> suggestion.`type`
+    ) ++ Json.writes[TextSuggestion].writes(suggestion)
   }
 }
 


### PR DESCRIPTION
There are lots of suggestion types we'd like to include in future, including the Wiki-like person lookups indicated in #12. This PR adds a more sophisticated `Suggestion` type, with a `type` field, so client consumers can disambiguate suggestions and handle them accordingly.