### PR TITLE
Add the row id to the rule error message on refresh

### DIFF
--- a/app/rules/SheetsRuleManager.scala
+++ b/app/rules/SheetsRuleManager.scala
@@ -108,11 +108,12 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String, matcherP
       val ruleType = row(PatternRuleCols.Type)
       val maybeIgnore = row.lift(PatternRuleCols.ShouldIgnore)
       val maybeId = row.lift(PatternRuleCols.Id).asInstanceOf[Option[String]]
+      val rowNumber = index + 1
 
       (maybeId, maybeIgnore, ruleType) match {
         case (_, Some("TRUE"), _) => Success(None)
-        case (None, _, _) => Failure(new Exception(s"no id for rule"))
-        case (Some(id), _, _) if id.length == 0 => Failure(new Exception(s"empty id for rule"))
+        case (None, _, _) => Failure(new Exception(s"no id for rule (row: ${rowNumber})"))
+        case (Some(id), _, _) if id.length == 0 => Failure(new Exception(s"empty id for rule (row: ${rowNumber})"))
         case (Some(id), _, "regex") => Success(Some(getRegexRule(
             id,
             row(PatternRuleCols.Pattern).asInstanceOf[String],
@@ -121,7 +122,7 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String, matcherP
             row(PatternRuleCols.Category).asInstanceOf[String],
             row.lift(PatternRuleCols.Description).asInstanceOf[Option[String]]
           )))
-        case (Some(id), _, ruleType) => Failure(new Exception(s"Rule type ${ruleType} for rule with id ${id} not supported"))
+        case (Some(id), _, ruleType) => Failure(new Exception(s"Rule type ${ruleType} for rule with id ${id} not supported (row: ${rowNumber})"))
       }
 
     } catch {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds the row id to the error messages produced when refreshing the rule set. This should make it easier to identify rules causing issues.

Before:
![image](https://user-images.githubusercontent.com/4633246/94412599-e03da280-0171-11eb-8ebb-716ea60b4954.png)

After:
![image](https://user-images.githubusercontent.com/4633246/94412725-0a8f6000-0172-11eb-951a-4542b6019c6f.png)

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Introduce an issue to the CODE ruleset, refresh the rules, observe the row with an issue is identified in the error message
