### PR TITLE
Add 'ignore' option to the rules sheet

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -43,8 +43,7 @@ class AppComponents(context: Context, identity: AppIdentity, creds: AWSCredentia
 
   val credentials = configuration.get[String]("typerighter.google.credentials")
   val spreadsheetId = configuration.get[String]("typerighter.sheetId")
-  val range = configuration.get[String]("typerighter.sheetRange")
-  val ruleResource = new SheetsRuleResource(credentials, spreadsheetId, range)
+  val ruleResource = new SheetsRuleResource(credentials, spreadsheetId)
 
   val capiApiKey = configuration.get[String]("capi.apiKey")
   val guardianContentClient = GuardianContentClient(capiApiKey)


### PR DESCRIPTION
## What does this change?

It'd be nice to be able to deactivate rules on a case by case basis without having to remove them from the active sheet.

This PR reads the ninth row of the rules sheet as 'ignore', and doesn't load the rule if that cell reads 'TRUE'.

## How to test

Run this branch in CODE. None of the rules in the CODE sheet with TRUE ignore cells should appear in the rules endpoint `/rules`.

## How can we measure success?

It's easy to disable troublesome rules at short notice.