### PR TITLE
Add a 'search for matches' mode to the rule audit client

### DIFF
--- a/app/assets/stylesheets/main.less
+++ b/app/assets/stylesheets/main.less
@@ -423,3 +423,8 @@ hr {
 
 .TyperighterPlugin__container {
   position: relative; }
+
+  #overlays {
+    position: relative;
+    z-index: 2;
+  }

--- a/app/services/ContentClient.scala
+++ b/app/services/ContentClient.scala
@@ -14,6 +14,7 @@ class ContentClient(client: GuardianContentClient) {
       .search
       .q(queryStr)
       .showFields("body")
+      .orderBy("newest")
       .page(page)
     val queryWithTags = tags.foldLeft(query) { case (q, tag) => q.tag(tag)}
     val queryWithSections = sections.foldLeft(queryWithTags) { case (q, section) => q.section(section)}

--- a/conf/routes
+++ b/conf/routes
@@ -16,6 +16,6 @@ GET     /audit                      controllers.AuditController.index
 + nocsrf
 POST    /check                      controllers.ApiController.check
 GET     /categories                 controllers.ApiController.getCurrentCategories
-GET     /capi/search                controllers.CapiProxyController.searchContent(query: String, tags: Option[List[String]], sections: Option[List[String]], page: Option[Int] = None)
+GET     /capi/search                controllers.CapiProxyController.searchContent(query: String, tags: Option[List[String]], sections: Option[List[String]], page: Option[Int])
 GET     /capi/tags/:query           controllers.CapiProxyController.searchTags(query)
 GET     /capi/sections/:query       controllers.CapiProxyController.searchSections(query)

--- a/rule-audit-client/package-lock.json
+++ b/rule-audit-client/package-lock.json
@@ -968,6 +968,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/classnames": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.10.tgz",
+      "integrity": "sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ=="
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -8800,9 +8805,9 @@
       }
     },
     "redux-bundle-creator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/redux-bundle-creator/-/redux-bundle-creator-1.0.1.tgz",
-      "integrity": "sha512-N1yutZxIAKlRYB3y+Lr0DDuQoR26flu/Us6fruIH7vgSJYz1hV3gkpErQUJbHxBivtm0pfU4Y335SOlqlPGHIQ=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/redux-bundle-creator/-/redux-bundle-creator-1.0.2.tgz",
+      "integrity": "sha512-f22DskTwtDwMGh1sE5sAwZpkvLBJ+P4jxuws435P2EpXyvOMgO2kCa254oHF8t+7Ph3AmBXaouYxlyGJdsXabA=="
     },
     "redux-thunk": {
       "version": "2.3.0",

--- a/rule-audit-client/package.json
+++ b/rule-audit-client/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@guardian/prosemirror-typerighter": "^0.5.1",
     "@guardian/threads": "^0.22.0-0",
+    "@types/classnames": "^2.2.10",
     "@types/prosemirror-history": "^1.0.1",
     "@types/prosemirror-inputrules": "^1.0.2",
     "@types/prosemirror-keymap": "^1.0.1",
@@ -64,7 +65,7 @@
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.5",
-    "redux-bundle-creator": "^1.0.1",
+    "redux-bundle-creator": "^1.0.2",
     "redux-thunk": "^2.3.0",
     "typesafe-actions": "^5.1.0",
     "uuid": "^8.1.0"

--- a/rule-audit-client/package.json
+++ b/rule-audit-client/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --config ./conf/webpack.dev.config.js --open",
+    "start": "webpack --config ./conf/webpack.prod.config.js --watch",
     "build": "webpack --config ./conf/webpack.prod.config.js",
     "test": "jest"
   },

--- a/rule-audit-client/src/components/App.tsx
+++ b/rule-audit-client/src/components/App.tsx
@@ -1,4 +1,3 @@
-import { hot } from "react-hot-loader/root";
 import * as React from "react";
 import { Provider } from "react-redux";
 
@@ -39,4 +38,4 @@ const App = () => (
   </Provider>
 );
 
-export default hot(App);
+export default App;

