### PR TITLE
Add matched text to the RuleMatch model

### DIFF
--- a/app/model/RuleMatch.scala
+++ b/app/model/RuleMatch.scala
@@ -6,11 +6,12 @@ import play.api.libs.json.{Json, Writes}
 import scala.collection.JavaConverters._
 
 object RuleMatch {
-  def fromLT(lt: LTRuleMatch): RuleMatch = {
+  def fromLT(lt: LTRuleMatch, block: TextBlock): RuleMatch = {
     RuleMatch(
       rule = LTRule.fromLT(lt.getRule),
       fromPos = lt.getFromPos,
       toPos = lt.getToPos,
+      matchedText = block.text.substring(lt.getFromPos, lt.getToPos),
       message = lt.getMessage,
       shortMessage = Some(lt.getMessage),
       suggestions = lt.getSuggestedReplacements.asScala.toList.map { TextSuggestion(_) }
@@ -21,6 +22,7 @@ object RuleMatch {
       "rule" -> BaseRule.toJson(ruleMatch.rule),
       "fromPos"-> ruleMatch.fromPos,
       "toPos" -> ruleMatch.toPos,
+      "matchedText" -> ruleMatch.matchedText,
       "message" -> ruleMatch.message,
       "shortMessage" -> ruleMatch.shortMessage,
       "suggestions" -> ruleMatch.suggestions,
@@ -32,6 +34,7 @@ object RuleMatch {
 case class RuleMatch(rule: BaseRule,
                      fromPos: Int,
                      toPos: Int,
+                     matchedText: String,
                      message: String,
                      shortMessage: Option[String] = None,
                      suggestions: List[Suggestion] = List.empty,

--- a/app/services/LanguageToolFactory.scala
+++ b/app/services/LanguageToolFactory.scala
@@ -59,7 +59,7 @@ class LanguageTool(category: String, instance: JLanguageTool)(implicit ec: Execu
   def check(request: MatcherRequest): Future[List[RuleMatch]] = {
     Future {
       request.blocks.flatMap { block =>
-        instance.check(block.text).asScala.map(RuleMatch.fromLT).toList.map { ruleMatch =>
+        instance.check(block.text).asScala.map(RuleMatch.fromLT(_, block)).toList.map { ruleMatch =>
           ruleMatch.copy(
             fromPos = ruleMatch.fromPos + block.from,
             toPos = ruleMatch.toPos + block.from

--- a/app/services/RegexMatcher.scala
+++ b/app/services/RegexMatcher.scala
@@ -22,6 +22,7 @@ class RegexMatcher(category: String, rules: List[RegexRule]) extends Matcher {
           rule = rule,
           fromPos = currentMatch.start + block.from,
           toPos = currentMatch.end + block.from,
+          matchedText = block.text.substring(currentMatch.start, currentMatch.end),
           message = rule.description,
           shortMessage = Some(rule.description),
           suggestions = rule.suggestions,

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -94,6 +94,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
           rule = responseRule,
           fromPos = from,
           toPos = to,
+          matchedText = "placeholder text",
           message = message
         )
     }

--- a/test/scala/services/RegexMatcherTest.scala
+++ b/test/scala/services/RegexMatcherTest.scala
@@ -19,6 +19,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     rule = exampleRule,
     fromPos = fromPos,
     toPos = toPos,
+    matchedText = text,
     message = "An example rule",
     shortMessage = Some("An example rule"),
     suggestions = List(TextSuggestion("other text"))


### PR DESCRIPTION
## What's changed?

Add matched text to the `RuleMatch` model. Although we can derive this on the client, it's simpler to include it in the model.

A `RuleMatch` corresponds to a match a `Matcher` has found in a `block` of text. A block of text is a continuous piece of text without structure -- think calling `innerText` on a `paragraph` node in the DOM. It contains everything the client-side needs to know about this match, including its position in the block, the rule that it matched against, and any suggestions or replacements that the rule or the matcher might have provided.

This change adds the matched text itself, which was previously missing.