### PR TITLE
Recover from stream failure

### DIFF
--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -179,6 +179,22 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     }
   }
 
+    "check" should "recover from validation failures" in {
+    val matchers = getMatchers(1)
+    val pool = getPool(matchers)
+    val futureResult = pool.check(getCheck(text = "Example text"))
+    val errorMessage = "Something went wrong"
+    matchers(0).fail(errorMessage)
+    ScalaFutures.whenReady(futureResult) { e =>
+      println(e)
+    }
+    val anotherResult = pool.check(getCheck(text = "Example text"))
+    matchers.head.markAsComplete(responses)
+    anotherResult.map { result =>
+      result shouldBe responses
+    }
+  }
+
   "check" should "correctly check multiple categories for a single job" in {
     val matchers = getMatchers(2)
     val pool = getPool(matchers)

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -252,26 +252,4 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
       case Failure(e) => e.getMessage should include("category-id-does-not-exist")
     }
   }
-
-  it should "emit events when validations are complete" in {
-    val matchers = getMatchers(2)
-    val pool = getPool(matchers)
-    var events = ListBuffer.empty[MatcherPoolEvent]
-    val subscriber = MatcherPoolSubscriber("set-id", (e: MatcherPoolEvent) => {
-      events += e
-      ()
-    })
-    pool.subscribe(subscriber)
-    val check = getCheck("Example text")
-    val futureResult = pool.check(check)
-    matchers.foreach(_.markAsComplete(responses))
-    futureResult.map { _ =>
-      val categories = matchers.map {_.getCategory}
-      events.toSet shouldBe Set(
-        MatcherPoolResultEvent(setId, MatcherResponse(check.blocks, List(categories(0)), responses)),
-        MatcherPoolResultEvent(setId, MatcherResponse(check.blocks, List(categories(1)), responses)),
-        MatcherPoolJobsCompleteEvent(setId)
-      )
-    }
-  }
 }

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -265,7 +265,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     val check = getCheck("Example text")
     val futureResult = pool.check(check)
     matchers.foreach(_.markAsComplete(responses))
-    ScalaFutures.whenReady(futureResult) { _ =>
+    futureResult.map { _ =>
       val categories = matchers.map {_.getCategory}
       events.toSet shouldBe Set(
         MatcherPoolResultEvent(setId, MatcherResponse(check.blocks, List(categories(0)), responses)),

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -112,27 +112,33 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     categoryIds,
     List(TextBlock(blockId, text, 0, text.length)))
 
-  "getCurrentCategories" should "report current categories" in {
+  behavior of "getCurrentCategories"
+
+  it should "report current categories" in {
     val matchers = getMatchers(1)
     val pool = getPool(matchers)
     pool.getCurrentCategories should be(List(("mock-matcher-0", getCategory(0), 0)))
   }
 
-  "removeMatcherByCategory" should "remove a matcher by its category id" in {
+  behavior of "removeMatcherByCategory"
+
+  it should "remove a matcher by its category id" in {
     val matchers = getMatchers(2)
     val pool = getPool(matchers)
     pool.removeMatcherByCategory(matchers(1).getCategory())
     pool.getCurrentCategories should be(List(("mock-matcher-0", getCategory(0), 0)))
   }
 
-  "removeMatcherByCategory" should "remove all matchers" in {
+  it should "remove all matchers" in {
     val matchers = getMatchers(2)
     val pool = getPool(matchers)
     pool.removeAllMatchers
     pool.getCurrentCategories should be(List.empty)
   }
 
-  "check" should "return a list of MatcherResponses" in {
+  behavior of "check"
+
+  it should "return a list of MatcherResponses" in {
     val matchers = getMatchers(1)
     val pool = getPool(matchers)
     val futureResult = pool.check(getCheck(text = "Example text"))
@@ -142,7 +148,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     }
   }
 
-  "check" should "complete queued jobs" in {
+  it should "complete queued jobs" in {
     val matchers = getMatchers(24)
     val pool = getPool(matchers)
     val futureResult = pool.check(getCheck(text = "Example text"))
@@ -152,7 +158,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     }
   }
 
-  "check" should "reject work that exceeds its buffer size" in {
+  it should "reject work that exceeds its buffer size" in {
     val matchers = getMatchers(1)
     // This check should produce a job for each block, filling the queue.
     val checkWithManyBlocks = Check(
@@ -169,7 +175,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     }
   }
 
-  "check" should "handle validation failures" in {
+  it should "handle validation failures" in {
     val matchers = getMatchers(2)
     val pool = getPool(matchers)
     val futureResult = pool.check(getCheck(text = "Example text"))
@@ -184,7 +190,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     result
   }
 
-  "check" should "recover from validation failures" in {
+  it should "recover from validation failures" in {
     val matchers = getMatchers(1)
     val pool = getPool(matchers)
     val futureResult = pool.check(getCheck(text = "Example text"))
@@ -201,15 +207,16 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
       val anotherResult = pool.check(getCheck(text = "Example text"))
       matchers.head.markAsComplete(responses)
       anotherResult
-    }.map { result =>
-      result shouldBe responses
+    } transformWith {
+      case Success(result) => result shouldBe responses
+      case Failure(e) => fail(e)
     }
 
     matchers.head.fail(errorMessage)
     eventualResult
   }
 
-  "check" should "correctly check multiple categories for a single job" in {
+  it should "correctly check multiple categories for a single job" in {
     val matchers = getMatchers(2)
     val pool = getPool(matchers)
     val futureResult = pool.check(getCheck(text = "Example text"))
@@ -222,7 +229,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     }
   }
 
-  "check" should "correctly check multiple categories for a single job don't overlap" in {
+  it should "correctly check multiple categories for a single job don't overlap" in {
     val matchers = getMatchers(2)
     val pool = getPool(matchers, 4, 100, MatcherPool.blockLevelCheckStrategy)
     val futureResult = pool.check(getCheck(text = "Example text"))
@@ -236,7 +243,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     }
   }
 
-   "check" should "handle requests for categories that do not exist" in {
+   it should "handle requests for categories that do not exist" in {
     val matchers = getMatchers(2)
     val pool = getPool(matchers)
     val futureResult = pool.check(getCheck("Example text", Some(List("category-id-does-not-exist"))))


### PR DESCRIPTION
## What does this change?

At the moment, if the stream that manages throughput for the `matcherPool` receives an error, it completes with a failure. This means the whole pool stops working.

This can happen when checks are run whilst the tool is refreshing its matches. Because the categories have been cleared out and not yet replaced with new rules, no categories will exist, and the stream will fail. This is causing boxes to become unresponsive to checks in prod.

This stream behaviour is the default behaviour of akka streams, and `mapAsync` in particular via a failed future. We can use a `SupervisionStrategy` to [prevent this from happening](https://doc.akka.io/docs/akka/current/stream/stream-error.html#errors-from-mapasync).

Another approach would be to emit the error as a value wrapped in a successful future, but we would probably want this behaviour in any case, to ensure that other errors causing the future to fail don't propagate up to the stream.

## How to test

One way to test this is to ask for matches for a category that doesn't exist. This fails a future without the stream, and will cause the `MatcherPool` to stop running jobs.

As above, an easy way produce that result is to repeatedly run checks whilst the tool is refreshing its matches. Hit the refresh button in the `/rules` UI, and immediately run a check. 

## How can we measure success?

The Typerighter service no longer becomes unresponsive when rules are refreshed by users.

## Developer notes

I've refactored the current tests to avoid using ScalaFutures, and removed a test that was intermittently failing as a part of this PR. Happy to bundle in a separate PR if needed.
