### PR TITLE
Add ID to rules and be specific in error message when ID is not present

### DIFF
--- a/app/views/rules.scala.html
+++ b/app/views/rules.scala.html
@@ -54,6 +54,7 @@
             <table class="table">
                 <thead>
                     <tr>
+                        <th scope="col">ID</th>
                         <th scope="col">Category</th>
                         <th scope="col">Match</th>
                         <th scope="col">Replacement</th>
@@ -63,6 +64,9 @@
                 <tbody>
                 @for(rule <- rules) {
                     <tr>
+                        <td>
+                          @rule.id
+                        </td>
                         <td>
                           @rule.category.name
                         </td>


### PR DESCRIPTION
## What does this change?

Adds a ruleId to ingested rules via a column in the sheet. We add UUIDs to this column.

We issue an error if a rule doesn't have an ID.

## How to test

Visit the `/rules` endpoint. You should see that rules are now added with IDs. 

When pressing 'refresh' , you should see that removing an ID from the sheet should give an error in the Typerighter UI.

Please contact me directly if you'd like links to the code environment or the rules sheet.

## How can we measure success?

We have a unique id per rule, that is stably tied to that rule.