### PR TITLE
Add pagination to CAPI proxy

### DIFF
--- a/app/controllers/CapiProxyController.scala
+++ b/app/controllers/CapiProxyController.scala
@@ -10,11 +10,12 @@ import scala.concurrent.{ExecutionContext, Future}
 class CapiProxyController(cc: ControllerComponents, contentClient: ContentClient)(implicit ec: ExecutionContext)
   extends AbstractController(cc) {
 
-  def searchContent(query: String, tags: Option[List[String]], sections: Option[List[String]]) = Action.async {
+  def searchContent(query: String, tags: Option[List[String]], sections: Option[List[String]], page: Option[Int]) = Action.async {
     contentClient.searchContent(
       query,
       tags.getOrElse(Nil),
-      sections.getOrElse(Nil)
+      sections.getOrElse(Nil),
+      page.getOrElse(1)
     ).map { result => Ok(result.asJson.toString).as(JSON) }
   }
 

--- a/app/services/ContentClient.scala
+++ b/app/services/ContentClient.scala
@@ -9,8 +9,12 @@ class ContentClient(client: GuardianContentClient) {
   /**
     * Search the Content API for articles with the given query parameters.
     */
-  def searchContent(queryStr: String, tags: List[String] = List.empty, sections: List[String] = List.empty)(implicit ec: ExecutionContext): Future[SearchResponse] = {
-    val query = ContentApiClient.search.q(queryStr).showFields("body")
+  def searchContent(queryStr: String, tags: List[String] = List.empty, sections: List[String] = List.empty, page: Int = 1)(implicit ec: ExecutionContext): Future[SearchResponse] = {
+    val query = ContentApiClient
+      .search
+      .q(queryStr)
+      .showFields("body")
+      .page(page)
     val queryWithTags = tags.foldLeft(query) { case (q, tag) => q.tag(tag)}
     val queryWithSections = sections.foldLeft(queryWithTags) { case (q, section) => q.section(section)}
     client.getResponse(queryWithSections)

--- a/conf/routes
+++ b/conf/routes
@@ -16,6 +16,6 @@ GET     /audit                      controllers.AuditController.index
 + nocsrf
 POST    /check                      controllers.ApiController.check
 GET     /categories                 controllers.ApiController.getCurrentCategories
-GET     /capi/search                controllers.CapiProxyController.searchContent(query: String, tags: Option[List[String]], sections: Option[List[String]])
+GET     /capi/search                controllers.CapiProxyController.searchContent(query: String, tags: Option[List[String]], sections: Option[List[String]], page: Option[Int])
 GET     /capi/tags/:query           controllers.CapiProxyController.searchTags(query)
 GET     /capi/sections/:query       controllers.CapiProxyController.searchSections(query)

--- a/conf/routes
+++ b/conf/routes
@@ -16,6 +16,6 @@ GET     /audit                      controllers.AuditController.index
 + nocsrf
 POST    /check                      controllers.ApiController.check
 GET     /categories                 controllers.ApiController.getCurrentCategories
-GET     /capi/search                controllers.CapiProxyController.searchContent(query: String, tags: Option[List[String]], sections: Option[List[String]], page: Option[Int])
+GET     /capi/search                controllers.CapiProxyController.searchContent(query: String, tags: Option[List[String]], sections: Option[List[String]], page: Option[Int] = None)
 GET     /capi/tags/:query           controllers.CapiProxyController.searchTags(query)
 GET     /capi/sections/:query       controllers.CapiProxyController.searchSections(query)

--- a/rule-audit-client/src/services/capi.ts
+++ b/rule-audit-client/src/services/capi.ts
@@ -1,5 +1,8 @@
 import { urls } from "../constants";
-import { IMatch, IBlock } from "@guardian/prosemirror-typerighter/dist/src/ts/interfaces/IMatch";
+import {
+  IMatch,
+  IBlock,
+} from "@guardian/prosemirror-typerighter/dist/src/ts/interfaces/IMatch";
 
 export type CapiResponse<TContent> = {
   status: "ok" | "error";
@@ -63,9 +66,11 @@ export type CapiTag = {
 export const fetchCapiSearch = async (
   query: string,
   tags: string[],
-  sections: string[]
+  sections: string[],
+  page: number
 ): Promise<CapiContentResponse> => {
   const params = new URLSearchParams();
+  params.append("page", page.toString());
   params.append("query", query);
 
   // Do not include empty tag or section values.

--- a/rule-audit-client/src/services/capi.ts
+++ b/rule-audit-client/src/services/capi.ts
@@ -67,10 +67,10 @@ export const fetchCapiSearch = async (
   query: string,
   tags: string[],
   sections: string[],
-  page: number
+  page?: number
 ): Promise<CapiContentResponse> => {
   const params = new URLSearchParams();
-  params.append("page", page.toString());
+  page && params.append("page", page.toString());
   params.append("query", query);
 
   // Do not include empty tag or section values.


### PR DESCRIPTION
## What does this change?

This PR adds a pagination argument to the CAPI proxy.

## How can we measure success?

This is a no-op at present – it's preparation for a future PR.

Because it's a pass-through on a well known API, I haven't added tests – they can be added if needed, though.