--- a/rule-audit-client/src/components/capiFeed/CapiFeedItem.tsx
+++ b/rule-audit-client/src/components/capiFeed/CapiFeedItem.tsx
@@ -18,7 +18,6 @@ type IProps = ReturnType<typeof mapStateToProps> &
 
 const CapiFeedItem = ({
   doSelectArticle,
-  selectedArticle,
   article,
   isLoading,
 }: IProps) => {

--- a/rule-audit-client/src/components/capiFeed/CapiResults.tsx
+++ b/rule-audit-client/src/components/capiFeed/CapiResults.tsx
@@ -37,7 +37,7 @@ const CapiResults = ({
   return (
     <>
       <p className={classnames("mt-2 mb-0", { "text-secondary": isLoading })}>
-        <span className="h5">{`Showing ${articleIds.length}  of ${totalArticles} articles`}</span>
+        <span className="h5">{`Showing ${articleIds.length}  of ~${totalArticles} articles`}</span>
         {isLoading && (
           <span
             className="spinner-border spinner-border-sm text-primary float-right"

--- a/rule-audit-client/src/components/capiFeed/CapiResults.tsx
+++ b/rule-audit-client/src/components/capiFeed/CapiResults.tsx
@@ -1,19 +1,31 @@
-import React, { useState } from "react";
-import AppTypes from "AppTypes";
+import React from "react";
+import classnames from "classnames";
 import { connect } from "react-redux";
 
+import AppTypes from "AppTypes";
 import { selectors as capiSelectors } from "redux/modules/capiContent";
-import { selectors as uiSelectors } from "redux/modules/ui";
-import { CapiContentWithMatches } from "services/capi";
-import { notEmpty } from "utils/predicates";
+import {
+  selectors as uiSelectors,
+  actions as uiActions,
+} from "redux/modules/ui";
+import { selectors as searchMatchesSelectors } from "redux/modules/searchMatches";
 import CapiFeedItem from "./CapiFeedItem";
+import { bindActionCreators } from "redux";
 
-type IProps = ReturnType<typeof mapStateToProps>;
+type IProps = ReturnType<typeof mapStateToProps> &
+  ReturnType<typeof mapDispatchToProps>;
 
 const articleNumberFormat = new Intl.NumberFormat("en-GB");
 const checkboxId = "capi-results__show-all-articles";
 
-const CapiResults = ({ articleIds, isLoading, pagination }: IProps) => {
+const CapiResults = ({
+  articleIds,
+  isLoading,
+  pagination,
+  searchMatchesLoadingText,
+  displayAllArticles,
+  doToggleDisplayAllArticles,
+}: IProps) => {
   const totalArticles = pagination
     ? articleNumberFormat.format(
         articleIds.length < pagination.pageSize
@@ -21,29 +33,69 @@ const CapiResults = ({ articleIds, isLoading, pagination }: IProps) => {
           : pagination.totalPages * pagination.pageSize
       )
     : "?";
+
   return (
     <>
-      {isLoading ? (
-        <h5 className="text-secondary mt-2 mb-0">Loading</h5>
-      ) : (
-        <h5 className="mt-2 mb-0">
-          {articleIds.length} of {totalArticles} articles
-        </h5>
-      )}
+      <p className={classnames("mt-2 mb-0", { "text-secondary": isLoading })}>
+        <span className="h5">{`Showing ${articleIds.length}  of ${totalArticles} articles`}</span>
+        {isLoading && (
+          <span
+            className="spinner-border spinner-border-sm text-primary float-right"
+            role="status"
+          >
+            <span className="sr-only">Loading...</span>
+          </span>
+        )}
+      </p>
+      {searchMatchesLoadingText && <p>{searchMatchesLoadingText}</p>}
+      <div className="form-check form-check-inline mt-2">
+        <input
+          className="form-check-input"
+          type="checkbox"
+          id={checkboxId}
+          checked={displayAllArticles}
+          onChange={doToggleDisplayAllArticles}
+        />
+        <label className="form-check-label" htmlFor={checkboxId}>
+          <small>Show articles that don't have matches</small>
+        </label>
+      </div>
       <div className="list-group mt-2">
         {articleIds.map((id) => (
-          <CapiFeedItem id={id} />
+          <CapiFeedItem id={id} key={id} />
         ))}
       </div>
     </>
   );
 };
 
-const mapStateToProps = (state: AppTypes.RootState) => ({
-  articleIds: capiSelectors.selectLastFetchedArticleIds(state),
-  isLoading: capiSelectors.selectIsLoading(state),
-  pagination: capiSelectors.selectPagination(state),
-  selectedArticle: uiSelectors.selectSelectedArticle(state),
-});
+const mapStateToProps = (state: AppTypes.RootState) => {
+  const selectAllArticles = uiSelectors.selectDisplayAllArticles(state);
+  const searchMode = uiSelectors.selectSearchMode(state);
 
-export default connect(mapStateToProps)(CapiResults);
+  return {
+    articleIds:
+      searchMode === "MATCHES"
+        ? searchMatchesSelectors.selectSearchMatchesArticleIds(state, selectAllArticles)
+        : capiSelectors.selectLastFetchedArticleIds(state, selectAllArticles),
+    isLoading:
+      capiSelectors.selectIsLoading(state) ||
+      searchMatchesSelectors.selectIsSearchMatchesInProgress(state),
+    searchMatchesLoadingText: searchMatchesSelectors.selectSearchMatchesLoadingText(
+      state
+    ),
+    pagination: capiSelectors.selectPagination(state),
+    selectedArticle: uiSelectors.selectSelectedArticle(state),
+    displayAllArticles: uiSelectors.selectDisplayAllArticles(state),
+  };
+};
+
+const mapDispatchToProps = (dispatch: AppTypes.Dispatch) =>
+  bindActionCreators(
+    {
+      doToggleDisplayAllArticles: uiActions.doToggleDisplayAllArticles,
+    },
+    dispatch
+  );
+
+export default connect(mapStateToProps, mapDispatchToProps)(CapiResults);

--- a/rule-audit-client/src/components/capiFeed/CapiSearchOptions.tsx
+++ b/rule-audit-client/src/components/capiFeed/CapiSearchOptions.tsx
@@ -8,14 +8,16 @@ import {
   Filter,
   SelectAsyncFilter,
 } from "@guardian/threads";
-import { debounce } from 'lodash';
+import { debounce } from "lodash";
 
 import AppTypes from "AppTypes";
-import { selectors, thunks } from "redux/modules/capiContent";
+import { selectors, thunks, actions } from "redux/modules/searchMatches";
+import { selectors as capiSelectors, thunks as capiThunks } from "redux/modules/capiContent";
 import {
-  fetchCapiTags,
-  fetchCapiSections,
-} from "services/capi";
+  selectors as uiSelectors,
+  actions as uiActions,
+} from "redux/modules/ui";
+import { fetchCapiTags, fetchCapiSections } from "services/capi";
 
 type IProps = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
@@ -52,61 +54,129 @@ const filters: (Filter | SelectAsyncFilter)[] = [
 const getSearchEntitiesFromQueryElements = (elements: QueryElement[]) => ({
   query: elements
     .filter((element) => element.type === "text")
-    .map(_ => _.value)
+    .map((_) => _.value)
     .join(""),
   tags: elements
     .filter((element) => element.type === "filter" && element.name === "Tag")
-    .map(_ => _.value),
+    .map((_) => _.value),
   sections: elements
     .filter(
       (element) => element.type === "filter" && element.name === "Section"
     )
-    .map(_ => _.value)
+    .map((_) => _.value),
 });
 
-const CapiSearchOptions = ({ fetchCapi, fetchMatches }: IProps) => {
+const CapiSearchOptions = ({
+  fetchSearch,
+  fetchMatches,
+  isLoading,
+  searchMode,
+  setSearchMode,
+  searchMatchesLimit,
+  setSearchMatchesLimit,
+  searchMatches,
+}: IProps) => {
   const [queryElements, setQueryElements] = useState<QueryElement[]>([]);
 
   useEffect(() => {
+    if (searchMode !== "ARTICLES") {
+      return;
+    }
     const { query, tags, sections } = getSearchEntitiesFromQueryElements(
       queryElements
     );
-    fetchCapi(query, tags, sections);
+    fetchSearch(query, tags, sections, 1);
   }, [queryElements]);
+
+  const searchMatchesWithCurrentQuery = () => {
+    const { query, tags, sections } = getSearchEntitiesFromQueryElements(
+      queryElements
+    );
+    searchMatches(query, tags, sections);
+  };
 
   return (
     <div>
+      <ul className="nav nav-tabs mb-2">
+        <li className="nav-item">
+          <a
+            className={`nav-link ${searchMode === "ARTICLES" && "active"}`}
+            href="#"
+            onClick={() => setSearchMode("ARTICLES")}
+          >
+            Search articles
+          </a>
+        </li>
+        <li className="nav-item">
+          <a
+            className={`nav-link ${searchMode === "MATCHES" && "active"}`}
+            href="#"
+            onClick={() => setSearchMode("MATCHES")}
+          >
+            Search matches
+          </a>
+        </li>
+      </ul>
       <InputSupper
         elements={queryElements}
         availableFilters={filters}
         onChange={setQueryElements}
       />
+      {searchMode === "MATCHES" && (
+        <div className="input-group mt-2">
+          <div className="input-group-prepend">
+            <button
+              className="btn btn-primary"
+              onClick={searchMatchesWithCurrentQuery}
+              disabled={isLoading}
+            >
+              Search for matches, limit
+            </button>
+          </div>
+          <input
+            className="form-control"
+            type="number"
+            step="1"
+            min="1"
+            max="100"
+            value={searchMatchesLimit}
+            onChange={(e) => setSearchMatchesLimit(parseInt(e.target.value))}
+          />
+        </div>
+      )}
       <button
-        className="btn btn-primary mt-2 w-100"
+        className="btn btn-secondary mt-2 w-100"
         onClick={() => fetchMatches()}
       >
-        Find matches for this search
+        Refresh matches
       </button>
     </div>
   );
 };
 
 const mapStateToProps = (state: AppTypes.RootState) => ({
-  content: selectors.selectAll(state),
+  searchMatchesLimit: selectors.selectSearchMatchesLimit(state),
+  searchMode: uiSelectors.selectSearchMode(state),
+  isLoading:
+    capiSelectors.selectIsLoading(state) ||
+    selectors.selectIsSearchMatchesInProgress(state),
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
-  const { fetchCapi, fetchMatches } = bindActionCreators(
+  const boundActions = bindActionCreators(
     {
-      fetchCapi: thunks.doFetchCapi,
-      fetchMatches: thunks.doFetchMatchesForLastSearch,
+      fetchSearch: capiThunks.doFetchCapi,
+      fetchMatches: capiThunks.doFetchMatchesForLastSearch,
+      searchMatches: thunks.doSearchMatches,
+      setSearchMatchesLimit: actions.doSetSearchMatchesLimit,
+      setSearchMode: uiActions.doSetSearchMode,
     },
     dispatch
   );
   return {
-    fetchCapi: debounce(fetchCapi, 500),
-    fetchMatches
-  }
-}
+    ...boundActions,
+    fetchSearch: debounce(boundActions.fetchSearch, 500),
+  };
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(CapiSearchOptions);

--- a/rule-audit-client/src/index.tsx
+++ b/rule-audit-client/src/index.tsx
@@ -5,11 +5,6 @@ import App from "./components/App";
 
 let rootElem: HTMLElement | null;
 
-if (ENV === 'prod') {
-  rootElem = document.getElementById("rule-audit-app");
-} else {
-  rootElem = document.createElement("div");
-  document.body.append(rootElem);
-}
+rootElem = document.getElementById("rule-audit-app");
 
 ReactDOM.render(<App />, rootElem);

--- a/rule-audit-client/src/redux/modules/searchMatches/__tests__/thunks.spec.ts
+++ b/rule-audit-client/src/redux/modules/searchMatches/__tests__/thunks.spec.ts
@@ -189,9 +189,9 @@ describe("doSearchMatches", () => {
 
     // We call CAPI, and it's returned two articles.
     // We then call Typerighter with those articles, and Typerighter
-    // returns matches for one. We call CAPI again, but the user
-    // cancels the search before the second CAPI request is processed,
-    // so nothing else should go to Typerighter.
+    // returns no matches. Normally we'd continue to call CAPI,
+    // but CAPI's pagination data indicates there are no more pages
+    // to consume, so we stop the loop.
     expect(mockCapiService).toBeCalledTimes(1);
     expect(mockTyperighterService).toBeCalledTimes(2);
 
@@ -231,11 +231,6 @@ describe("doSearchMatches", () => {
 
     const state = store.getState();
 
-    // We call CAPI, and it's returned two articles.
-    // We then call Typerighter with those articles, and Typerighter
-    // returns matches for one. We call CAPI again, but the user
-    // cancels the search before the second CAPI request is processed,
-    // so nothing else should go to Typerighter.
     expect(mockCapiService).toBeCalledTimes(1);
     expect(mockTyperighterService).toBeCalledTimes(3);
 

--- a/rule-audit-client/src/redux/modules/ui/index.ts
+++ b/rule-audit-client/src/redux/modules/ui/index.ts
@@ -2,25 +2,57 @@ import { createAction, createReducer } from "typesafe-actions";
 
 import AppTypes from "AppTypes";
 
-export type UIState = {
+export type SearchMode = "MATCHES" | "ARTICLES";
+
+type UIState = {
   readonly selectedArticle: string | undefined;
+  readonly displayAllArticles: boolean;
+  readonly searchMode: SearchMode;
 };
 
 const initialState: UIState = {
-  selectedArticle: undefined
+  selectedArticle: undefined,
+  displayAllArticles: true,
+  searchMode: "ARTICLES",
 };
 
 const doSelectArticle = createAction("SELECT_ARTICLE")<string>();
 
-const selectSelectedArticle = (state: AppTypes.RootState) => state.ui.selectedArticle;
+const doToggleDisplayAllArticles = createAction(
+  "TOGGLE_DISPLAY_ALL_ARTICLES"
+)();
 
-export const reducer = createReducer(initialState).handleAction(
-  doSelectArticle,
-  (state, action) => ({
+const doSetSearchMode = createAction("SET_SEARCH_MODE")<SearchMode>();
+
+const selectSelectedArticle = (state: AppTypes.RootState) =>
+  state.ui.selectedArticle;
+
+const selectDisplayAllArticles = (state: AppTypes.RootState) =>
+  state.ui.displayAllArticles;
+
+const selectSearchMode = (state: AppTypes.RootState) => state.ui.searchMode;
+
+export const reducer = createReducer(initialState)
+  .handleAction(doSelectArticle, (state, action) => ({
     ...state,
-    selectedArticle: action.payload
-  })
-);
+    selectedArticle: action.payload,
+  }))
+  .handleAction(doToggleDisplayAllArticles, (state, action) => ({
+    ...state,
+    displayAllArticles: !state.displayAllArticles,
+  }))
+  .handleAction(doSetSearchMode, (state, action) => ({
+    ...state,
+    searchMode: action.payload
+  }));
 
-export const selectors = { selectSelectedArticle };
-export const actions = { doSelectArticle };
+export const selectors = {
+  selectSelectedArticle,
+  selectDisplayAllArticles,
+  selectSearchMode,
+};
+export const actions = {
+  doSelectArticle,
+  doToggleDisplayAllArticles,
+  doSetSearchMode,
+};

--- a/rule-audit-client/src/services/capi.ts
+++ b/rule-audit-client/src/services/capi.ts
@@ -70,8 +70,8 @@ export const fetchCapiSearch = async (
   page?: number
 ): Promise<CapiContentResponse> => {
   const params = new URLSearchParams();
-  page && params.append("page", page.toString());
   params.append("query", query);
+  page && params.append("page", page.toString());
 
   // Do not include empty tag or section values.
   tags.filter(_ => _).forEach(_ => params.append("tags", _));


### PR DESCRIPTION
~Depends on #52 – please review that PR first for a smaller diff of the state management code.~ This is now ready for review.

## What does this change?

This PR adds a 'search for matches' mode, in addition to the standard CAPI search. This mode runs a CAPI search, finds Typerighter results for it, and repeats, until n articles with matches have been found. N is specified by the user.

![search-matches](https://user-images.githubusercontent.com/7767575/86578317-8911a280-bf73-11ea-9ad6-d24da0c38aab.gif)

## Why is this useful?

At the moment, it's easy to answer the question, 'what results does Typerighter give for the results of this particular CAPI search'. But it's difficult to answer the question, 'how does Typerighter perform for this CAPI search more generally'?

By searching for articles with matches, and not just articles, we can get a better idea of how rules will be applied across the corpus more generally – both by finding lots of articles with matches, and also by giving us an idea of how often these matches will apply, to spot e.g. noisy rules.

## How can we measure success?

In the rule audit client, click on 'search by matches', and then click the search button. The app should search CAPI and run articles through Typerighter until the number of articles with matches specified in the number input have been found.
