### PR TITLE
Add timeout to matcher checks

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -20,6 +20,7 @@ import router.Routes
 import rules.SheetsRuleResource
 import services._
 import utils.Loggable
+import play.api.libs.concurrent.DefaultFutures
 
 class AppComponents(context: Context, identity: AppIdentity, creds: AWSCredentialsProvider)
   extends BuiltInComponentsFromContext(context)

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -40,7 +40,8 @@ class AppComponents(context: Context, identity: AppIdentity, creds: AWSCredentia
 
   val ngramPath: Option[File] = configuration.getOptional[String]("typerighter.ngramPath").map(new File(_))
   val matcherPoolDispatcher = actorSystem.dispatchers.lookup("matcher-pool-dispatcher")
-  val matcherPool = new MatcherPool()(matcherPoolDispatcher, materializer)
+  val defaultFutures = new DefaultFutures(actorSystem)
+  val matcherPool = new MatcherPool(futures = defaultFutures)(matcherPoolDispatcher, materializer)
 
   val credentials = configuration.get[String]("typerighter.google.credentials")
   val spreadsheetId = configuration.get[String]("typerighter.sheetId")

--- a/app/services/MatcherPool.scala
+++ b/app/services/MatcherPool.scala
@@ -6,13 +6,18 @@ import net.logstash.logback.marker.Markers
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future, Promise}
-import play.api.Logging
+import scala.util.Failure
+import scala.concurrent.duration._
+
 import model.{BaseRule, Category, Check, MatcherResponse, RuleMatch, TextBlock}
 import utils.{Matcher, RuleMatchHelpers}
 import akka.stream.QueueOfferResult.{Dropped, QueueClosed, Failure => QueueFailure}
 import akka.stream._
 import akka.stream.scaladsl.{Sink, Source}
-import scala.util.Failure
+import play.api.libs.concurrent.Futures
+import play.api.Logging
+import java.util.concurrent.TimeoutException
+import scala.util.Success
 
 case class MatcherRequest(blocks: List[TextBlock], categoryId: String)
 

--- a/app/services/MatcherPool.scala
+++ b/app/services/MatcherPool.scala
@@ -67,7 +67,7 @@ class MatcherPool(
   val maxQueuedJobs: Int = 1000,
   val checkStrategy: MatcherPool.CheckStrategy = MatcherPool.blockLevelCheckStrategy,
   val futures: Futures,
-  val checkTimeoutDuration: FiniteDuration = 1 second
+  val checkTimeoutDuration: FiniteDuration = 5 seconds
 )(implicit ec: ExecutionContext, implicit val mat: Materializer) extends Logging {
   type JobProgressMap = Map[String, Int]
 

--- a/app/services/MatcherPool.scala
+++ b/app/services/MatcherPool.scala
@@ -62,7 +62,13 @@ object MatcherPool extends Logging {
   }
 }
 
-class MatcherPool(val maxCurrentJobs: Int = 8, val maxQueuedJobs: Int = 1000, val checkStrategy: MatcherPool.CheckStrategy = MatcherPool.blockLevelCheckStrategy)(implicit ec: ExecutionContext, implicit val mat: Materializer) extends Logging {
+class MatcherPool(
+  val maxCurrentJobs: Int = 8,
+  val maxQueuedJobs: Int = 1000,
+  val checkStrategy: MatcherPool.CheckStrategy = MatcherPool.blockLevelCheckStrategy,
+  val futures: Futures,
+  val checkTimeoutDuration: FiniteDuration = 1 second
+)(implicit ec: ExecutionContext, implicit val mat: Materializer) extends Logging {
   type JobProgressMap = Map[String, Int]
 
   private val matchers = new ConcurrentHashMap[String, (Category, Matcher)]().asScala
@@ -185,7 +191,8 @@ class MatcherPool(val maxCurrentJobs: Int = 8, val maxQueuedJobs: Int = 1000, va
 
     val eventuallyJobResults : List[Future[(Category, List[RuleMatch])]] = matchersAndCategoryIds.map {
       case (Some((category, matcher)), _) =>
-        matcher.check(MatcherRequest(job.blocks, category.id)).map((category, _))
+        val eventuallyCheck = matcher.check(MatcherRequest(job.blocks, category.id)).map((category, _))
+        futures.timeout(checkTimeoutDuration)(eventuallyCheck)
       case (None, categoryId) =>
         val message = s"Could not run job with -- no matcher for category for id: $categoryId"
         logger.error(message)(job.toMarker)

--- a/app/services/MatcherPool.scala
+++ b/app/services/MatcherPool.scala
@@ -1,6 +1,7 @@
 package services
 
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeoutException
 
 import net.logstash.logback.marker.Markers
 
@@ -8,6 +9,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.Failure
 import scala.concurrent.duration._
+import scala.util.Success
 
 import model.{BaseRule, Category, Check, MatcherResponse, RuleMatch, TextBlock}
 import utils.{Matcher, RuleMatchHelpers}
@@ -16,8 +18,6 @@ import akka.stream._
 import akka.stream.scaladsl.{Sink, Source}
 import play.api.libs.concurrent.Futures
 import play.api.Logging
-import java.util.concurrent.TimeoutException
-import scala.util.Success
 
 case class MatcherRequest(blocks: List[TextBlock], categoryId: String)
 


### PR DESCRIPTION
## What does this change?

Adds a timeout to each call to `check`, configured by the `MatcherPool` This should ensure that users don't have to wait for their socket to time out (30 seconds? A minute?) before they see checks fail.

The initial, misiguided response to a problem that was solved by #73 – although the problems we saw with odd regexes didn't end up being caused by a timeout, I think it's worth adding one as long as we've a test to ensure it works, as it's likely we'll eventually run into a problem with long-running and possibly pathological calls to `check` for some matcher.

## How to test

We don't have a way of inducing a timeout on a single check with runtime configuration for now. You could manually alter the code in this branch to never complete a future, and observe the results.

The automated test, which effectively does the same thing, should pass.

## How can we measure success?

If we introduce rules that cause checks to time out, users (and us!) are alerted early.
