### PR TITLE
Update readme and add expired token message to start script

### DIFF
--- a/docs/01-running-locally.md
+++ b/docs/01-running-locally.md
@@ -1,6 +1,6 @@
 # Basic developer run
 
-`./script/start` and visit `localhost:9000` to confirm the service came up correctly.
+Get credentials for Composer profile then run `./script/start` and visit `localhost:9000` to confirm the service came up correctly.
 
 To attach an interactive debugger, run `./script/start --debug` to expose port 5005 for debugging.
 
@@ -47,4 +47,3 @@ EOF
 ```
 
 Assuming you are running a CODE environment, the response should indicate that the word 'Grauniad' is misspelled.
-

--- a/script/start
+++ b/script/start
@@ -1,5 +1,16 @@
 #!/bin/bash -e
 
+
+STATUS=$(aws sts get-caller-identity --profile composer 2>&1 || true)
+if [[ ${STATUS} =~ (ExpiredToken) ]]; then
+  echo -e "${red}Credentials for the composer profile are expired. Please fetch new credentials and run this again.${plain}"
+  exit 1
+elif [[ ${STATUS} =~ ("could not be found") ]]; then
+  echo -e "${red}Credentials for the composer profile are missing. Please ensure you have the right credentials.${plain}"
+  exit 1
+fi
+
+
 IS_DEBUG=false
 for arg in "$@"
 do


### PR DESCRIPTION
Co-authored-by: Sam Hession <sam.hession@guardian.co.uk>

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR updates the running locally readme to indicate that the user needs to get Composer credentials.
The `start` script has been updated to include a message if the credentials have expired.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run `./script/start` without, or with expired, Composer credentials and you should see a message in the terminal.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![image](https://user-images.githubusercontent.com/15648334/88411744-60413800-cdd0-11ea-9c88-6ae81bf4fbfc.png)
