### PR TITLE
start script following the script/task pattern

### DIFF
--- a/docs/01-running-locally.md
+++ b/docs/01-running-locally.md
@@ -1,6 +1,8 @@
 # Basic developer run
 
-`sbt run` and visit `localhost:9000` to confirm the service came up correctly.
+`./script/start` and visit `localhost:9000` to confirm the service came up correctly.
+
+To attach an interactive debugger, run `./script/start --debug` to expose port 5005 for debugging.
 
 ## Demonstration of null request
 

--- a/script/start
+++ b/script/start
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+IS_DEBUG=false
+for arg in "$@"
+do
+  if [[ "$arg" == "--debug" ]]; then
+    IS_DEBUG=true
+    shift
+  fi
+done
+
+if [[ "$IS_DEBUG" = true ]] ; then
+  sbt -jvm-debug 5005 run
+else
+  sbt run
+fi


### PR DESCRIPTION
`./script/start` also takes in a conditional `--debug` argument to debug the app on port 5005

More info [here](https://github.com/github/scripts-to-rule-them-all)