### PR TITLE
Improve Typerighter rules page

### DIFF
--- a/app/controllers/RulesController.scala
+++ b/app/controllers/RulesController.scala
@@ -15,6 +15,10 @@ import scala.concurrent.ExecutionContext
 class RulesController(cc: ControllerComponents, matcherPool: MatcherPool, ruleResource: SheetsRuleResource, sheetId: String, val publicSettings: PublicSettings)(implicit ec: ExecutionContext)
   extends AbstractController(cc) with PandaAuthentication {
   def refresh = ApiAuthAction.async { implicit request: Request[AnyContent] =>
+
+    // This reset will need to be revisited when we're ingesting from multiple matchers.
+    matcherPool.removeAllMatchers()
+
     for {
       (rulesByCategory, ruleErrors) <- ruleResource.fetchRulesByCategory()
       errorsByCategory = addMatcherToPool(rulesByCategory)

--- a/app/services/MatcherPool.scala
+++ b/app/services/MatcherPool.scala
@@ -80,7 +80,6 @@ class MatcherPool(val maxCurrentJobs: Int = 8, val maxQueuedJobs: Int = 1000, va
       case Some(ids) => ids
     }
 
-
     logger.info(s"Matcher pool query received")(query.toMarker)
 
     val jobs = createJobsFromPartialJobs(query.requestId, query.documentId.getOrElse("no-document-id"),  checkStrategy(query.blocks, categoryIds))
@@ -110,6 +109,18 @@ class MatcherPool(val maxCurrentJobs: Int = 8, val maxQueuedJobs: Int = 1000, va
   def addMatcher(category: Category, matcher: Matcher): Option[(Category, Matcher)] = {
     logger.info(s"New instance of matcher available of id: ${matcher.getId} for category: ${category.id}")
     matchers.put(category.id, (category, matcher))
+  }
+
+  /**
+    * Remove a matcher from the pool by its category id.
+    * Returns the removed category and matcher.
+    */
+  def removeMatcherByCategory(categoryId: String): Option[(Category, Matcher)] = {
+    matchers.remove(categoryId)
+  }
+
+  def removeAllMatchers(): Unit = {
+    matchers.map(_._1).foreach(removeMatcherByCategory)
   }
 
   def getCurrentCategories: List[(String, Category)] = {

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -115,6 +115,20 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     pool.getCurrentCategories should be(List(("mock-matcher-0", getCategory(0))))
   }
 
+  "removeMatcherByCategory" should "remove a matcher by its category id" in {
+    val matchers = getMatchers(2)
+    val pool = getPool(matchers)
+    pool.removeMatcherByCategory(matchers(1).getCategory())
+    pool.getCurrentCategories should be(List(("mock-matcher-0", getCategory(0))))
+  }
+
+  "removeMatcherByCategory" should "remove all matchers" in {
+    val matchers = getMatchers(2)
+    val pool = getPool(matchers)
+    pool.removeAllMatchers
+    pool.getCurrentCategories should be(List.empty)
+  }
+
   "check" should "return a list of MatcherResponses" in {
     val matchers = getMatchers(1)
     val pool = getPool(matchers)


### PR DESCRIPTION
## What does this change?
Adds more information to the rules dash, to note rule counts against categories, add more information about rules, and be slightly more concise.

Before:

<img width="1177" alt="Screenshot 2020-08-05 at 13 32 08" src="https://user-images.githubusercontent.com/7767575/89413414-b68f6e80-d720-11ea-9215-548c743e5c2c.png">

After:

<img width="1177" alt="Screenshot 2020-08-05 at 13 31 31" src="https://user-images.githubusercontent.com/7767575/89413436-bc854f80-d720-11ea-845d-6d4156b419b1.png">

## How to test

Deploy to CODE. The dash at the /rules endpoint should look as described.
