### PR TITLE
Refactor rule ingestion

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -67,7 +67,7 @@ class AppComponents(context: Context, identity: AppIdentity, creds: AWSCredentia
   val ruleProvisioner = new RuleProvisionerService(bucketRuleResource, matcherPool)
 
   val apiController = new ApiController(controllerComponents, matcherPool, publicSettings)
-  val rulesController = new RulesController(controllerComponents, matcherPool, ruleResource, bucketRuleResource, spreadsheetId, publicSettings)
+  val rulesController = new RulesController(controllerComponents, matcherPool, ruleResource, bucketRuleResource, spreadsheetId, ruleProvisioner, publicSettings)
   val homeController = new HomeController(controllerComponents, publicSettings)
   val auditController = new AuditController(controllerComponents, publicSettings)
   val capiProxyController = new CapiProxyController(controllerComponents, contentClient, publicSettings)

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -60,8 +60,8 @@ class AppComponents(context: Context, identity: AppIdentity, creds: AWSCredentia
   publicSettings.start()
 
   val typerighterBucket = identity match {
-    case identity: AwsIdentity => s"typerighter-rules-${identity.stage.toLowerCase}"
-    case _: DevIdentity => "typerighter-rules-code"
+    case identity: AwsIdentity => s"typerighter-${identity.stage.toLowerCase}"
+    case _: DevIdentity => "typerighter-code"
   }
   val bucketRuleResource = new BucketRuleResource(s3Client, typerighterBucket)
   val ruleProvisioner = new RuleProvisionerService(bucketRuleResource, matcherPool)

--- a/app/controllers/RulesController.scala
+++ b/app/controllers/RulesController.scala
@@ -18,7 +18,6 @@ class RulesController(cc: ControllerComponents, matcherPool: MatcherPool, ruleRe
 
     // This reset will need to be revisited when we're ingesting from multiple matchers.
     matcherPool.removeAllMatchers()
-
     ruleResource.fetchRulesByCategory().map { maybeRules =>
       maybeRules match {
         case Left(errors) => {

--- a/app/controllers/RulesController.scala
+++ b/app/controllers/RulesController.scala
@@ -16,8 +16,6 @@ class RulesController(cc: ControllerComponents, matcherPool: MatcherPool, ruleRe
                       ruleProvisioner: RuleProvisionerService, val publicSettings: PublicSettings)(implicit ec: ExecutionContext)
   extends AbstractController(cc) with PandaAuthentication {
   def refresh = ApiAuthAction.async { implicit request: Request[AnyContent] =>
-
-    // This reset will need to be revisited when we're ingesting from multiple matchers.
     ruleResource.fetchRulesByCategory().map { maybeRules =>
       maybeRules match {
         case Left(errors) => {

--- a/app/model/RegexRule.scala
+++ b/app/model/RegexRule.scala
@@ -1,13 +1,15 @@
 package model
 
-import play.api.libs.json.{JsString, Json, Writes}
+import play.api.libs.json.{JsPath, JsResult, JsString, JsSuccess, JsValue, Json, Reads, Writes}
 
 import scala.util.matching.Regex
 import utils.Text
 
 object RegexRule {
   implicit val regexWrites: Writes[Regex] = (regex: Regex) => JsString(regex.toString)
+  implicit val regexReads: Reads[Regex] = (JsPath).read[String].map(new Regex(_))
   implicit val writes: Writes[RegexRule] = Json.writes[RegexRule]
+  implicit val reads: Reads[RegexRule] = Json.reads[RegexRule]
 }
 
 case class RegexRule(

--- a/app/rules/BucketRuleResource.scala
+++ b/app/rules/BucketRuleResource.scala
@@ -15,24 +15,27 @@ import scala.io.Source.fromInputStream
 class BucketRuleResource (s3: AmazonS3, bucketName: String) extends Loggable {
     private val RULES_KEY = "typerighter-rules.json"
 
-    def serialiseAndUploadRules(rules: List[RegexRule]) {
+    def serialiseAndUploadRules(rules: List[RegexRule]): Either[String, Unit] = {
         val ruleJson = Json.toJson(rules)
         val stream: java.io.InputStream = new java.io.ByteArrayInputStream(ruleJson.toString.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
         uploadRules(stream)
     }
 
-    def uploadRules(stream: InputStream) {
+    def uploadRules(stream: InputStream): Either[String, Unit] = {
         try {
             val metaData = new ObjectMetadata()
             val putObjectRequest = new PutObjectRequest(bucketName, RULES_KEY, stream, metaData)
-            val result = s3.putObject(putObjectRequest)
+            s3.putObject(putObjectRequest)
+            Right(())
         }
         catch  {
             case e: AmazonServiceException => {
                 log.warn(e.getMessage)
+                Left(e.getMessage)
             }
             case e: SdkClientException => {
                 log.warn(e.getMessage)
+                Left(e.getMessage)
             }
         }
     }

--- a/app/rules/BucketRuleResource.scala
+++ b/app/rules/BucketRuleResource.scala
@@ -11,7 +11,7 @@ import model.RegexRule
 import utils.Loggable
 
 class BucketRuleResource (s3: AmazonS3, bucketName: String) extends Loggable {
-    private val RULES_KEY = "typerighter-rules.json"
+    private val RULES_KEY = "rules/typerighter-rules.json"
 
     def serialiseAndUploadRules(rules: List[RegexRule]): Either[String, Date] = {
         val ruleJson = Json.toJson(rules)

--- a/app/rules/BucketRuleResource.scala
+++ b/app/rules/BucketRuleResource.scala
@@ -15,13 +15,14 @@ class BucketRuleResource (s3: AmazonS3, bucketName: String) extends Loggable {
 
     def serialiseAndUploadRules(rules: List[RegexRule]): Either[String, Date] = {
         val ruleJson = Json.toJson(rules)
-        val stream: java.io.InputStream = new java.io.ByteArrayInputStream(ruleJson.toString.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
-        uploadRules(stream)
+        uploadRules(ruleJson.toString.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
     }
 
-    def uploadRules(stream: InputStream): Either[String, Date] = {
+    def uploadRules(bytes: Array[Byte]): Either[String, Date] = {
         try {
+            val stream: java.io.InputStream = new java.io.ByteArrayInputStream(bytes)
             val metaData = new ObjectMetadata()
+            metaData.setContentLength(bytes.length)
             val putObjectRequest = new PutObjectRequest(bucketName, RULES_KEY, stream, metaData)
             val result = s3.putObject(putObjectRequest)
             Right(result.getMetadata.getLastModified)

--- a/app/rules/BucketRuleResource.scala
+++ b/app/rules/BucketRuleResource.scala
@@ -12,8 +12,8 @@ import utils.Loggable
 import scala.io.Source.fromInputStream
 
 
-class BucketRuleResource (s3: AmazonS3, rulesKey: String) extends Loggable {
-    private val BUCKET_NAME = "typerighter-rules"
+class BucketRuleResource (s3: AmazonS3, bucketName: String) extends Loggable {
+    private val RULES_KEY = "typerighter-rules.json"
 
     def serialiseAndUploadRules(rules: List[RegexRule]) {
         val ruleJson = Json.toJson(rules)
@@ -24,7 +24,7 @@ class BucketRuleResource (s3: AmazonS3, rulesKey: String) extends Loggable {
     def uploadRules(stream: InputStream) {
         try {
             val metaData = new ObjectMetadata()
-            val putObjectRequest = new PutObjectRequest(BUCKET_NAME, rulesKey, stream, metaData)
+            val putObjectRequest = new PutObjectRequest(bucketName, RULES_KEY, stream, metaData)
             val result = s3.putObject(putObjectRequest)
         }
         catch  {
@@ -39,7 +39,7 @@ class BucketRuleResource (s3: AmazonS3, rulesKey: String) extends Loggable {
 
     def getRules(): Option[List[RegexRule]] = {
         try {
-            val rules = s3.getObject(BUCKET_NAME, rulesKey)
+            val rules = s3.getObject(bucketName, RULES_KEY)
             val rulesStream = rules.getObjectContent()
             val rulesJson = Json.parse(rulesStream)
             rules.close()

--- a/app/rules/BucketRuleResource.scala
+++ b/app/rules/BucketRuleResource.scala
@@ -13,18 +13,18 @@ import utils.Loggable
 class BucketRuleResource (s3: AmazonS3, bucketName: String) extends Loggable {
     private val RULES_KEY = "typerighter-rules.json"
 
-    def serialiseAndUploadRules(rules: List[RegexRule]): Either[String, Unit] = {
+    def serialiseAndUploadRules(rules: List[RegexRule]): Either[String, Date] = {
         val ruleJson = Json.toJson(rules)
         val stream: java.io.InputStream = new java.io.ByteArrayInputStream(ruleJson.toString.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
         uploadRules(stream)
     }
 
-    def uploadRules(stream: InputStream): Either[String, Unit] = {
+    def uploadRules(stream: InputStream): Either[String, Date] = {
         try {
             val metaData = new ObjectMetadata()
             val putObjectRequest = new PutObjectRequest(bucketName, RULES_KEY, stream, metaData)
-            s3.putObject(putObjectRequest)
-            Right(())
+            val result = s3.putObject(putObjectRequest)
+            Right(result.getMetadata.getLastModified)
         }
         catch  {
             case e: AmazonServiceException => {

--- a/app/rules/BucketRuleResource.scala
+++ b/app/rules/BucketRuleResource.scala
@@ -1,0 +1,60 @@
+package rules
+
+import play.api.libs.json.Json
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest, S3Object}
+import java.io.InputStream
+
+import com.amazonaws.{AmazonServiceException, SdkClientException}
+import model.RegexRule
+import utils.Loggable
+
+import scala.io.Source.fromInputStream
+
+
+class BucketRuleResource (s3: AmazonS3, rulesKey: String) extends Loggable {
+    private val BUCKET_NAME = "typerighter-rules"
+
+    def serialiseAndUploadRules(rules: List[RegexRule]) {
+        val ruleJson = Json.toJson(rules)
+        val stream: java.io.InputStream = new java.io.ByteArrayInputStream(ruleJson.toString.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
+        uploadRules(stream)
+    }
+
+    def uploadRules(stream: InputStream) {
+        try {
+            val metaData = new ObjectMetadata()
+            val putObjectRequest = new PutObjectRequest(BUCKET_NAME, rulesKey, stream, metaData)
+            val result = s3.putObject(putObjectRequest)
+        }
+        catch  {
+            case e: AmazonServiceException => {
+                log.warn(e.getMessage)
+            }
+            case e: SdkClientException => {
+                log.warn(e.getMessage)
+            }
+        }
+    }
+
+    def getRules(): Option[List[RegexRule]] = {
+        try {
+            val rules = s3.getObject(BUCKET_NAME, rulesKey)
+            val rulesStream = rules.getObjectContent()
+            val rulesJson = Json.parse(rulesStream)
+            rules.close()
+            Some(rulesJson.as[List[RegexRule]])
+        }
+        catch  {
+            case e: AmazonServiceException => {
+                log.warn(e.getMessage)
+                None
+            }
+            case e: SdkClientException => {
+                log.warn(e.getMessage)
+                None
+            }
+        }
+    }
+  
+}

--- a/app/rules/RuleProvisionerService.scala
+++ b/app/rules/RuleProvisionerService.scala
@@ -14,9 +14,9 @@ class RuleProvisionerService(ruleBucket: BucketRuleResource, matcherPool: Matche
   var lastModified: Date = new Date(0)
 
   def updateRules(): Unit = {
-    matcherPool.removeAllMatchers()
     ruleBucket.getRules match {
       case Some((rules, date)) => {
+        matcherPool.removeAllMatchers()
         rules.groupBy(_.category).foreach { case (category, rules) => {
           val matcher = new RegexMatcher(category.name, rules)
           matcherPool.addMatcher(category, matcher)
@@ -31,7 +31,7 @@ class RuleProvisionerService(ruleBucket: BucketRuleResource, matcherPool: Matche
     ruleBucket.getRulesLastModified match {
       case Some(date) if date.compareTo(lastModified) > 0 => updateRules
       case Some(_) => log.info("No rule update needed")
-      case None => log.error("No last modified date found for rules")
+      case None => log.error("Could not get last modified from S3")
     }
   }
 

--- a/app/rules/RuleProvisionerService.scala
+++ b/app/rules/RuleProvisionerService.scala
@@ -29,7 +29,8 @@ class RuleProvisionerService(ruleBucket: BucketRuleResource, matcherPool: Matche
 
   def maybeUpdateRules(): Unit = {
     ruleBucket.getRulesLastModified match {
-      case Some(date) if (date.compareTo(lastModified) > 0) => updateRules
+      case Some(date) if date.compareTo(lastModified) > 0 => updateRules
+      case Some(_) => log.info("No rule update needed")
       case None => log.error("No last modified date found for rules")
     }
   }

--- a/app/rules/RuleProvisionerService.scala
+++ b/app/rules/RuleProvisionerService.scala
@@ -1,0 +1,43 @@
+package rules
+
+import java.util.Date
+
+import akka.actor.Scheduler
+import matchers.RegexMatcher
+import services.MatcherPool
+import utils.Loggable
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+class RuleProvisionerService(ruleBucket: BucketRuleResource, matcherPool: MatcherPool)(implicit ec: ExecutionContext) extends Loggable with Runnable {
+  var lastModified: Date = new Date(0)
+
+  def updateRules(): Unit = {
+    matcherPool.removeAllMatchers()
+    ruleBucket.getRules match {
+      case Some((rules, date)) => {
+        rules.groupBy(_.category).foreach { case (category, rules) => {
+          val matcher = new RegexMatcher(category.name, rules)
+          matcherPool.addMatcher(category, matcher)
+          lastModified = date
+        }}
+      }
+      case _ => log.error(s"Could not get rules from S3")
+    }
+  }
+
+  def maybeUpdateRules(): Unit = {
+    ruleBucket.getRulesLastModified match {
+      case Some(date) if (date.compareTo(lastModified) > 0) => updateRules
+      case None => log.error("No last modified date found for rules")
+    }
+  }
+
+  override def run(): Unit = maybeUpdateRules
+
+  def scheduleUpdateRules(scheduler: Scheduler): Unit = {
+    scheduler.scheduleWithFixedDelay(0.seconds, 1.minute)(this)
+  }
+
+}

--- a/app/rules/SheetsRuleResource.scala
+++ b/app/rules/SheetsRuleResource.scala
@@ -18,13 +18,12 @@ import scala.util.{Failure, Success, Try}
   *
   * @param credentialsJson A string containing the JSON the Google credentials service expects
   * @param spreadsheetId Available in the sheet URL
-  * @param range E.g. "A:G"
   */
 class SheetsRuleResource(credentialsJson: String, spreadsheetId: String) {
   private val APPLICATION_NAME = "Typerighter"
   private val JSON_FACTORY = JacksonFactory.getDefaultInstance
 
-  def fetchRulesByCategory(): Future[Either[List[String], Map[Category, List[RegexRule]]]] = { // Build a new authorized API client service.
+  def fetchRulesByCategory(): Future[Either[List[String], List[RegexRule]]] = { // Build a new authorized API client service.
     val HTTP_TRANSPORT = GoogleNetHttpTransport.newTrustedTransport
     val credentials = getCredentials(credentialsJson)
     val service = new Sheets.Builder(
@@ -53,7 +52,7 @@ class SheetsRuleResource(credentialsJson: String, spreadsheetId: String) {
       if (errors.size != 0) {
         Future.successful(Left(errors))
       } else {
-        Future.successful(Right(rules.groupBy(_.category)))
+        Future.successful(Right(rules))
       }
     }
   }

--- a/app/views/rules.scala.html
+++ b/app/views/rules.scala.html
@@ -16,7 +16,7 @@
     @if(rulesRefreshed.isInstanceOf[Some[Boolean]] ) {
         <div class="alert alert-@if(errors != Nil) {danger} else {success}" role="alert">
             @if(rulesRefreshed == Some(true)){
-                Rules were refreshed, @rulesIngested.getOrElse("No") found. @if(errors != Nil) {Errors found: @errors.size}
+                Rules were refreshed, @rulesIngested.getOrElse("No") found. These will be available within a minute. @if(errors != Nil) {Errors found: @errors.size}
             } else {
                 Rules were not refreshed due to errors. @if(errors != Nil) {Errors found: @errors.size}
             }

--- a/app/views/rules.scala.html
+++ b/app/views/rules.scala.html
@@ -3,7 +3,8 @@
 @import model.Category
 @import helper._
 
-@(sheetId: String, rules: scala.List[BaseRule], categories: scala.List[(String, Category, Int)], rulesIngested: Option[Int] = None, errors: List[String] = List.empty)(implicit req: RequestHeader)
+@(sheetId: String, rules: scala.List[BaseRule], categories: scala.List[(String, Category, Int)], rulesRefreshed: Option[Boolean] = None,
+        rulesIngested: Option[Int] = None, errors: List[String] = List.empty)(implicit req: RequestHeader)
 @main(title = "Typerighter", breadcrumbsList = List("Rules")) {
     @form(CSRF(routes.RulesController.refresh())) {
         @CSRF.formField
@@ -12,12 +13,18 @@
             <button class="btn btn-primary btn-sm ml-3">Refresh rules</button>
         </h1>
     }
-    @if(rulesIngested.nonEmpty || errors.size != 0) {
+    @if(rulesRefreshed.isInstanceOf[Some[Boolean]] ) {
         <div class="alert alert-@if(errors != Nil) {danger} else {success}" role="alert">
-            @rulesIngested.getOrElse("No") rules added. @if(errors != Nil) {Errors found: @errors.size}
-            @for(error <- errors) {
-                <p>@error</p>
+            @if(rulesRefreshed == Some(true)){
+                Rules were refreshed, @rulesIngested.getOrElse("No") found. @if(errors != Nil) {Errors found: @errors.size}
+            } else {
+                Rules were not refreshed due to errors. @if(errors != Nil) {Errors found: @errors.size}
             }
+            <ul>
+                @for(error <- errors) {
+                    <li>@error</li>
+                }
+            </ul>
         </div>
     }
     <div class="row">

--- a/app/views/rules.scala.html
+++ b/app/views/rules.scala.html
@@ -16,7 +16,7 @@
     @if(rulesRefreshed.isInstanceOf[Some[Boolean]] ) {
         <div class="alert alert-@if(errors != Nil) {danger} else {success}" role="alert">
             @if(rulesRefreshed == Some(true)){
-                Rules were refreshed, @rulesIngested.getOrElse("No") found. These will be available within a minute. @if(errors != Nil) {Errors found: @errors.size}
+                Rules were refreshed, @rulesIngested.getOrElse("No") found. These rules will be available within a minute. @if(errors != Nil) {Errors found: @errors.size}
             } else {
                 Rules were not refreshed due to errors. @if(errors != Nil) {Errors found: @errors.size}
             }

--- a/typerighter.cfn.yaml
+++ b/typerighter.cfn.yaml
@@ -194,6 +194,22 @@ Resources:
       Roles:
         - !Ref AppRole
 
+  GetRulesPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: GetRulesPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Action:
+          - s3:GetObject
+          Resource: !Sub
+            - arn:aws:s3:::typerighter-${Stage}/rules/*
+            - { Stage: !Ref Stage }
+      Roles:
+      - !Ref AppRole
+
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:

--- a/typerighter.cfn.yaml
+++ b/typerighter.cfn.yaml
@@ -49,11 +49,14 @@ Mappings:
       MaxInstances: 2
       MinInstances: 1
       InstanceType: t3.small
-
     PROD:
       MaxInstances: 6
       MinInstances: 3
       InstanceType: t3.small
+  StageLookup:
+    Lowercase:
+      PROD: prod
+      CODE: code
 
 Resources:
   AutoScalingGroup:
@@ -333,7 +336,8 @@ Resources:
   RuleBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: "typerighter-rules"
+      BucketName:
+        !Join [ "-", ['typerighter-rules', Fn::FindInMap: [ StageLookup, Lowercase, Ref: Stage ] ] ]
       AccessControl: Private
       Tags:
       - Key: Stack

--- a/typerighter.cfn.yaml
+++ b/typerighter.cfn.yaml
@@ -207,7 +207,7 @@ Resources:
           - s3:PutObject
           Resource: !Sub
             - arn:aws:s3:::typerighter-${Stage}/rules/*
-            - { Stage: !Ref Stage }
+            - { Stage: { Fn::FindInMap: [ StageLookup, Lowercase, Ref: Stage ] } }
       Roles:
       - !Ref AppRole
 

--- a/typerighter.cfn.yaml
+++ b/typerighter.cfn.yaml
@@ -333,11 +333,11 @@ Resources:
         ToPort: 443
         CidrIp: 0.0.0.0/0
 
-  RuleBucket:
+  Bucket:
     Type: AWS::S3::Bucket
     Properties:
       BucketName:
-        !Join [ "-", ['typerighter-rules', Fn::FindInMap: [ StageLookup, Lowercase, Ref: Stage ] ] ]
+        !Join [ "-", ['typerighter', Fn::FindInMap: [ StageLookup, Lowercase, Ref: Stage ] ] ]
       AccessControl: Private
       Tags:
       - Key: Stack

--- a/typerighter.cfn.yaml
+++ b/typerighter.cfn.yaml
@@ -332,7 +332,8 @@ Resources:
 
   RuleBucket:
     Type: AWS::S3::Bucket
-    Properties: 
+    Properties:
+      BucketName: "typerighter-rules"
       AccessControl: Private
       Tags:
       - Key: Stack

--- a/typerighter.cfn.yaml
+++ b/typerighter.cfn.yaml
@@ -204,6 +204,7 @@ Resources:
         - Effect: Allow
           Action:
           - s3:GetObject
+          - s3:PutObject
           Resource: !Sub
             - arn:aws:s3:::typerighter-${Stage}/rules/*
             - { Stage: !Ref Stage }

--- a/typerighter.cfn.yaml
+++ b/typerighter.cfn.yaml
@@ -42,6 +42,7 @@ Parameters:
     Description: Name of the ELK logging stream in this account
     Type: AWS::SSM::Parameter::Value<String>
     Default: /account/services/logging.stream
+    
 Mappings:
   StageVariables:
     CODE:
@@ -328,3 +329,15 @@ Resources:
         FromPort: 443
         ToPort: 443
         CidrIp: 0.0.0.0/0
+
+  RuleBucket:
+    Type: AWS::S3::Bucket
+    Properties: 
+      AccessControl: Private
+      Tags:
+      - Key: Stack
+        Value: !Ref Stack
+      - Key: App
+        Value: !Ref App
+      - Key: Stage
+        Value: !Ref Stage


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR changes the rule ingestion process to account for multiple instances. Currently to refresh the rules, a user would have to hit each Typerighter instance with a request to update. This is fixed by introducing a bucket shared between the instances which holds a serialised version of the latest ruleset. Each instance periodically checks the ruleset for changes and compares the date to its local instance, if the rules have changed it will pull down the latest.

There is also a change to how rules are updated. Previously the matchers would be cleared before attempting to add the rules. As this attempt can fail, you could end up in state where you have no available rules. This is now changed so rules are only cleared at the point where you are ingesting new rules, this should help to avoid issues.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This can be tested either locally or on CODE:

1. Setup a new Typerighter instance
2. Observe that the rules are pulled down from the S3 (available in the rules page)
3. Make a change to the JSON rule set in the typerighter-code bucket
4. Wait a minute
5. Observe the change is reflected in the displayed rules
 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
A user refreshing rules only needs to press the refresh button once.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

It is possible for the scheduled ingestion to fail quietly, some alerting should be added to notify us when there may be problems with an instance ingesting rules.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![image](https://user-images.githubusercontent.com/4633246/93783405-8db92f00-fc23-11ea-823a-72066a83904a.png)

