### PR TITLE
Extend grace period for panda auth

### DIFF
--- a/app/services/PandaAuthentication.scala
+++ b/app/services/PandaAuthentication.scala
@@ -21,7 +21,7 @@ trait PandaAuthentication extends BaseControllerHelpers with Loggable {
       cookie.value,
       publicKey,
       PanDomain.guardianValidation,
-      apiGracePeriod = 60 * 60 * 10000, // one hours worth of milliseconds
+      apiGracePeriod = 2 * 60 * 60 * 10000, // two hours worth of milliseconds
       system = "typerighter",
       cacheValidation = false
     )


### PR DESCRIPTION
## What does this change?

Extends the grace period for panda auth. There are [known issues](https://trello.com/c/1D65k3El/384-workflow-functionality-lost-after-losing-credentials-should-try-to-reauth) with our tooling re: reauthentication, and this smoothes things out a little whilst we wait for a broader solution to that problem.

## How to test

(Level: difficult, or perhaps: tedious 😅 ) Leave a composer tab open for longer than an hour, and attempt to use Typerighter. Your session should still be valid.

## How can we measure success?

Typerighter issues [fewer auth errors](https://logs.gutools.co.uk/s/editorial-tools/goto/10f36727321c004163a6f993135efff5).