### PR TITLE
Apply replacement groups in regex replacements

### DIFF
--- a/app/matchers/RegexMatcher.scala
+++ b/app/matchers/RegexMatcher.scala
@@ -28,9 +28,14 @@ class RegexMatcher(category: String, rules: List[RegexRule]) extends Matcher {
 
   private def checkRule(request: MatcherRequest, rule: RegexRule): List[RuleMatch] = {
     request.blocks.flatMap { block =>
-        rule.regex.findAllMatchIn(block.text).map { currentMatch => RuleMatch.fromMatch(currentMatch.start, currentMatch.end, block, rule) }
+        rule.regex.findAllMatchIn(block.text).map { currentMatch =>
+          println(currentMatch)
+          RuleMatch.fromRegex(
+            currentMatch.start,
+            currentMatch.end,
+            block,
+            rule
+          ) }
     }
   }
-
-
 }

--- a/app/matchers/RegexMatcher.scala
+++ b/app/matchers/RegexMatcher.scala
@@ -29,12 +29,10 @@ class RegexMatcher(category: String, rules: List[RegexRule]) extends Matcher {
   private def checkRule(request: MatcherRequest, rule: RegexRule): List[RuleMatch] = {
     request.blocks.flatMap { block =>
         rule.regex.findAllMatchIn(block.text).map { currentMatch =>
-          println(currentMatch)
-          RuleMatch.fromRegex(
+          rule.toMatch(
             currentMatch.start,
             currentMatch.end,
-            block,
-            rule
+            block
           ) }
     }
   }

--- a/app/model/BaseRule.scala
+++ b/app/model/BaseRule.scala
@@ -6,11 +6,32 @@ import play.api.libs.json.{JsObject, Json}
   * A rule to match text against.
   */
 trait BaseRule {
+  val surroundingBuffer = 100
+
+  def surroundingText(text: String, from: Int, to: Int, buffer: Int = 0) = {
+
+    val textBefore = text.substring(scala.math.max(from - buffer, 0), scala.math.max(from, 0))
+    val textMatch = text.substring(from, to)
+    val textAfter = text.substring(scala.math.min(to, text.length), scala.math.min(to + buffer, text.length))
+
+    textBefore + "[" + textMatch + "]" + textAfter
+
+  }
+
   val id: String
   val category: Category
   val description: String
   val suggestions: List[Suggestion]
   val replacement: Option[TextSuggestion]
+
+  /**
+   * Given a block and a match, translate this rule into a RuleMatch.
+   *
+   * @param {Int} the from position
+   * @param {Int} the to position
+   * @param {TextBlock} the Textblock this rule is matching
+   */
+  def toMatch: (Int, Int, TextBlock) => RuleMatch
 }
 
 object BaseRule {

--- a/app/model/BaseRule.scala
+++ b/app/model/BaseRule.scala
@@ -6,32 +6,11 @@ import play.api.libs.json.{JsObject, Json}
   * A rule to match text against.
   */
 trait BaseRule {
-  val surroundingBuffer = 100
-
-  def surroundingText(text: String, from: Int, to: Int, buffer: Int = 0) = {
-
-    val textBefore = text.substring(scala.math.max(from - buffer, 0), scala.math.max(from, 0))
-    val textMatch = text.substring(from, to)
-    val textAfter = text.substring(scala.math.min(to, text.length), scala.math.min(to + buffer, text.length))
-
-    textBefore + "[" + textMatch + "]" + textAfter
-
-  }
-
   val id: String
   val category: Category
   val description: String
   val suggestions: List[Suggestion]
   val replacement: Option[TextSuggestion]
-
-  /**
-   * Given a block and a match, translate this rule into a RuleMatch.
-   *
-   * @param {Int} the from position
-   * @param {Int} the to position
-   * @param {TextBlock} the Textblock this rule is matching
-   */
-  def toMatch: (Int, Int, TextBlock) => RuleMatch
 }
 
 object BaseRule {

--- a/app/model/RegexRule.scala
+++ b/app/model/RegexRule.scala
@@ -3,6 +3,7 @@ package model
 import play.api.libs.json.{JsString, Json, Writes}
 
 import scala.util.matching.Regex
+import utils.Text
 
 object RegexRule {
   implicit val regexWrites: Writes[Regex] = (regex: Regex) => JsString(regex.toString)
@@ -30,7 +31,7 @@ case class RegexRule(
       suggestions = suggestions,
       replacement = replacement.map(replacement => regex.replaceAllIn(matchedText, replacement.text)),
       markAsCorrect = replacement.map(_.text).getOrElse("") == block.text.substring(start, end),
-      matchContext = surroundingText(block.text, start, end, surroundingBuffer)
+      matchContext = Text.getSurroundingText(block.text, start, end)
     )
   }
 }

--- a/app/model/RegexRule.scala
+++ b/app/model/RegexRule.scala
@@ -16,4 +16,21 @@ case class RegexRule(
     suggestions: List[TextSuggestion] = List.empty,
     replacement: Option[TextSuggestion] = None,
     regex: Regex
-) extends BaseRule
+) extends BaseRule {
+
+  def toMatch(start: Int, end: Int, block: TextBlock): RuleMatch = {
+    val matchedText = block.text.substring(start, end)
+    RuleMatch(
+      rule = this,
+      fromPos = start + block.from,
+      toPos = end + block.from,
+      matchedText = matchedText,
+      message = description,
+      shortMessage = Some(description),
+      suggestions = suggestions,
+      replacement = replacement.map(replacement => regex.replaceAllIn(matchedText, replacement.text)),
+      markAsCorrect = replacement.map(_.text).getOrElse("") == block.text.substring(start, end),
+      matchContext = surroundingText(block.text, start, end, surroundingBuffer)
+    )
+  }
+}

--- a/app/model/RuleMatch.scala
+++ b/app/model/RuleMatch.scala
@@ -33,18 +33,21 @@ object RuleMatch {
       matchContext = surroundingText(block.text, lt.getFromPos, lt.getToPos, surroundingBuffer)
     )
 
-  def fromMatch(start: Int, end: Int, block: TextBlock, rule: BaseRule): RuleMatch =
+  def fromRegex(start: Int, end: Int, block: TextBlock, rule: RegexRule): RuleMatch = {
+    val matchedText = block.text.substring(start, end)
     RuleMatch(
       rule = rule,
       fromPos = start + block.from,
       toPos = end + block.from,
-      matchedText = block.text.substring(start, end),
+      matchedText = matchedText,
       message = rule.description,
       shortMessage = Some(rule.description),
       suggestions = rule.suggestions,
+      replacement = rule.replacement.map(replacement => rule.regex.replaceAllIn(matchedText, replacement.text)),
       markAsCorrect = rule.replacement.map(_.text).getOrElse("") == block.text.substring(start, end),
       matchContext = surroundingText(block.text, start, end, surroundingBuffer)
     )
+  }
 
 
   implicit val writes: Writes[RuleMatch] = Writes[RuleMatch]((ruleMatch: RuleMatch) => Json.obj(
@@ -68,6 +71,7 @@ case class RuleMatch(rule: BaseRule,
                      message: String,
                      shortMessage: Option[String] = None,
                      suggestions: List[Suggestion] = List.empty,
+                     replacement: Option[String] = None,
                      markAsCorrect: Boolean = false,
                      matchContext: String)
 

--- a/app/model/RuleMatch.scala
+++ b/app/model/RuleMatch.scala
@@ -7,19 +7,6 @@ import scala.collection.JavaConverters._
 import scala.util.matching.Regex
 
 object RuleMatch {
-
-  val surroundingBuffer = 100
-
-  def surroundingText(text: String, from: Int, to: Int, buffer: Int = 0) = {
-
-    val textBefore = text.substring(scala.math.max(from - buffer, 0), scala.math.max(from, 0))
-    val textMatch = text.substring(from, to)
-    val textAfter = text.substring(scala.math.min(to, text.length), scala.math.min(to + buffer, text.length))
-
-    textBefore + "[" + textMatch + "]" + textAfter
-
-  }
-
   def fromLT(lt: LTRuleMatch, block: TextBlock): RuleMatch = RuleMatch(
       rule = LTRule.fromLT(lt.getRule),
       fromPos = lt.getFromPos,
@@ -33,23 +20,6 @@ object RuleMatch {
       matchContext = surroundingText(block.text, lt.getFromPos, lt.getToPos, surroundingBuffer)
     )
 
-  def fromRegex(start: Int, end: Int, block: TextBlock, rule: RegexRule): RuleMatch = {
-    val matchedText = block.text.substring(start, end)
-    RuleMatch(
-      rule = rule,
-      fromPos = start + block.from,
-      toPos = end + block.from,
-      matchedText = matchedText,
-      message = rule.description,
-      shortMessage = Some(rule.description),
-      suggestions = rule.suggestions,
-      replacement = rule.replacement.map(replacement => rule.regex.replaceAllIn(matchedText, replacement.text)),
-      markAsCorrect = rule.replacement.map(_.text).getOrElse("") == block.text.substring(start, end),
-      matchContext = surroundingText(block.text, start, end, surroundingBuffer)
-    )
-  }
-
-
   implicit val writes: Writes[RuleMatch] = Writes[RuleMatch]((ruleMatch: RuleMatch) => Json.obj(
     "rule" -> BaseRule.toJson(ruleMatch.rule),
     "fromPos" -> ruleMatch.fromPos,
@@ -61,7 +31,6 @@ object RuleMatch {
     "markAsCorrect" -> ruleMatch.markAsCorrect,
     "matchContext" -> ruleMatch.matchContext
   ))
-
 }
 
 case class RuleMatch(rule: BaseRule,

--- a/app/model/RuleMatch.scala
+++ b/app/model/RuleMatch.scala
@@ -6,6 +6,8 @@ import play.api.libs.json.{Json, Writes}
 import scala.collection.JavaConverters._
 import scala.util.matching.Regex
 
+import utils.Text
+
 object RuleMatch {
   def fromLT(lt: LTRuleMatch, block: TextBlock): RuleMatch = RuleMatch(
       rule = LTRule.fromLT(lt.getRule),
@@ -17,7 +19,7 @@ object RuleMatch {
       suggestions = lt.getSuggestedReplacements.asScala.toList.map {
         TextSuggestion(_)
       },
-      matchContext = surroundingText(block.text, lt.getFromPos, lt.getToPos, surroundingBuffer)
+      matchContext = Text.getSurroundingText(block.text, lt.getFromPos, lt.getToPos)
     )
 
   implicit val writes: Writes[RuleMatch] = Writes[RuleMatch]((ruleMatch: RuleMatch) => Json.obj(

--- a/app/utils/Text.scala
+++ b/app/utils/Text.scala
@@ -1,0 +1,12 @@
+package utils
+
+object Text {
+  def getSurroundingText(text: String, from: Int, to: Int, buffer: Int = 100) = {
+
+    val textBefore = text.substring(scala.math.max(from - buffer, 0), scala.math.max(from, 0))
+    val textMatch = text.substring(from, to)
+    val textAfter = text.substring(scala.math.min(to, text.length), scala.math.min(to + buffer, text.length))
+
+    textBefore + "[" + textMatch + "]" + textAfter
+  }
+}

--- a/test/scala/matchers/RegexMatcherTest.scala
+++ b/test/scala/matchers/RegexMatcherTest.scala
@@ -135,4 +135,26 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
       matches(0) should matchTo(expectedMatch)
     }
   }
+
+   "check" should "handle multiple substitions" in {
+    val rule = RegexRule(
+      id = s"example-rule",
+      category = Category("new-category", "New Category", "puce"),
+      description = s"Example rule",
+      replacement = Some(TextSuggestion("$1-$2-long")),
+      regex = "\\b(one|two|three|four|five|six|seven|eight|nine|\\d)-? (year|day|month|week|mile)-? long".r
+    )
+
+    val validator = new RegexMatcher("example-category", List(rule))
+    val eventuallyMatches = validator.check(
+      MatcherRequest(getBlocks("A nine month long sabbatical"), "example-category")
+    )
+
+    eventuallyMatches.map { matches =>
+      matches.size shouldBe 1
+      val expectedReplacement = Some("nine-month-long")
+      val expectedMatch = getMatch("nine month long", 2, 17, "A [nine month long] sabbatical", rule, expectedReplacement)
+      matches(0) should matchTo(expectedMatch)
+    }
+  }
 }

--- a/test/scala/matchers/RegexMatcherTest.scala
+++ b/test/scala/matchers/RegexMatcherTest.scala
@@ -25,7 +25,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
 
   def getBlocks(text: String) = List(TextBlock("text-block-id", text, 0, text.length))
 
-  def getMatch(text: String, fromPos: Int, toPos: Int, matchText: String, rule: RegexRule = exampleRule) = RuleMatch(
+  def getMatch(text: String, fromPos: Int, toPos: Int, matchText: String, rule: RegexRule = exampleRule, replacement: Option[String] = None) = RuleMatch(
     rule = rule,
     fromPos = fromPos,
     toPos = toPos,
@@ -33,6 +33,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     message = rule.description,
     shortMessage = Some(rule.description),
     suggestions = rule.suggestions,
+    replacement = replacement,
     matchContext = matchText
   )
 
@@ -110,6 +111,28 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
       matches(0) should matchTo(getMatch("ton", 5, 8, "tone [ton] goto", overlapRules(1)))
       matches(1) should matchTo(getMatch("one", 1, 4, "t[one] ton goto", overlapRules(2)))
       matches(2) should matchTo(getMatch("got", 9, 12, "tone ton [got]o", overlapRules(3)))
+    }
+  }
+
+  "check" should "use substitions when generating replacements" in {
+    val rule = RegexRule(
+      id = s"example-rule",
+      category = Category("new-category", "New Category", "puce"),
+      description = s"Example rule",
+      replacement = Some(TextSuggestion("tea$1")),
+      regex = "\\btea-? ?(shop|bag|leaf|leaves|pot)".r
+    )
+
+    val validator = new RegexMatcher("example-category", List(rule))
+    val eventuallyMatches = validator.check(
+      MatcherRequest(getBlocks("I'm a little tea pot"), "example-category")
+    )
+
+    eventuallyMatches.map { matches =>
+      matches.size shouldBe 1
+      val expectedReplacement = Some("teapot")
+      val expectedMatch = getMatch("tea pot", 13, 20, "I'm a little [tea pot]", rule, expectedReplacement)
+      matches(0) should matchTo(expectedMatch)
     }
   }
 }


### PR DESCRIPTION
## What does this change?

Our regex rules ingeniously use regex capture groups when creating replacements. For example, with the rule and replacement

`\\btea-? ?(shop|bag|leaf|leaves|pot)` -> `tea$1`

We can address an extra dash, space or both space in `tea-pot`, `tea-shop` etc.

Previously, we were providing the replacement verbatim, so users would see `tea$1` as a replacement.

With this change, we add a `replacement` directly to the `RuleMatch`, necessary because it's now dynamically generated from the rule and the match.

We'll need to update the UI downstream from this change before users are able to see this behaviour for themselves, as at the moment, the UI is pointed at the rule replacement, not the new match replacement.

## How to test

Check out the automated tests. Do they demonstrate the expected behaviour?

You could also run a check with this branch and examine the API output to verify that substitutions are working as expected.

## How can we measure success?

Rule creators can use substitutions in their rules, and they're applied correctly on the server-side.