### PR TITLE
Add document ID to requests and improve logging

### DIFF
--- a/app/model/Check.scala
+++ b/app/model/Check.scala
@@ -1,12 +1,23 @@
 package model
 
+import scala.collection.JavaConverters._
+import net.logstash.logback.marker.Markers
 import play.api.libs.json.{Json, Reads}
 
 case class Check(
-                  requestId: String,
-                  categoryIds: Option[List[String]],
-                  blocks: List[TextBlock]
-                )
+  documentId: Option[String],
+  requestId: String,
+  categoryIds: Option[List[String]],
+  blocks: List[TextBlock]
+) {
+  def toMarker = Markers.appendEntries(Map(
+    "requestId" -> this.requestId,
+    "documentId" -> this.documentId,
+    "blocks" -> this.blocks.map(_.id).mkString(", "),
+    "categoryIds" -> this.categoryIds.mkString(", ")
+  ).asJava)
+}
+
 
 object Check {
   implicit val reads: Reads[Check] = Json.reads[Check]

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -103,6 +103,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
   private val blockId = "block-id"
 
   private def getCheck(text: String, categoryIds: Option[List[String]] = None) = Check(
+    Some("example-document"),
     setId,
     categoryIds,
     List(TextBlock(blockId, text, 0, text.length)))
@@ -137,6 +138,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     val matchers = getMatchers(1)
     // This check should produce a job for each block, filling the queue.
     val checkWithManyBlocks = Check(
+      Some("example-document"),
       setId,
       None,
       (0 to 100).toList.map { id => TextBlock(id.toString, "Example text", 0, 12) });


### PR DESCRIPTION
... by adding markers to the `MatcherPool` data.

The `MatcherPool` is the service that manages the flow of work through Typerighter as it receives and parses requests. By adding a document ID to requests and logging it out, we can tell which docs are being run through the service. There's a [corresponding change in the prosemirror-typerighter plugin](https://github.com/guardian/prosemirror-typerighter/tree/jsh/0.4.8) to pass this property through.

I borrowed the `toMarker` pattern from @akash1810, who I've seen use it on the Grid -- thanks Akash!