### PR TITLE
Alter dash to include rule counts and more rule data

### DIFF
--- a/app/services/MatcherPool.scala
+++ b/app/services/MatcherPool.scala
@@ -76,7 +76,7 @@ class MatcherPool(val maxCurrentJobs: Int = 8, val maxQueuedJobs: Int = 1000, va
     */
   def check(query: Check): Future[List[RuleMatch]] = {
     val categoryIds = query.categoryIds match {
-      case None => getCurrentCategories.map { case (_, category) => category.id }
+      case None => getCurrentCategories.map { case (_, category, _) => category.id }
       case Some(ids) => ids
     }
 
@@ -123,9 +123,9 @@ class MatcherPool(val maxCurrentJobs: Int = 8, val maxQueuedJobs: Int = 1000, va
     matchers.map(_._1).foreach(removeMatcherByCategory)
   }
 
-  def getCurrentCategories: List[(String, Category)] = {
+  def getCurrentCategories: List[(String, Category, Int)] = {
     val matchersAndCategories = matchers.values.map {
-      case (category, matcher) => (matcher.getId, category)
+      case (category, matcher) => (matcher.getId, category, matcher.getRules.length)
     }.toList
     matchersAndCategories
   }

--- a/app/views/rules.scala.html
+++ b/app/views/rules.scala.html
@@ -1,8 +1,9 @@
 @import model.BaseRule
+@import model.RegexRule
 @import model.Category
 @import helper._
 
-@(sheetId: String, rules: scala.List[BaseRule], categories: scala.List[(String, Category)], rulesIngested: Option[Int] = None, errors: List[String] = List.empty)(implicit req: RequestHeader)
+@(sheetId: String, rules: scala.List[BaseRule], categories: scala.List[(String, Category, Int)], rulesIngested: Option[Int] = None, errors: List[String] = List.empty)(implicit req: RequestHeader)
 @main(title = "Typerighter", breadcrumbsList = List("Rules")) {
     @form(CSRF(routes.RulesController.refresh())) {
         @CSRF.formField
@@ -26,23 +27,23 @@
                 <thead>
                     <tr>
                         <th scope="col">Id</th>
-                        <th scope="col">Colour</th>
                         <th scope="col">Name</th>
                         <th scope="col">Handler</th>
+                        <th scope="col">Rule count</th>
                     </tr>
                 </thead>
                 <tbody>
-                @for((handler, category) <- categories) {
+                @for((handler, category, ruleCount) <- categories) {
                     <tr>
-                        <td>@category.name</td>
                         <td>
-                            <span class="badge" style="background-color: #@category.colour;
-                                color: white">
-                                #@category.colour
-                            </span>
+                          <span class="badge" style="background-color: #@category.colour; color: white">
+                              &nbsp;
+                          </span>
+                          @category.id
                         </td>
                         <td>@category.name</td>
                         <td>@handler</td>
+                        <td>@ruleCount</td>
                     </tr>
                 }
                 </tbody>
@@ -54,22 +55,29 @@
                 <thead>
                     <tr>
                         <th scope="col">Category</th>
-                        <th scope="col">Colour</th>
+                        <th scope="col">Match</th>
+                        <th scope="col">Replacement</th>
                         <th scope="col">Description</th>
                     </tr>
                 </thead>
                 <tbody>
                 @for(rule <- rules) {
                     <tr>
-                        <td>@rule.category.name</td>
                         <td>
-                            <span class="badge" style="background-color: #@rule.category.colour; color: white">
-                                #@rule.category.colour
-                            </span>
+                          @rule.category.name
                         </td>
+                        <td>@rule match {
+                          case r: RegexRule => {
+                            @r.regex.toString.slice(0, 30)
+                          }
+                          case _ => { None }
+                        }</td>
+                        <td>@if(rule.replacement.nonEmpty) {
+                            @rule.replacement.get.text
+                        } else { None }</td>
                         <td>@if(rule.description.nonEmpty) {
                             @rule.description
-                        } else { No&nbsp;description }</td>
+                        } else { None }</td>
                     </tr>
                 }
                 </tbody>

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -112,14 +112,14 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
   "getCurrentCategories" should "report current categories" in {
     val matchers = getMatchers(1)
     val pool = getPool(matchers)
-    pool.getCurrentCategories should be(List(("mock-matcher-0", getCategory(0))))
+    pool.getCurrentCategories should be(List(("mock-matcher-0", getCategory(0), 0)))
   }
 
   "removeMatcherByCategory" should "remove a matcher by its category id" in {
     val matchers = getMatchers(2)
     val pool = getPool(matchers)
     pool.removeMatcherByCategory(matchers(1).getCategory())
-    pool.getCurrentCategories should be(List(("mock-matcher-0", getCategory(0))))
+    pool.getCurrentCategories should be(List(("mock-matcher-0", getCategory(0), 0)))
   }
 
   "removeMatcherByCategory" should "remove all matchers" in {


### PR DESCRIPTION
NB: As with #58, but including the crucial commit! 🤦 

## What does this change?
Adds more information to the rules dash, to note rule counts against categories, add more information about rules, and be slightly more concise.

Before:

<img width="1177" alt="Screenshot 2020-08-05 at 13 32 08" src="https://user-images.githubusercontent.com/7767575/89413414-b68f6e80-d720-11ea-9215-548c743e5c2c.png">

After:

<img width="1177" alt="Screenshot 2020-08-05 at 13 31 31" src="https://user-images.githubusercontent.com/7767575/89413436-bc854f80-d720-11ea-845d-6d4156b419b1.png">

## How to test

Deploy to CODE. The dash at the /rules endpoint should look as described.
