### PR TITLE
Removes overlapping rules by category

### DIFF
--- a/app/matchers/RegexMatcher.scala
+++ b/app/matchers/RegexMatcher.scala
@@ -2,7 +2,8 @@ package matchers
 
 import model.{RegexRule, RuleMatch}
 import services.MatcherRequest
-import utils.Matcher
+import utils.{Matcher, RuleMatchHelpers}
+
 
 import scala.concurrent.Future
 
@@ -16,7 +17,7 @@ class RegexMatcher(category: String, rules: List[RegexRule]) extends Matcher {
   override def check(request: MatcherRequest): Future[List[RuleMatch]] = {
     val matches = rules.foldLeft(List.empty[RuleMatch])((acc, rule) => {
       val matches = checkRule(request, rule)
-      removeOverlappingRules(acc, matches) ++ matches
+      RuleMatchHelpers.removeOverlappingRules(acc, matches) ++ matches
     })
     Future.successful(matches)
   }
@@ -31,11 +32,5 @@ class RegexMatcher(category: String, rules: List[RegexRule]) extends Matcher {
     }
   }
 
-  private def removeOverlappingRules(currentMatches: List[RuleMatch], incomingMatches: List[RuleMatch]): List[RuleMatch] =
-    currentMatches.filter { currentMatch =>
-      incomingMatches.forall { incomingMatch =>
-        currentMatch.fromPos < incomingMatch.fromPos && currentMatch.toPos < incomingMatch.fromPos ||
-        currentMatch.fromPos > incomingMatch.toPos
-      }
-    }
+
 }

--- a/app/utils/RuleMatchHelpers.scala
+++ b/app/utils/RuleMatchHelpers.scala
@@ -1,0 +1,13 @@
+package utils
+
+import model.RuleMatch
+
+object RuleMatchHelpers {
+  def removeOverlappingRules(currentMatches: List[RuleMatch], incomingMatches: List[RuleMatch]): List[RuleMatch] =
+    currentMatches.filter { currentMatch =>
+      incomingMatches.forall { incomingMatch =>
+        currentMatch.fromPos < incomingMatch.fromPos && currentMatch.toPos < incomingMatch.fromPos ||
+          currentMatch.fromPos > incomingMatch.toPos
+      }
+    }
+}

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -192,6 +192,20 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     }
   }
 
+  "check" should "correctly check multiple categories for a single job don't overlap" in {
+    val matchers = getMatchers(2)
+    val pool = getPool(matchers, 4, 100, MatcherPool.blockLevelCheckStrategy)
+    val futureResult = pool.check(getCheck(text = "Example text"))
+    val firstMatch = getResponses(List((0, 5, "test-response")))
+    val secondMatch = getResponses(List((0, 5, "test-response-2")))
+    matchers(0).markAsComplete(firstMatch)
+    matchers(1).markAsComplete(secondMatch)
+    futureResult.map { result =>
+      result.size should matchTo(1)
+      result should matchTo(secondMatch)
+    }
+  }
+
    "check" should "handle requests for categories that do not exist" in {
     val matchers = getMatchers(2)
     val pool = getPool(matchers)


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR builds on the work completed in #61 to remove overlapping rules from results. It goes on to remove overlapping results at a category and matcher level, rather than just a matcher level. This will prevent rules from overlapping between categories but stops short of preventing overlapping rules at a request level.

The order of the priority for the rules is arbitrarily set to be the category id, this ensures the same match is consistently returned. However, ideally a priority would be specified against a category / state (correct, ambiguous, unambiguous). 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Enter a word which has matches against multiple categories such as "Midwest", observe one result is returned consistently.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users no longer experience issues with rules being highlighted with overlapping matches.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
This bug was initially observed on the Typerighter client demo, highlighting the word midwest under two different categories:
![TyperighterBugII](https://user-images.githubusercontent.com/4633246/90155558-61d49f00-dd83-11ea-9216-1e0babb2db87.gif)
