### PR TITLE
Use Set not List for comparison to avoid stochastic effects

### DIFF
--- a/script/citest
+++ b/script/citest
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/sh -e
 
 sbt clean compile test riffRaffNotifyTeamcity

--- a/script/citest
+++ b/script/citest
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+sbt clean compile test riffRaffNotifyTeamcity

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -185,13 +185,12 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     val futureResult = pool.check(check)
     matchers.foreach(_.markAsComplete(responses))
     ScalaFutures.whenReady(futureResult) { _ =>
-    val categories = matchers.map {_.getCategory}
-    val comparator = (a:MatcherPoolEvent,b:MatcherPoolEvent) => a.requestId < b.requestId
-    events.toList.sortWith(comparator) shouldBe List(
-      MatcherPoolResultEvent(setId, MatcherResponse(check.blocks, List(categories(0)), responses)),
-      MatcherPoolResultEvent(setId, MatcherResponse(check.blocks, List(categories(1)), responses)),
-      MatcherPoolJobsCompleteEvent(setId)
-    ).sortWith(comparator)
+      val categories = matchers.map {_.getCategory}
+      events.toSet shouldBe Set(
+        MatcherPoolResultEvent(setId, MatcherResponse(check.blocks, List(categories(0)), responses)),
+        MatcherPoolResultEvent(setId, MatcherResponse(check.blocks, List(categories(1)), responses)),
+        MatcherPoolJobsCompleteEvent(setId)
+      )
     }
   }
 }


### PR DESCRIPTION
With a list, stochastic effects of queuing/polling mean that the eventual order is not consistent.  This makes testing inconsistent.

As the ordering is actually irrelevent, switching to an unordered collection (Set) removes this problem.