### PR TITLE
Fix mapping of getCurrentCategories to return category ids not matcher ID

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -26,7 +26,7 @@ class ApiController(
             val response = MatcherResponse(
               matches = matches,
               blocks = check.blocks,
-              categoryIds = check.categoryIds.getOrElse(matcherPool.getCurrentCategories.map { _._1 })
+              categoryIds = check.categoryIds.getOrElse(matcherPool.getCurrentCategories.map { _._2.id })
             )
             Ok(Json.toJson(response))
           } recover {


### PR DESCRIPTION
## What does this change?
This work is related to [this PR](https://github.com/guardian/prosemirror-typerighter/pull/136) and fixes a bug that meant that the matcher IDs were returned instead of the category IDs.

## How to test
Run branch locally with the same branch from `prosemirror-typerighter` and see the category IDs in the response.