### PR TITLE
Remove first row from sheet on ingest

### DIFF
--- a/app/rules/SheetsRuleResource.scala
+++ b/app/rules/SheetsRuleResource.scala
@@ -37,7 +37,11 @@ class SheetsRuleResource(credentialsJson: String, spreadsheetId: String) {
     if (values == null || values.isEmpty) {
       Future.successful((Map(), Nil))
     } else {
-      val (rules, errors) = values.asScala.zipWithIndex.foldLeft((List.empty[RegexRule], List.empty[String])) {
+      val (rules, errors) = values
+        .asScala
+        .zipWithIndex
+        .tail // The first row contains the table headings
+        .foldLeft((List.empty[RegexRule], List.empty[String])) {
         case ((rules, errors), (row, index)) => {
           getPatternRuleFromRow(row.asScala.toList, index) match {
             case Success(rule) => (rules ++ rule, errors)


### PR DESCRIPTION
## What does this change?

This PR removes the first row from the google sheet on ingest – it's the heading, and right now we remove it by adding an intentional error to the 'regex' cell 😅 

## How to test

Spin this up in e.g. CODE. You should no longer see the table header of the CODE rules sheet being ingested.

