### PR TITLE
Change replacement type to TextSuggestion

### DIFF
--- a/app/model/RegexRule.scala
+++ b/app/model/RegexRule.scala
@@ -21,6 +21,7 @@ case class RegexRule(
 
   def toMatch(start: Int, end: Int, block: TextBlock): RuleMatch = {
     val matchedText = block.text.substring(start, end)
+    val replacementText = replacement.map(replacement => regex.replaceAllIn(matchedText, replacement.text))
     RuleMatch(
       rule = this,
       fromPos = start + block.from,
@@ -29,7 +30,7 @@ case class RegexRule(
       message = description,
       shortMessage = Some(description),
       suggestions = suggestions,
-      replacement = replacement.map(replacement => regex.replaceAllIn(matchedText, replacement.text)),
+      replacement = replacementText.map(TextSuggestion(_)),
       markAsCorrect = replacement.map(_.text).getOrElse("") == block.text.substring(start, end),
       matchContext = Text.getSurroundingText(block.text, start, end)
     )

--- a/app/model/RuleMatch.scala
+++ b/app/model/RuleMatch.scala
@@ -28,6 +28,7 @@ object RuleMatch {
     "toPos" -> ruleMatch.toPos,
     "matchedText" -> ruleMatch.matchedText,
     "message" -> ruleMatch.message,
+    "replacement" -> ruleMatch.replacement,
     "shortMessage" -> ruleMatch.shortMessage,
     "suggestions" -> ruleMatch.suggestions,
     "markAsCorrect" -> ruleMatch.markAsCorrect,
@@ -42,7 +43,7 @@ case class RuleMatch(rule: BaseRule,
                      message: String,
                      shortMessage: Option[String] = None,
                      suggestions: List[Suggestion] = List.empty,
-                     replacement: Option[String] = None,
+                     replacement: Option[Suggestion] = None,
                      markAsCorrect: Boolean = false,
                      matchContext: String)
 


### PR DESCRIPTION
## What does this change?

At the moment, we output replacements as strings. This isn't consistent with our Suggestions model, which represents rule suggestions as a sealed trait of Suggestions. This is designed to accommodate diverse suggestion types over time (for e.g. #12).

This PR replaces the string type with a TextSuggestion type.

## How to test

The API output for matches should now match the TextSuggestion model when replacements are available. You could test with e.g. a local instance of [prosemirror-typerighter](https://github.com/guardian/prosemirror-typerighter).

The automated tests which produce replacements should pass.
