### PR TITLE
Add matcher type to rules

### DIFF
--- a/app/matchers/LanguageToolMatcher.scala
+++ b/app/matchers/LanguageToolMatcher.scala
@@ -8,7 +8,7 @@ import org.languagetool.rules.spelling.morfologik.suggestions_ordering.Suggestio
 import org.languagetool.rules.{CategoryId, Rule => LanguageToolRule}
 import play.api.Logging
 import services.MatcherRequest
-import utils.Matcher
+import utils.{Matcher, MatcherCompanion}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -54,17 +54,21 @@ class LanguageToolFactory(
   }
 }
 
+object LanguageToolMatcher extends MatcherCompanion {
+  def getType = "languageTool"
+}
+
 /**
   * A Matcher that wraps a LanguageTool instance.
   */
-class LanguageToolMatcher(category: Category, instance: JLanguageTool) extends Matcher {
-  def getId = "language-tool"
+class LanguageToolMatcher(category: String, instance: JLanguageTool) extends Matcher {
 
+  def getType = LanguageToolMatcher.getType
   def getCategory = category
 
   def check(request: MatcherRequest)(implicit ec: ExecutionContext): Future[List[RuleMatch]] = Future {
     request.blocks.flatMap { block =>
-      instance.check(block.text).asScala.map(RuleMatch.fromLT(_, block)).toList.map { ruleMatch =>
+      instance.check(block.text).asScala.map(RuleMatch.fromLT(_, block, getType)).toList.map { ruleMatch =>
         ruleMatch.copy(
           fromPos = ruleMatch.fromPos + block.from,
           toPos = ruleMatch.toPos + block.from

--- a/app/matchers/LanguageToolMatcher.scala
+++ b/app/matchers/LanguageToolMatcher.scala
@@ -61,7 +61,7 @@ object LanguageToolMatcher extends MatcherCompanion {
 /**
   * A Matcher that wraps a LanguageTool instance.
   */
-class LanguageToolMatcher(category: String, instance: JLanguageTool) extends Matcher {
+class LanguageToolMatcher(category: Category, instance: JLanguageTool) extends Matcher {
 
   def getType = LanguageToolMatcher.getType
   def getCategory = category

--- a/app/matchers/RegexMatcher.scala
+++ b/app/matchers/RegexMatcher.scala
@@ -2,16 +2,22 @@ package matchers
 
 import model.{RegexRule, RuleMatch, Category}
 import services.MatcherRequest
-import utils.{Matcher, RuleMatchHelpers}
+import utils.{Matcher, MatcherCompanion, RuleMatchHelpers}
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
+
+object RegexMatcher extends MatcherCompanion {
+  def getType() = "regex"
+}
+
 
 /**
   * A Matcher for rules based on regular expressions.
   */
 class RegexMatcher(category: Category, rules: List[RegexRule]) extends Matcher {
-  def getType() = "regex"
+
+  def getType() = RegexMatcher.getType
 
   override def check(request: MatcherRequest)(implicit ec: ExecutionContext): Future[List[RuleMatch]] = {
     Future {

--- a/app/matchers/RegexMatcher.scala
+++ b/app/matchers/RegexMatcher.scala
@@ -11,7 +11,7 @@ import scala.concurrent.ExecutionContext
   * A Matcher for rules based on regular expressions.
   */
 class RegexMatcher(category: Category, rules: List[RegexRule]) extends Matcher {
-  def getId() = "regex-validator"
+  def getType() = "regex"
 
   override def check(request: MatcherRequest)(implicit ec: ExecutionContext): Future[List[RuleMatch]] = {
     Future {

--- a/app/model/RegexRule.scala
+++ b/app/model/RegexRule.scala
@@ -4,6 +4,7 @@ import play.api.libs.json.{JsPath, JsResult, JsString, JsSuccess, JsValue, Json,
 
 import scala.util.matching.Regex
 import utils.Text
+import matchers.RegexMatcher
 
 object RegexRule {
   implicit val regexWrites: Writes[Regex] = (regex: Regex) => JsString(regex.toString)
@@ -34,7 +35,8 @@ case class RegexRule(
       suggestions = suggestions,
       replacement = replacement.map(_.replaceAllIn(regex, matchedText)),
       markAsCorrect = replacement.map(_.text).getOrElse("") == block.text.substring(start, end),
-      matchContext = Text.getSurroundingText(block.text, start, end)
+      matchContext = Text.getSurroundingText(block.text, start, end),
+      matcherType = RegexMatcher.getType
     )
   }
 }

--- a/app/model/RuleMatch.scala
+++ b/app/model/RuleMatch.scala
@@ -9,7 +9,7 @@ import scala.util.matching.Regex
 import utils.Text
 
 object RuleMatch {
-  def fromLT(lt: LTRuleMatch, block: TextBlock): RuleMatch = {
+  def fromLT(lt: LTRuleMatch, block: TextBlock, matcherType: String): RuleMatch = {
     val suggestions = lt.getSuggestedReplacements.asScala.toList.map {
       TextSuggestion(_)
     }
@@ -25,7 +25,8 @@ object RuleMatch {
       shortMessage = Some(lt.getMessage),
       replacement = replacement,
       suggestions = suggestions,
-      matchContext = Text.getSurroundingText(block.text, lt.getFromPos, lt.getToPos)
+      matchContext = Text.getSurroundingText(block.text, lt.getFromPos, lt.getToPos),
+      matcherType = matcherType
     )
   }
 
@@ -40,7 +41,7 @@ object RuleMatch {
     "suggestions" -> ruleMatch.suggestions,
     "markAsCorrect" -> ruleMatch.markAsCorrect,
     "matchContext" -> ruleMatch.matchContext,
-    "matcherId" -> ruleMatch.matcherId
+    "matcherType" -> ruleMatch.matcherType
   ))
 }
 
@@ -54,4 +55,4 @@ case class RuleMatch(rule: BaseRule,
                      replacement: Option[Suggestion] = None,
                      markAsCorrect: Boolean = false,
                      matchContext: String,
-                     matcherId: String)
+                     matcherType: String)

--- a/app/model/RuleMatch.scala
+++ b/app/model/RuleMatch.scala
@@ -39,7 +39,8 @@ object RuleMatch {
     "shortMessage" -> ruleMatch.shortMessage,
     "suggestions" -> ruleMatch.suggestions,
     "markAsCorrect" -> ruleMatch.markAsCorrect,
-    "matchContext" -> ruleMatch.matchContext
+    "matchContext" -> ruleMatch.matchContext,
+    "matcherId" -> ruleMatch.matcherId
   ))
 }
 
@@ -52,5 +53,5 @@ case class RuleMatch(rule: BaseRule,
                      suggestions: List[Suggestion] = List.empty,
                      replacement: Option[Suggestion] = None,
                      markAsCorrect: Boolean = false,
-                     matchContext: String)
-
+                     matchContext: String,
+                     matcherId: String)

--- a/app/services/MatcherPool.scala
+++ b/app/services/MatcherPool.scala
@@ -124,7 +124,7 @@ class MatcherPool(
     * the replaced matcher.
     */
   def addMatcher(category: Category, matcher: Matcher): Option[(Category, Matcher)] = {
-    logger.info(s"New instance of matcher available of id: ${matcher.getId} for category: ${category.id}")
+    logger.info(s"New instance of matcher available of type: ${matcher.getType} for category: ${category.id}")
     matchers.put(category.id, (category, matcher))
   }
 
@@ -142,7 +142,7 @@ class MatcherPool(
 
   def getCurrentCategories: List[(String, Category, Int)] = {
     val matchersAndCategories = matchers.values.map {
-      case (category, matcher) => (matcher.getId, category, matcher.getRules.length)
+      case (category, matcher) => (matcher.getType, category, matcher.getRules.length)
     }.toList
     matchersAndCategories
   }
@@ -253,4 +253,3 @@ class MatcherPool(
     eventBus.publish(MatcherPoolJobsCompleteEvent(requestId))
   }
 }
-

--- a/app/utils/Matcher.scala
+++ b/app/utils/Matcher.scala
@@ -7,9 +7,13 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
 import model.Category
 
+trait MatcherCompanion {
+  def getType(): String
+}
+
 trait Matcher {
   def check(request: MatcherRequest)(implicit ec: ExecutionContext): Future[List[RuleMatch]]
-  def getType(): String
   def getRules(): List[BaseRule]
   def getCategory(): Category
+  def getType(): String
 }

--- a/app/utils/Matcher.scala
+++ b/app/utils/Matcher.scala
@@ -9,7 +9,7 @@ import model.Category
 
 trait Matcher {
   def check(request: MatcherRequest)(implicit ec: ExecutionContext): Future[List[RuleMatch]]
-  def getId(): String
+  def getType(): String
   def getRules(): List[BaseRule]
   def getCategory(): Category
 }

--- a/rule-audit-client/src/redux/modules/searchMatches/__tests__/fixtures.ts
+++ b/rule-audit-client/src/redux/modules/searchMatches/__tests__/fixtures.ts
@@ -36,7 +36,7 @@ export const createCapiArticle = (articleId: string) => ({
 
 export const createTyperighterResponse = (noOfMatches = 0) => ({
   type: "VALIDATOR_RESPONSE",
-  categoryIds: ["regex-validator"],
+  categoryIds: ["regex"],
   blocks: [
     {
       id: "0-from:1-to:427",

--- a/test/scala/matchers/RegexMatcherTest.scala
+++ b/test/scala/matchers/RegexMatcherTest.scala
@@ -35,7 +35,8 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     shortMessage = Some(rule.description),
     suggestions = rule.suggestions,
     replacement = replacement.map(TextSuggestion(_)),
-    matchContext = matchText
+    matchContext = matchText,
+    matcherType = RegexMatcher.getType()
   )
 
 

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -121,7 +121,8 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
           toPos = to,
           matchedText = "placeholder text",
           message = message,
-          matchContext = "[placeholder text]"
+          matchContext = "[placeholder text]",
+          matcherType = "regex"
         )
     }
   }

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -24,7 +24,8 @@ import scala.concurrent.Future
 class MockMatcher(id: Int) extends Matcher {
   private var currentWork: Option[Promise[List[RuleMatch]]] = None
   private var currentResponses:  Option[List[RuleMatch]] = None
-  def getId = s"mock-matcher-$id"
+
+  def getType = s"mock-matcher-$id"
   def getCategory = Category(s"mock-category-$id", "Example category", "puce")
   def getRules = List.empty
 
@@ -62,7 +63,7 @@ class MockMatcher(id: Int) extends Matcher {
 }
 
 class MockMatcherThatThrows(e: Throwable) extends Matcher {
-  def getId = s"mock-matcher-that-throws"
+  def getType = s"mock-matcher-that-throws"
   def getCategory = Category("example-category", "Example category", "puce")
   def getRules = List.empty
 


### PR DESCRIPTION
Co-authored-by: Jonathon Herbert <jonathon.herbert@guardian.co.uk>

## What does this change?
At the moment, our rules don't include the name of their matcher. This will be useful in determining whether rules from different matchers have different telemetry profiles.

This PR adds the matcher type to the match that's produced to pass it to the client as a part of the response. We then pass the matcher type to the telemetry data in `prosemirror-typerighter` [in this PR](https://github.com/guardian/prosemirror-typerighter/pull/139).

## How to test
Run the branch locally along with the client (including cookie from Composer). Run 'Check document' and see the `matcherType` in the responses.

## How can we measure success?
We're able to determine which matcher produced a match in the response.
