### PR TITLE
Add match context

### DIFF
--- a/app/matchers/RegexMatcher.scala
+++ b/app/matchers/RegexMatcher.scala
@@ -23,17 +23,7 @@ class RegexMatcher(category: String, rules: List[RegexRule]) extends Matcher {
 
   private def checkRule(request: MatcherRequest, rule: RegexRule): List[RuleMatch] = {
     request.blocks.flatMap { block =>
-        rule.regex.findAllMatchIn(block.text).map { currentMatch => RuleMatch(
-          rule = rule,
-          fromPos = currentMatch.start + block.from,
-          toPos = currentMatch.end + block.from,
-          matchedText = block.text.substring(currentMatch.start, currentMatch.end),
-          message = rule.description,
-          shortMessage = Some(rule.description),
-          suggestions = rule.suggestions,
-          markAsCorrect = rule.replacement.map(_.text).getOrElse("") == block.text.substring(currentMatch.start, currentMatch.end)
-        )
-      }
+        rule.regex.findAllMatchIn(block.text).map { currentMatch => RuleMatch.fromMatch(currentMatch.start, currentMatch.end, block, rule) }
     }
   }
 }

--- a/test/scala/matchers/RegexMatcherTest.scala
+++ b/test/scala/matchers/RegexMatcherTest.scala
@@ -16,23 +16,63 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
 
   def getBlocks(text: String) = List(TextBlock("text-block-id", text, 0, text.length))
 
-  def getMatch(text: String, fromPos: Int, toPos: Int) = RuleMatch(
+  def getMatch(text: String, fromPos: Int, toPos: Int, matchText: String) = RuleMatch(
     rule = exampleRule,
     fromPos = fromPos,
     toPos = toPos,
     matchedText = text,
     message = "An example rule",
     shortMessage = Some("An example rule"),
-    suggestions = List(TextSuggestion("other text"))
+    suggestions = List(TextSuggestion("other text")),
+    matchContext = matchText
   )
 
-  "check" should "report single matches" in {
+
+  "check" should "report single matches in short text" in {
+    val sampleText = "example text is here"
+    val matchText = "example [text] is here"
+
     val eventuallyMatches = regexValidator.check(
-      MatcherRequest(getBlocks("example text"), "example-category")
+      MatcherRequest(getBlocks(sampleText), "example-category")
     )
     eventuallyMatches.map { matches =>
       matches shouldEqual List(
-        getMatch("text", 8, 12)
+        getMatch("text", 8, 12, matchText)
+      )
+    }
+  }
+
+  "check" should "report single matches in long text" in {
+    val sampleText = """
+                       | 123456789 123456789 123456789
+                       | 123456789 123456789 123456789
+                       | 123456789 123456789 123456789
+                       | 123456789 123456789 123456789
+                       | text
+                       | 123456789 123456789 123456789
+                       | 123456789 123456789 123456789
+                       | 123456789 123456789 123456789
+                       | 123456789 123456789 123456789
+                       |""".stripMargin.replace("\n", "")
+
+    val matchText = """
+                       |123456789
+                       | 123456789 123456789 123456789
+                       | 123456789 123456789 123456789
+                       | 123456789 123456789 123456789
+                       | [text]
+                       | 123456789 123456789 123456789
+                       | 123456789 123456789 123456789
+                       | 123456789 123456789 123456789
+                       | 123456789
+                       |""".stripMargin.replace("\n", "")
+
+    val eventuallyMatches = regexValidator.check(
+      MatcherRequest(getBlocks(sampleText), "example-category")
+    )
+    eventuallyMatches.map { matches =>
+      matches shouldEqual List(
+        getMatch("text", 121, 125, matchText)
       )
     }
   }
@@ -43,9 +83,9 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     )
     eventuallyMatches.map { matches =>
       matches shouldEqual List(
-        getMatch("text", 0, 4),
-        getMatch("text", 5, 9),
-        getMatch("text", 10, 14)
+        getMatch("text", 0, 4, "[text] text text"),
+        getMatch("text", 5, 9, "text [text] text"),
+        getMatch("text", 10, 14, "text text [text]")
       )
     }
   }

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -95,7 +95,8 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
           fromPos = from,
           toPos = to,
           matchedText = "placeholder text",
-          message = message
+          message = message,
+          matchContext = "[placeholder text]"
         )
     }
   }


### PR DESCRIPTION
## What does this change?
Adds the match context (ie surrounding text  at time of matching) to the model returned to the prosemirror plugin.

## How to test
Install on local compower and run local typerighter.  This has been done successfully.

See also: https://github.com/guardian/prosemirror-typerighter/pull/80

## How can we measure success?
Prosemirror plugin has matchContext and passes it in  to the feedback form.

## Have we considered potential risks?
None.

## Images
None.