### PR TITLE
Fails rule ingestion if any rules fail

### DIFF
--- a/app/views/rules.scala.html
+++ b/app/views/rules.scala.html
@@ -12,9 +12,9 @@
             <button class="btn btn-primary btn-sm ml-3">Refresh rules</button>
         </h1>
     }
-    @if(rulesIngested.nonEmpty) {
+    @if(rulesIngested.nonEmpty || errors.size != 0) {
         <div class="alert alert-@if(errors != Nil) {danger} else {success}" role="alert">
-            @rulesIngested rules added. @if(errors != Nil) {Errors found: @errors.size}
+            @rulesIngested.getOrElse("No") rules added. @if(errors != Nil) {Errors found: @errors.size}
             @for(error <- errors) {
                 <p>@error</p>
             }


### PR DESCRIPTION
## What does this change?

Fails rule ingestion if any rules fail, to encourage us to provide well-formed rules. We report via the UI if this happens via the 'refresh' bottom.

## How to test

Induce an error in a rule – for example by adding a single { in the 'pattern' field. Visit the `/rules` endpoint. When pressing 'refresh' , you should see that
- no rules are added
- the error is clearly enumerated

Please contact me directly if you'd like links to the code environment or the rules sheet.
 
## How can we measure success?

We only ingest new rulesets if all of the incoming rules are well-formed.
