### PR TITLE
Add a 'search matches' function to the state

### DIFF
--- a/rule-audit-client/jest.config.js
+++ b/rule-audit-client/jest.config.js
@@ -1,6 +1,8 @@
 module.exports = {
-  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  moduleFileExtensions: ["ts", "tsx", "js"],
+  modulePaths: ["<rootDir>/src"],
+  testMatch: ["**/?(*.)+(spec|test).[jt]s?(x)"],
   transform: {
-    '^.+\\.(ts|tsx|js)$': 'ts-jest'
-  }
+    "^.+\\.(ts|tsx|js)$": "ts-jest",
+  },
 };

--- a/rule-audit-client/src/components/App.tsx
+++ b/rule-audit-client/src/components/App.tsx
@@ -2,9 +2,11 @@ import { hot } from "react-hot-loader/root";
 import * as React from "react";
 import { Provider } from "react-redux";
 
-import store from "redux/store";
+import { createStore } from "redux/store";
 import CapiFeed from "./capiFeed/CapiFeed";
 import Document from "./document/Document";
+
+const store = createStore();
 
 const App = () => (
   <Provider store={store}>

--- a/rule-audit-client/src/components/capiFeed/CapiResults.tsx
+++ b/rule-audit-client/src/components/capiFeed/CapiResults.tsx
@@ -11,32 +11,13 @@ import CapiFeedItem from "./CapiFeedItem";
 type IProps = ReturnType<typeof mapStateToProps>;
 
 const articleNumberFormat = new Intl.NumberFormat("en-GB");
+const checkboxId = "capi-results__show-all-articles";
 
-const filterArticles = (
-  articles: (CapiContentWithMatches | undefined)[],
-  showArticlesWithMatchesOnly: boolean
-) =>
-  showArticlesWithMatchesOnly
-    ? (articles.filter(
-        (_) => (_ !== undefined && !_.meta.matches) || _?.meta.matches.length
-      ) as CapiContentWithMatches[])
-    : (articles.filter((_) => _ !== undefined) as CapiContentWithMatches[]);
-
-const CapiResults = ({ articles, isLoading, pagination }: IProps) => {
-  const [
-    showArticlesWithMatchesOnly,
-    setShowArticlesWithMatchesOnly,
-  ] = useState(false);
-  const checkboxId = "checkbox-show-article-matches";
-  const articleArray = Object.values(articles).filter(notEmpty);
-  const filteredArticles = filterArticles(
-    articleArray,
-    showArticlesWithMatchesOnly
-  );
+const CapiResults = ({ articleIds, isLoading, pagination }: IProps) => {
   const totalArticles = pagination
     ? articleNumberFormat.format(
-        filteredArticles.length < pagination.pageSize
-          ? filteredArticles.length
+        articleIds.length < pagination.pageSize
+          ? articleIds.length
           : pagination.totalPages * pagination.pageSize
       )
     : "?";
@@ -46,24 +27,12 @@ const CapiResults = ({ articles, isLoading, pagination }: IProps) => {
         <h5 className="text-secondary mt-2 mb-0">Loading</h5>
       ) : (
         <h5 className="mt-2 mb-0">
-          {filteredArticles.length} of {totalArticles} articles
+          {articleIds.length} of {totalArticles} articles
         </h5>
       )}
-      <div className="form-check form-check-inline mt-2">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          id={checkboxId}
-          value={showArticlesWithMatchesOnly.toString()}
-          onChange={(_) => setShowArticlesWithMatchesOnly(_.target.checked)}
-        />
-        <label className="form-check-label" htmlFor={checkboxId}>
-          <small>Hide articles that don't have matches</small>
-        </label>
-      </div>
       <div className="list-group mt-2">
-        {filteredArticles.map((article) => (
-          <CapiFeedItem id={article.id} />
+        {articleIds.map((id) => (
+          <CapiFeedItem id={id} />
         ))}
       </div>
     </>
@@ -71,7 +40,7 @@ const CapiResults = ({ articles, isLoading, pagination }: IProps) => {
 };
 
 const mapStateToProps = (state: AppTypes.RootState) => ({
-  articles: capiSelectors.selectLastFetchedArticles(state),
+  articleIds: capiSelectors.selectLastFetchedArticleIds(state),
   isLoading: capiSelectors.selectIsLoading(state),
   pagination: capiSelectors.selectPagination(state),
   selectedArticle: uiSelectors.selectSelectedArticle(state),

--- a/rule-audit-client/src/components/capiFeed/CapiSearchOptions.tsx
+++ b/rule-audit-client/src/components/capiFeed/CapiSearchOptions.tsx
@@ -11,7 +11,7 @@ import {
 import { debounce } from 'lodash';
 
 import AppTypes from "AppTypes";
-import { actions, selectors, thunks } from "redux/modules/capiContent";
+import { selectors, thunks } from "redux/modules/capiContent";
 import {
   fetchCapiTags,
   fetchCapiSections,
@@ -64,14 +64,14 @@ const getSearchEntitiesFromQueryElements = (elements: QueryElement[]) => ({
     .map(_ => _.value)
 });
 
-const CapiSearchOptions = ({ fetchSearch, fetchMatches }: IProps) => {
+const CapiSearchOptions = ({ fetchCapi, fetchMatches }: IProps) => {
   const [queryElements, setQueryElements] = useState<QueryElement[]>([]);
 
   useEffect(() => {
     const { query, tags, sections } = getSearchEntitiesFromQueryElements(
       queryElements
     );
-    fetchSearch(query, tags, sections);
+    fetchCapi(query, tags, sections);
   }, [queryElements]);
 
   return (
@@ -96,15 +96,15 @@ const mapStateToProps = (state: AppTypes.RootState) => ({
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
-  const { fetchSearch, fetchMatches} = bindActionCreators(
+  const { fetchCapi, fetchMatches } = bindActionCreators(
     {
-      fetchSearch: thunks.fetchSearch,
-      fetchMatches: thunks.fetchMatches,
+      fetchCapi: thunks.doFetchCapi,
+      fetchMatches: thunks.doFetchMatchesForLastSearch,
     },
     dispatch
   );
   return {
-    fetchSearch: debounce(fetchSearch, 500),
+    fetchCapi: debounce(fetchCapi, 500),
     fetchMatches
   }
 }

--- a/rule-audit-client/src/components/document/Document.tsx
+++ b/rule-audit-client/src/components/document/Document.tsx
@@ -26,7 +26,7 @@ const Document = ({ article }: IProps) => (
 const mapStateToProps = (state: AppTypes.RootState) => ({
   article: capiSelectors.selectById(
     state,
-    uiSelectors.selectSelectedArticle(state)
+    uiSelectors.selectSelectedArticle(state) || ""
   )
 });
 

--- a/rule-audit-client/src/redux/modules/capiContent/index.ts
+++ b/rule-audit-client/src/redux/modules/capiContent/index.ts
@@ -1,82 +1,15 @@
-import { Dispatch } from "redux";
-import set from "lodash/fp/set";
-import AppTypes from "AppTypes";
 import { createAsyncResourceBundle } from "redux-bundle-creator";
 
-import { CapiContentWithMatches, fetchCapiSearch } from "services/capi";
-import { getBlocksFromHtmlString } from "utils/prosemirror";
-import { fetchTyperighterMatches } from "services/typerighter";
-import { notEmpty } from "utils/predicates";
+import { CapiContentWithMatches } from "services/capi";
+import * as _selectors from './selectors';
 
-const bundle = createAsyncResourceBundle<CapiContentWithMatches, {}, "capi">(
+export * as thunks from './thunks';
+
+export const { actions, reducer, ...bundle } = createAsyncResourceBundle<CapiContentWithMatches, {}, "capi">(
   "capi",
   {
     indexById: true,
   }
 );
 
-const fetchSearch = (
-  query: string,
-  tags: string[],
-  sections: string[]
-) => async (dispatch: Dispatch): Promise<void> => {
-  dispatch(bundle.actions.fetchStart());
-  try {
-    const content = await fetchCapiSearch(query, tags, sections);
-    const models = content.results?.map((article) => ({
-      ...article,
-      meta: {
-        blocks: getBlocksFromHtmlString(article.fields.body),
-        matches: undefined,
-      },
-    }));
-    dispatch(
-      bundle.actions.fetchSuccess(models, {
-        pagination: {
-          pageSize: content.pageSize,
-          totalPages: content.pages,
-          currentPage: content.currentPage,
-        },
-      })
-    );
-  } catch (e) {
-    dispatch(bundle.actions.fetchError(e.message));
-  }
-};
-
-const fetchMatches = () => async (
-  dispatch: Dispatch,
-  getState: () => AppTypes.RootState
-) => {
-  const articles = selectLastFetchedArticles(getState());
-  Object.values(articles).map(async (article) => {
-    dispatch(bundle.actions.updateStart(article));
-    const { matches } = await fetchTyperighterMatches(
-      article.id,
-      article.meta.blocks
-    );
-    const articleWithMatches = set(["meta", "matches"], matches, article);
-    dispatch(bundle.actions.updateSuccess(article.id, articleWithMatches));
-  });
-};
-
-const selectLastFetchedArticles = (
-  state: AppTypes.RootState
-): CapiContentWithMatches[] =>
-  selectors
-    .selectLastFetchOrder(state)
-    .map((id) => selectors.selectById(state, id))
-    .filter(notEmpty);
-
-export const actions = {
-  ...bundle.actions,
-};
-
-export const thunks = {
-  fetchSearch,
-  fetchMatches,
-};
-
-export const selectors = { ...bundle.selectors, selectLastFetchedArticles };
-
-export const reducer = bundle.reducer;
+export const selectors = { ...bundle.selectors, ..._selectors };

--- a/rule-audit-client/src/redux/modules/capiContent/selectors.ts
+++ b/rule-audit-client/src/redux/modules/capiContent/selectors.ts
@@ -1,0 +1,14 @@
+import AppTypes from "AppTypes";
+import { notEmpty } from "utils/predicates";
+import { selectors } from ".";
+
+export const selectLastFetchedArticleIds = (
+  state: AppTypes.RootState,
+  selectAll = true
+): string[] =>
+  selectors
+    .selectLastFetchOrder(state)
+    .map((id) => selectors.selectById(state, id))
+    .filter(notEmpty)
+    .filter((article) => selectAll || article?.meta.matches.length)
+    .map((_) => _.id);

--- a/rule-audit-client/src/redux/modules/capiContent/thunks.ts
+++ b/rule-audit-client/src/redux/modules/capiContent/thunks.ts
@@ -1,0 +1,76 @@
+import { Dispatch } from "redux";
+import set from "lodash/fp/set";
+
+import AppTypes from "AppTypes";
+import { getBlocksFromHtmlString } from "utils/prosemirror";
+import { fetchTyperighterMatches } from "services/typerighter";
+import { fetchCapiSearch, CapiContentWithMatches } from "services/capi";
+import { actions, selectors } from ".";
+
+export const doFetchCapi = (
+  query: string,
+  tags: string[],
+  sections: string[],
+  page: number,
+  fetchCapiSearchService = fetchCapiSearch
+) => async (dispatch: AppTypes.Dispatch): Promise<CapiContentWithMatches[]> => {
+  dispatch(actions.fetchStart());
+  try {
+    const content = await fetchCapiSearchService(query, tags, sections, page);
+    const models = content.results?.map((article) => ({
+      ...article,
+      meta: {
+        blocks: getBlocksFromHtmlString(article.fields.body),
+        matches: [],
+      },
+    }));
+    dispatch(
+      actions.fetchSuccess(models, {
+        pagination: {
+          pageSize: content.pageSize,
+          totalPages: content.pages,
+          currentPage: content.currentPage,
+        },
+      })
+    );
+    return models || [];
+  } catch (e) {
+    dispatch(actions.fetchError(e.message));
+    return [];
+  }
+};
+
+export const doFetchMatchesForLastSearch = (
+  fetchTyperighterMatchesService = fetchTyperighterMatches
+) => async (
+  dispatch: AppTypes.Dispatch,
+  getState: () => AppTypes.RootState
+) => {
+  const articles = selectors.selectLastFetchedArticleIds(getState(), true);
+  return dispatch(doFetchMatches(articles, fetchTyperighterMatchesService));
+};
+
+export const doFetchMatches = (
+  articleIds: string[],
+  fetchTyperighterMatchesService = fetchTyperighterMatches
+) => async (
+  dispatch: Dispatch,
+  getState: () => AppTypes.RootState
+): Promise<(CapiContentWithMatches | undefined)[]> => {
+  const state = getState();
+  const fetchMatchPromises = articleIds.map(async (id) => {
+    const article = selectors.selectById(state, id);
+    if (!article) {
+      return Promise.resolve(undefined);
+    }
+    dispatch(actions.updateStart(article));
+    const { matches } = await fetchTyperighterMatchesService(
+      id,
+      article.meta.blocks
+    );
+    const articleWithMatches = set(["meta", "matches"], matches, article);
+    dispatch(actions.updateSuccess(id, articleWithMatches));
+    return articleWithMatches;
+  });
+  return await Promise.all(fetchMatchPromises);
+};

--- a/rule-audit-client/src/redux/modules/capiContent/thunks.ts
+++ b/rule-audit-client/src/redux/modules/capiContent/thunks.ts
@@ -11,7 +11,7 @@ export const doFetchCapi = (
   query: string,
   tags: string[],
   sections: string[],
-  page: number,
+  page?: number,
   fetchCapiSearchService = fetchCapiSearch
 ) => async (dispatch: AppTypes.Dispatch): Promise<CapiContentWithMatches[]> => {
   dispatch(actions.fetchStart());

--- a/rule-audit-client/src/redux/modules/searchMatches/__tests__/fixtures.ts
+++ b/rule-audit-client/src/redux/modules/searchMatches/__tests__/fixtures.ts
@@ -1,11 +1,11 @@
-export const createCapiResponse = (noOfArticles: number, responseNo = 0) => ({
+export const createCapiResponse = (noOfArticles: number, responseNo = 0, pages = 1000) => ({
   status: "ok",
   userTier: "developer",
   total: 2142557,
   startIndex: 1,
   pageSize: 10,
   currentPage: 1,
-  pages: 214256,
+  pages,
   orderBy: "relevance",
   results: new Array(noOfArticles)
     .fill(undefined)

--- a/rule-audit-client/src/redux/modules/searchMatches/__tests__/fixtures.ts
+++ b/rule-audit-client/src/redux/modules/searchMatches/__tests__/fixtures.ts
@@ -1,0 +1,68 @@
+export const createCapiResponse = (noOfArticles: number, responseNo = 0) => ({
+  status: "ok",
+  userTier: "developer",
+  total: 2142557,
+  startIndex: 1,
+  pageSize: 10,
+  currentPage: 1,
+  pages: 214256,
+  orderBy: "relevance",
+  results: new Array(noOfArticles)
+    .fill(undefined)
+    .map((_, index) => createCapiArticle(`article-${responseNo}-${index + 1}`)),
+});
+
+export const createCapiArticle = (articleId: string) => ({
+  id: `commentisfree/2020/may/25/${articleId}`,
+  type: "article",
+  sectionId: "commentisfree",
+  sectionName: "Opinion",
+  webPublicationDate: "2020-05-25T17:04:56Z",
+  webTitle: "Kadyrov is a despot, not a strongman | Brief letters",
+  webUrl:
+    "https://www.theguardian.com/commentisfree/2020/may/25/kadyrov-is-a-despot-not-a-strongman",
+  apiUrl:
+    "https://content.guardianapis.com/commentisfree/2020/may/25/kadyrov-is-a-despot-not-a-strongman",
+  fields: {
+    body:
+      '<p>I encourage the Guardian to drop the description “strongman” for despots like Ramzan Kadyrov, the Chechen leader who rules with fear, torture and murder (<a href="https://www.theguardian.com/world/2020/may/21/head-of-chechen-republic-hospitalised-with-suspected-covid-19" title="">Chechen strongman Ramzan Kadyrov ‘hospitalised with suspected Covid-19’</a>, 21 May). It conflates strength and violence. And it denigrates other men. True strength is found in those who courageously oppose Kadyrov.<br><strong>Tim Nichols</strong><br><em>Hackney, London</em></p>',
+  },
+  tags: [],
+  references: [],
+  isHosted: false,
+  pillarId: "pillar/opinion",
+  pillarName: "Opinion",
+});
+
+export const createTyperighterResponse = (noOfMatches = 0) => ({
+  type: "VALIDATOR_RESPONSE",
+  categoryIds: ["regex-validator"],
+  blocks: [
+    {
+      id: "0-from:1-to:427",
+      text: "block-text-placeholder",
+      from: 1,
+      to: 427,
+    },
+  ],
+  matches: new Array(noOfMatches).fill(undefined).map(_ => ({
+    rule: {
+      id: "1181",
+      category: {
+        id: "General Election, 2019",
+        name: "General Election, 2019",
+        colour: "04d514",
+      },
+      description: "Placeholder description",
+      suggestions: [],
+      replacement: { type: "TEXT_SUGGESTION", text: "Placeholder replacement" },
+    },
+    fromPos: 183,
+    toPos: 196,
+    matchedText: "Placeholder matchedText",
+    message: "Placeholder message",
+    shortMessage: "Placeholder shortMessage",
+    suggestions: [],
+    markAsCorrect: true,
+  })),
+});

--- a/rule-audit-client/src/redux/modules/searchMatches/__tests__/thunks.spec.ts
+++ b/rule-audit-client/src/redux/modules/searchMatches/__tests__/thunks.spec.ts
@@ -1,0 +1,205 @@
+import { createStore } from "../../../store";
+import { doSearchMatches } from "../thunks";
+import { ThunkDispatch } from "redux-thunk";
+import AppTypes from "AppTypes";
+import * as selectors from "../selectors";
+import {selectors as capiSelectors } from "../../capiContent"
+import * as actions from "../actions";
+import { createCapiResponse, createTyperighterResponse } from "./fixtures";
+
+const mockCapiService = jest.fn();
+const mockTyperighterService = jest.fn();
+
+const emptyTyperighterResponse = createTyperighterResponse(0);
+const typerighterResponse = createTyperighterResponse(1);
+const capiResponse = createCapiResponse(2);
+const secondCapiResponse = createCapiResponse(2, 2);
+
+const mockResponses = (
+  capiResponses: typeof capiResponse[],
+  typerighterResponses: typeof typerighterResponse[]
+) => {
+  capiResponses.forEach((response) =>
+    mockCapiService.mockReturnValueOnce(Promise.resolve(response))
+  );
+  typerighterResponses.forEach((response) =>
+    mockTyperighterService.mockReturnValueOnce(Promise.resolve(response))
+  );
+};
+
+describe("doSearchMatches", () => {
+  beforeEach(() => {
+    mockCapiService.mockReset();
+    mockTyperighterService.mockReset();
+  });
+
+  it("should ask for articles and their matches, persisting articles that have matches to the state", async () => {
+    const store = createStore();
+    store.dispatch(actions.doSetSearchMatchesLimit(2));
+    mockResponses([capiResponse], [typerighterResponse, typerighterResponse]);
+
+    await (store.dispatch as ThunkDispatch<
+      AppTypes.RootState,
+      {},
+      AppTypes.RootAction
+    >)(
+      doSearchMatches(
+        "query",
+        [],
+        [],
+        mockCapiService,
+        mockTyperighterService
+      )
+    );
+    const state = store.getState();
+
+    // We've called CAPI once, and it's returned two articles.
+    // We then call Typerighter with those articles, and Typerighter
+    // returns matches for both.
+    expect(mockCapiService).toBeCalledTimes(1);
+    expect(mockTyperighterService).toBeCalledTimes(2);
+
+    capiResponse.results.forEach((article) => {
+      const articleInState = capiSelectors.selectById(state, article.id);
+      expect(articleInState).toMatchObject(article);
+    });
+
+    expect(selectors.selectSearchMatchesArticleIds(state, false)).toEqual(
+      capiResponse.results.map(_ => _.id)
+    );
+  });
+  it("should continue to ask for new articles until the given limit is reached", async () => {
+    const store = createStore();
+    store.dispatch(actions.doSetSearchMatchesLimit(2));
+    mockResponses(
+      [capiResponse, secondCapiResponse],
+      [
+        emptyTyperighterResponse,
+        emptyTyperighterResponse,
+        typerighterResponse,
+        typerighterResponse,
+      ]
+    );
+
+    await (store.dispatch as ThunkDispatch<
+      AppTypes.RootState,
+      {},
+      AppTypes.RootAction
+    >)(
+      doSearchMatches(
+        "query",
+        [],
+        [],
+        mockCapiService,
+        mockTyperighterService
+      )
+    );
+    const state = store.getState();
+
+    // We've called CAPI twice, and it's returned four articles.
+    // We then call Typerighter with those articles, and Typerighter
+    // returns matches for the last two articles.
+    expect(mockCapiService).toBeCalledTimes(2);
+    expect(mockTyperighterService).toBeCalledTimes(4);
+
+    capiResponse.results.forEach((article) => {
+      const articleInState = capiSelectors.selectById(state, article.id);
+      expect(articleInState).toMatchObject(article);
+    });
+
+    expect(selectors.selectSearchMatchesArticleIds(state, false)).toEqual(
+      secondCapiResponse.results.map(_ => _.id)
+    );
+  });
+  it("should stop asking for articles if the cancel action is dispatched", async () => {
+    const store = createStore();
+    store.dispatch(actions.doSetSearchMatchesLimit(2));
+
+    mockResponses(
+      [capiResponse],
+      [
+        typerighterResponse,
+        emptyTyperighterResponse
+      ]
+    );
+
+   const thunk = (store.dispatch as ThunkDispatch<
+      AppTypes.RootState,
+      {},
+      AppTypes.RootAction
+    >)(
+      doSearchMatches(
+        "query",
+        [],
+        [],
+        mockCapiService,
+        mockTyperighterService
+      )
+    );
+
+    store.dispatch(actions.doSearchMatchesEnd());
+    await thunk;
+
+    const state = store.getState();
+
+    // We call CAPI, and it's returned two articles.
+    // We then call Typerighter with those articles, and Typerighter
+    // returns matches for one. We call CAPI again, but the user
+    // cancels the search before the second CAPI request is processed,
+    // so nothing else should go to Typerighter.
+    expect(mockCapiService).toBeCalledTimes(1);
+    expect(mockTyperighterService).toBeCalledTimes(2);
+
+    capiResponse.results.forEach((article) => {
+      const articleInState = capiSelectors.selectById(state, article.id);
+      expect(articleInState).toMatchObject(article);
+    });
+
+    expect(selectors.selectSearchMatchesArticleIds(state, false)).toEqual([capiResponse.results[0].id]);
+  });
+
+  it("should not give the user more matches than they asked for", async () => {
+    const store = createStore();
+    store.dispatch(actions.doSetSearchMatchesLimit(2));
+
+    mockResponses(
+      [createCapiResponse(3)],
+      [
+        typerighterResponse,
+        typerighterResponse,
+        typerighterResponse
+      ]
+    );
+
+   await (store.dispatch as ThunkDispatch<
+      AppTypes.RootState,
+      {},
+      AppTypes.RootAction
+    >)(
+      doSearchMatches(
+        "query",
+        [],
+        [],
+        mockCapiService,
+        mockTyperighterService
+      )
+    );
+
+    const state = store.getState();
+
+    // We call CAPI, and it's returned two articles.
+    // We then call Typerighter with those articles, and Typerighter
+    // returns matches for one. We call CAPI again, but the user
+    // cancels the search before the second CAPI request is processed,
+    // so nothing else should go to Typerighter.
+    expect(mockCapiService).toBeCalledTimes(1);
+    expect(mockTyperighterService).toBeCalledTimes(3);
+
+    capiResponse.results.forEach((article) => {
+      const articleInState = capiSelectors.selectById(state, article.id);
+      expect(articleInState).toMatchObject(article);
+    });
+
+    expect(selectors.selectSearchMatchesArticleIds(state, false)).toEqual(capiResponse.results.slice(0, 2).map(_ => _.id));
+  });
+});

--- a/rule-audit-client/src/redux/modules/searchMatches/actions.ts
+++ b/rule-audit-client/src/redux/modules/searchMatches/actions.ts
@@ -1,0 +1,15 @@
+import { createAction } from "typesafe-actions";
+
+export const doSetSearchMatchesLimit = createAction("SET_SEARCH_MATCHES_ARTICLE_LIMIT")<number>();
+
+export const doAppendSearchMatchesArticleIds = createAction("SET_SEARCH_MATCHES_ARTICLE_IDS")<
+  string[]
+>();
+
+export const doSearchMatchesStart = createAction(
+  "SEARCH_MATCHES_ARTICLES_WITH_MATCHES_START"
+)();
+
+export const doSearchMatchesEnd = createAction(
+  "SEARCH_MATCHES_ARTICLES_WITH_MATCHES_END"
+)();

--- a/rule-audit-client/src/redux/modules/searchMatches/index.ts
+++ b/rule-audit-client/src/redux/modules/searchMatches/index.ts
@@ -1,0 +1,4 @@
+export { default as reducer } from "./reducer";
+export * as actions from "./actions";
+export * as selectors from "./selectors";
+export * as thunks from "./thunks";

--- a/rule-audit-client/src/redux/modules/searchMatches/reducer.ts
+++ b/rule-audit-client/src/redux/modules/searchMatches/reducer.ts
@@ -1,0 +1,31 @@
+import { createReducer } from "typesafe-actions";
+import { doSetSearchMatchesLimit, doSearchMatchesStart, doAppendSearchMatchesArticleIds, doSearchMatchesEnd } from "./actions";
+
+const initialState = {
+  searchMatchesLimit: 10,
+  isSearchMatchesInProgress: false,
+  searchMatchesArticleIds: [] as string[]
+};
+
+export type SearchMatchesState = typeof initialState
+
+const reducer = createReducer(initialState)
+  .handleAction(doSetSearchMatchesLimit, (state, action) => ({
+    ...state,
+    searchMatchesLimit: action.payload,
+  }))
+  .handleAction(doSearchMatchesStart, (state) => ({
+    ...state,
+    isSearchMatchesInProgress: true,
+    searchMatchesArticleIds: []
+  }))
+  .handleAction(doAppendSearchMatchesArticleIds, (state, action) => ({
+    ...state,
+    searchMatchesArticleIds: state.searchMatchesArticleIds.concat(action.payload),
+  }))
+  .handleAction(doSearchMatchesEnd, (state) => ({
+    ...state,
+    isSearchMatchesInProgress: false,
+  }));
+
+export default reducer;

--- a/rule-audit-client/src/redux/modules/searchMatches/selectors.ts
+++ b/rule-audit-client/src/redux/modules/searchMatches/selectors.ts
@@ -1,0 +1,44 @@
+import AppTypes from "AppTypes";
+
+import { selectors } from "../capiContent";
+
+export const selectSearchMatchesArticleIds = (
+  state: AppTypes.RootState,
+  selectAll = true
+): string[] =>
+  selectAll
+    ? state.searchMatches.searchMatchesArticleIds
+    : selectSearchMatchesArticleIdsWithMatches(state);
+
+export const selectSearchMatchesArticleIdsWithMatches = (
+  state: AppTypes.RootState
+): string[] =>
+  selectSearchMatchesArticleIds(state).filter(
+    (id) => selectors.selectById(state, id)?.meta.matches.length
+  );
+
+export const selectIsSearchMatchesInProgress = (state: AppTypes.RootState): boolean =>
+  state.searchMatches.isSearchMatchesInProgress;
+
+export const selectSearchMatchesLoadingText = (
+  state: AppTypes.RootState
+): string => {
+  const {
+    searchMatches: { searchMatchesArticleIds },
+  } = state;
+  const idsWithMatches = selectSearchMatchesArticleIdsWithMatches(state);
+
+  if (
+    !searchMatchesArticleIds.length ||
+    !idsWithMatches.length
+  ) {
+    return '';
+  }
+
+  return `${idsWithMatches.length} have matches (${Math.floor(
+    (idsWithMatches.length / searchMatchesArticleIds.length) * 100
+  )})%`;
+};
+
+export const selectSearchMatchesLimit = (state: AppTypes.RootState): number =>
+  state.searchMatches.searchMatchesLimit;

--- a/rule-audit-client/src/redux/modules/searchMatches/thunks.ts
+++ b/rule-audit-client/src/redux/modules/searchMatches/thunks.ts
@@ -1,0 +1,77 @@
+import AppTypes from "AppTypes";
+import { fetchCapiSearch } from "services/capi";
+import { fetchTyperighterMatches } from "services/typerighter";
+import * as selectors from "./selectors";
+import * as actions from "./actions";
+import { notEmpty } from "utils/predicates";
+import { doFetchCapi, doFetchMatches } from "../capiContent/thunks";
+
+export const doSearchMatches = (
+  query: string,
+  tags: string[],
+  sections: string[],
+  fetchCapiSearchService = fetchCapiSearch,
+  fetchTyperighterMatchesService = fetchTyperighterMatches
+): AppTypes.Thunk => async (
+  dispatch: AppTypes.Dispatch,
+  getState: () => AppTypes.RootState
+): Promise<void> => {
+  dispatch(actions.doSearchMatchesStart());
+
+  const loop = async (
+    noOfArticlesToFetch: number,
+    page: number = 1
+  ): Promise<void> => {
+    const articles = await dispatch(
+      doFetchCapi(query, tags, sections, page, fetchCapiSearchService)
+    );
+
+    const incomingArticleIds = (articles || []).map((_) => _.id);
+
+    const articlesWithMatchData = await dispatch(
+      doFetchMatches(
+        articles.map((_) => _.id),
+        fetchTyperighterMatchesService
+      )
+    );
+
+    const articleIdsWithMatches = articlesWithMatchData
+      .filter(notEmpty)
+      .filter((_) => _.meta.matches.length)
+      .map((_) => _.id);
+
+    const noOfArticlesToFetchRemaining =
+      noOfArticlesToFetch - articleIdsWithMatches.length;
+
+    // If we have more articles with matches than the user has asked for, discard the remainder
+    const lastMatchId =
+      noOfArticlesToFetchRemaining < 0
+        ? articleIdsWithMatches[
+            articleIdsWithMatches.length + noOfArticlesToFetchRemaining
+          ]
+        : undefined;
+    const lastValidIndex = lastMatchId
+      ? incomingArticleIds.indexOf(lastMatchId)
+      : undefined;
+    const articleIdsToAdd = incomingArticleIds.slice(0, lastValidIndex);
+
+    dispatch(actions.doAppendSearchMatchesArticleIds(articleIdsToAdd));
+
+    if (
+      noOfArticlesToFetchRemaining > 0 &&
+      // Do not continue if the user has stopped the search operation
+      selectors.selectIsSearchMatchesInProgress(getState())
+    ) {
+      await loop(noOfArticlesToFetchRemaining, page + 1);
+    } else {
+      dispatch(actions.doSearchMatchesEnd());
+    }
+  };
+
+  try {
+    const searchMatchesLimit = selectors.selectSearchMatchesLimit(getState());
+    await loop(searchMatchesLimit);
+  } catch (e) {
+    dispatch(actions.doSearchMatchesEnd());
+  }
+};

--- a/rule-audit-client/src/redux/store/index.ts
+++ b/rule-audit-client/src/redux/store/index.ts
@@ -1,16 +1,21 @@
-import { createStore, applyMiddleware, compose } from "redux";
+import {
+  createStore as _createStore,
+  applyMiddleware,
+  compose,
+  CombinedState,
+} from "redux";
 import thunk from "redux-thunk";
 
 import rootReducer from "./rootReducer";
 
 const initialState = {};
 
-const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+const composeEnhancers =
+  (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
-const store = createStore(
-  rootReducer,
-  initialState,
-  composeEnhancers(applyMiddleware(thunk))
-);
-
-export default store;
+export const createStore = () =>
+  _createStore(
+    rootReducer,
+    initialState,
+    composeEnhancers(applyMiddleware(thunk))
+  );

--- a/rule-audit-client/src/redux/store/rootAction.ts
+++ b/rule-audit-client/src/redux/store/rootAction.ts
@@ -1,7 +1,9 @@
 import { actions as capiActions } from "../modules/capiContent";
 import { actions as uiActions } from "../modules/ui";
+import { actions as searchMatchesActions } from "../modules/searchMatches";
 
 export default {
     capi: capiActions,
-    ui: uiActions
+    ui: uiActions,
+    searchMatches: searchMatchesActions
 }

--- a/rule-audit-client/src/redux/store/rootReducer.ts
+++ b/rule-audit-client/src/redux/store/rootReducer.ts
@@ -1,9 +1,11 @@
 import { combineReducers } from "redux";
 
-import { reducer as capiReducer } from "../modules/capiContent";
-import { reducer as uiReducer } from "../modules/ui";
+import { reducer as capi } from "../modules/capiContent";
+import { reducer as ui } from "../modules/ui";
+import { reducer as searchMatches } from "../modules/searchMatches";
 
 export default combineReducers({
-  capi: capiReducer,
-  ui: uiReducer,
+  capi,
+  ui,
+  searchMatches
 });

--- a/rule-audit-client/src/redux/store/types.d.ts
+++ b/rule-audit-client/src/redux/store/types.d.ts
@@ -1,12 +1,20 @@
-import { StateType, ActionType } from "typesafe-actions";
-import store from "./index";
+import { StateType, ActionType, Action } from "typesafe-actions";
+import { createStore } from "./index";
 import rootAction from "./rootAction";
 import rootReducer from "./rootReducer";
+import { ThunkAction, ThunkDispatch } from "redux-thunk";
 
 declare module "AppTypes" {
-  export type Store = StateType<typeof store>;
+  export type Store = StateType<ReturnType<typeof createStore>>;
   export type RootAction = ActionType<typeof rootAction>;
-  export type RootState = StateType<ReturnType<typeof rootReducer>>;
+  export type RootState = ReturnType<typeof rootReducer>;
+  export type Thunk<ReturnType = void> = ThunkAction<
+    ReturnType,
+    RootState,
+    unknown,
+    Action<string>
+  >;
+  export type Dispatch = ThunkDispatch<RootState, {}, RootAction>;
 }
 
 declare module "typesafe-actions" {


### PR DESCRIPTION
~Greetings, gentle reader! Please review #51 first – this PR depends upon it.~ This is now ready for review.

## What does this change?

This PR adds a 'search for matches' function. This function runs a CAPI search, finds Typerighter results for it, and repeats, until n articles with matches have been found. N is specified by the user.

It doesn't expose this functionality in the UI yet – a previous PR includes this but is very large and thus harder to review.

## Why will this eventually be useful?
At the moment, it's easy to answer the question, 'what results does Typerighter give for the results of this particular CAPI search'. But it's difficult to answer the question, 'how does Typerighter perform for this CAPI search more generally'?

By searching for articles with matches, and not just articles, we can get a better idea of how rules will be applied across the corpus more generally – both by finding lots of articles with matches, and also by giving us an idea of how often these matches will apply, to spot e.g. noisy rules.

## How can we measure success?

The tests pass, and describe the behaviour we expect for the function.