### PR TITLE
Add LanguageTool rules from our rules sheet

### DIFF
--- a/app/matchers/LanguageToolMatcher.scala
+++ b/app/matchers/LanguageToolMatcher.scala
@@ -2,7 +2,7 @@ package matchers
 
 import java.io.File
 
-import model.{LTRule, RuleMatch}
+import model.{LTRule, LTRuleXML, RuleMatch}
 import org.languagetool._
 import org.languagetool.rules.spelling.morfologik.suggestions_ordering.SuggestionsOrdererConfig
 import org.languagetool.rules.{CategoryId, Rule => LanguageToolRule}
@@ -13,12 +13,19 @@ import utils.{Matcher, MatcherCompanion}
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import model.Category
+import org.languagetool.rules.patterns.PatternRuleLoader
+import org.languagetool.rules.patterns.PatternRule
+import org.languagetool.rules.patterns.AbstractPatternRule
+import scala.xml.XML
+import scala.util.Try
+import scala.util.Success
+import scala.util.Failure
 
 class LanguageToolFactory(
                            maybeLanguageModelDir: Option[File],
                            useLanguageModelRules: Boolean = false) extends Logging {
 
-  def createInstance(category: Category, rules: List[LTRule], defaultRuleIds: List[String] = Nil)(implicit ec: ExecutionContext): (Matcher, List[String]) = {
+  def createInstance(category: Category, ruleXMLs: List[LTRuleXML], defaultRuleIds: List[String] = Nil)(implicit ec: ExecutionContext): (Matcher, List[String]) = {
     val language: Language = Languages.getLanguageForShortCode("en")
     val cache: ResultCache = new ResultCache(10000)
     val userConfig: UserConfig = new UserConfig()
@@ -30,6 +37,8 @@ class LanguageToolFactory(
       if (useLanguageModelRules) instance.activateLanguageModelRules(languageModel)
     }
 
+    logger.info(s"Adding ${ruleXMLs.size} rules and enabling ${defaultRuleIds.size} default rules to matcher instance ${category}")
+
     // Disable all default rules, apart from those we'd explicitly like
     instance.getAllRules().asScala.foreach { rule =>
       if (!defaultRuleIds.contains(rule.getId())) {
@@ -37,20 +46,44 @@ class LanguageToolFactory(
       }
     }
 
-    logger.info(s"Adding ${rules.size} rules and enabling ${defaultRuleIds.size} default rules to matcher instance ${category}")
-    val ruleIngestionErrors = rules.flatMap { rule =>
-      try {
-        instance.addRule(LTRule.toLT(rule))
-        None
-      } catch {
-        case e: Throwable => {
-          Some(s"LanguageTool could not parse rule with id ${rule.id} and description ${rule.description}. The message was: ${e.getMessage}")
-        }
+    // Add custom rules
+    val maybeRuleErrors = getRulesFromXML(ruleXMLs) match {
+      case Success(rules) => {
+        rules.map { rule => Try(instance.addRule(rule)) }
+      }
+      case Failure(e) => List(Failure(e))
+    }
+    val ruleErrors = maybeRuleErrors.flatMap {
+      case Success(_) => None
+      case Failure(e) => {
+        logger.error(e.getMessage(), e)
+        Some(e.getMessage())
       }
     }
+
     instance.enableRuleCategory(new CategoryId(category.id))
 
-    (new LanguageToolMatcher(category, instance), ruleIngestionErrors)
+    (new LanguageToolMatcher(category, instance), ruleErrors)
+  }
+
+  private def getRulesFromXML(rules: List[LTRuleXML]): Try[List[AbstractPatternRule]] = {
+    val loader = new PatternRuleLoader()
+    getXMLStreamFromLTRules(rules) flatMap {
+      xmlStream => Try(loader.getRules(xmlStream, "languagetool-generated-xml").asScala.toList)
+    }
+  }
+
+  private def getXMLStreamFromLTRules(rules: List[LTRuleXML]): Try[java.io.ByteArrayInputStream] = {
+    Try {
+      val rulesXml = rules.map(rule =>
+        <rule id={rule.id} name={rule.description}>
+          {XML.loadString(rule.xml)}
+        </rule>
+      )
+      val ruleXml = <rules>{rulesXml}</rules>
+      val bytes = rulesXml.toString.getBytes(java.nio.charset.StandardCharsets.UTF_8.name)
+      new java.io.ByteArrayInputStream(bytes)
+    }
   }
 }
 

--- a/app/model/BaseRule.scala
+++ b/app/model/BaseRule.scala
@@ -69,7 +69,27 @@ case class RegexRule(
 }
 
 /**
-  * The application's representation of a LanguageTool PatternRule.
+  * The application's representation of a LanguageTool PatternRule as expressed
+  * in XML. Consumed directly by the LanguageToolMatcher to produce a rule.
+  */
+case class LTRuleXML(
+  id: String,
+  xml: String,
+  category: Category,
+  description: String
+) extends BaseRule {
+  val suggestions = List.empty
+  val replacement: Option[TextSuggestion] = None
+}
+
+object LTRuleXML {
+  implicit val writes: Writes[LTRuleXML] = Json.writes[LTRuleXML]
+  implicit val reads: Reads[LTRuleXML] = Json.reads[LTRuleXML]
+}
+
+/**
+  * The application's representation of a LanguageTool PatternRule. Used to
+  * (lossily) present a LanguageTool PatternRule in a UI.
   */
 case class LTRule(id: String,
                   category: Category,

--- a/app/model/Category.scala
+++ b/app/model/Category.scala
@@ -3,20 +3,18 @@ package model
 import org.languagetool.rules.{CategoryId, Category => LTCategory}
 import play.api.libs.json.{Json, Writes, Reads}
 
-case class Category(id: String, name: String, colour: String)
+case class Category(id: String, name: String)
 
 /**
   * The application's representation of a LanguageTool Category.
-  *
-  * We use tabName as a temporary place to store colour information.
   */
 object Category {
   def fromLT(lt: LTCategory): Category = {
-    Category(lt.getId.toString, lt.getName, lt.getTabName)
+    Category(lt.getId.toString, lt.getName)
   }
 
   def toLT(category: Category): LTCategory = {
-    new LTCategory(new CategoryId(category.id), category.name, LTCategory.Location.EXTERNAL, true, category.colour)
+    new LTCategory(new CategoryId(category.id), category.name, LTCategory.Location.EXTERNAL, true)
   }
 
   implicit val writes: Writes[Category] = Json.writes[Category]

--- a/app/model/PatternToken.scala
+++ b/app/model/PatternToken.scala
@@ -4,7 +4,7 @@ import org.languagetool.rules.patterns.{PatternToken => LTPatternToken}
 import play.api.libs.json.{Json, Reads, Writes}
 
 /**
-  * The application's representation of a LanguageTool PatternToken.
+  * The application's representation of a LanguageTool PatternToken, for display purposes only.
   */
 case class PatternToken(
                        token: String,

--- a/app/rules/SheetsRuleManager.scala
+++ b/app/rules/SheetsRuleManager.scala
@@ -122,11 +122,11 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String, matcherP
             row(PatternRuleCols.Category).asInstanceOf[String],
             row.lift(PatternRuleCols.Description).asInstanceOf[Option[String]]
           )))
-        case (Some(id), _, "lt") => Success(Some(getLTPatternRule(
+        case (Some(id), _, "lt") => Success(Some(getLTRuleXML(
             id,
             row(PatternRuleCols.Pattern).asInstanceOf[String],
-            row(PatternRuleCols.Suggestion).asInstanceOf[String],
-            row(PatternRuleCols.Category).asInstanceOf[String]
+            row(PatternRuleCols.Category).asInstanceOf[String],
+            row(PatternRuleCols.Description).asInstanceOf[String],
           )))
         case (Some(id), _, ruleType) => Failure(new Exception(s"Rule type ${ruleType} for rule with id ${id} not supported"))
       }
@@ -152,7 +152,7 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String, matcherP
       regex = pattern.r,
     )
 
-  private def getLTPatternRule(
+  private def getLTRuleXML(
     id: String,
     pattern: String,
     category: String,

--- a/app/rules/SheetsRuleManager.scala
+++ b/app/rules/SheetsRuleManager.scala
@@ -142,7 +142,7 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String, matcherP
   ) = {
     RegexRule(
       id = id,
-      category = Category(category, category, colour),
+      category = Category(category, category),
       description = description.getOrElse(""),
       replacement = if (suggestion.isEmpty) None else Some(TextSuggestion(suggestion)),
       regex = pattern.r,

--- a/app/rules/SheetsRuleManager.scala
+++ b/app/rules/SheetsRuleManager.scala
@@ -157,7 +157,9 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String, matcherP
     pattern: String,
     category: String,
     description: String
-  ) = LTRuleXML(id, pattern, Category(category, category), description)
+  ) = {
+    LTRuleXML(id, pattern, Category(category, category), description)
+  }
 
   private def getLTRuleFromRow(row: List[Any], index: Int): Try[Option[String]] = {
      try {

--- a/app/services/RuleProvisionerService.scala
+++ b/app/services/RuleProvisionerService.scala
@@ -43,7 +43,7 @@ class RuleProvisionerService(
       }
     }
 
-    val category = new Category("languagetool-default", "Default LanguageTool rules", "puce")
+    val category = new Category("languagetool-default", "Default LanguageTool rules")
     val (matcher, errors) = languageToolFactory.createInstance(category, Nil, ruleResource.ltDefaultRuleIds)
     matcherPool.addMatcher(matcher)
 

--- a/app/services/RuleProvisionerService.scala
+++ b/app/services/RuleProvisionerService.scala
@@ -12,6 +12,7 @@ import model.{RegexRule, BaseRule, Category, RuleResource}
 import rules.BucketRuleManager
 import matchers.LanguageToolFactory
 import model.LTRule
+import model.LTRuleXML
 
 class RuleProvisionerService(
   bucketRuleManager: BucketRuleManager,
@@ -35,7 +36,7 @@ class RuleProvisionerService(
           matcherPool.addMatcher(regexMatcher)
         }
 
-        val ltRules = rules.collect { case r: LTRule => r }
+        val ltRules = rules.collect { case r: LTRuleXML => r }
         if (ltRules.size > 0) {
           val (ltMatcher, _) = languageToolFactory.createInstance(category, ltRules)
           matcherPool.addMatcher(ltMatcher)

--- a/app/views/rules.scala.html
+++ b/app/views/rules.scala.html
@@ -43,9 +43,6 @@
                 @for((handler, category, ruleCount) <- categories) {
                     <tr>
                         <td>
-                          <span class="badge" style="background-color: #@category.colour; color: white">
-                              &nbsp;
-                          </span>
                           @category.id
                         </td>
                         <td>@category.name</td>

--- a/app/views/rules.scala.html
+++ b/app/views/rules.scala.html
@@ -1,5 +1,6 @@
 @import model.BaseRule
 @import model.RegexRule
+@import model.LTRule
 @import model.Category
 @import helper._
 
@@ -58,16 +59,22 @@
             <table class="table">
                 <thead>
                     <tr>
+                        <th scope="col">Type</th>
                         <th scope="col">ID</th>
                         <th scope="col">Category</th>
                         <th scope="col">Match</th>
-                        <th scope="col">Replacement</th>
                         <th scope="col">Description</th>
                     </tr>
                 </thead>
                 <tbody>
                 @for(rule <- rules) {
                     <tr>
+                        <td>@rule match {
+                          case r: RegexRule => { regex }
+                          case r: LTRule => { languagetool }
+                          case _ => { unknown }
+                        }
+                        </td>
                         <td>
                           @rule.id
                         </td>
@@ -80,9 +87,6 @@
                           }
                           case _ => { None }
                         }</td>
-                        <td>@if(rule.replacement.nonEmpty) {
-                            @rule.replacement.get.text
-                        } else { None }</td>
                         <td>@if(rule.description.nonEmpty) {
                             @rule.description
                         } else { None }</td>

--- a/test/resources/logback.xml
+++ b/test/resources/logback.xml
@@ -17,13 +17,13 @@
 	<!-- uncomment and set to TRACE to log all HTTP requests -->
 	<!--<logger name="io.gatling.http.engine.response" level="TRACE" />-->
 
-	<!--<root level="WARN">-->
-		<!--<appender-ref ref="CONSOLE" />-->
-	<!--</root>-->
-	<!--<root level="TRACE">-->
-		<!--<appender-ref ref="FILE" />-->
-	<!--</root>-->
-	<!--<root level="DEBUG">-->
-		<!--<appender-ref ref="FILE" />-->
-	<!--</root>-->
+	<root level="WARN">-->
+		<appender-ref ref="CONSOLE" />
+	</root>
+	<root level="TRACE">
+		<appender-ref ref="FILE" />
+	</root>
+	<root level="DEBUG">
+		<appender-ref ref="FILE" />
+	</root>
 </configuration>

--- a/test/scala/matchers/LanguageToolMatcherTest.scala
+++ b/test/scala/matchers/LanguageToolMatcherTest.scala
@@ -36,11 +36,19 @@ class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
     instance.getRules().map(_.id) shouldBe List("FEWER_LESS", "FEWER_LESS", "DOES_YOU", "DOES_YOU")
   }
 
-  "getInstance" should "include the rules we provide via LTRules via `rules`" in {
+  // "getInstance" should "include the rules we provide via LTRules via `rules`" in {
+  //   val ltFactory = new LanguageToolFactory(None)
+  //   val exampleRules = List(exampleRule)
+  //   val (instance, _) = ltFactory.createInstance(exampleCategory, exampleRules, Nil)
+  //   instance.getRules().map(_.id) shouldBe List("EXAMPLE_RULE")
+  // }
+
+  "getInstance" should "handle cases where no novel rules are available" in {
     val ltFactory = new LanguageToolFactory(None)
     val exampleRules = List(exampleRule)
-    val (instance, _) = ltFactory.createInstance(exampleCategory, exampleRules, Nil)
-    instance.getRules().map(_.id) shouldBe List("EXAMPLE_RULE")
+    val (instance, errors) = ltFactory.createInstance(exampleCategory, List.empty, Nil)
+    instance.getRules().map(_.id) shouldBe List.empty
+    errors shouldBe List.empty
   }
 
   "check" should "apply LanguageTool rules" in {

--- a/test/scala/matchers/LanguageToolMatcherTest.scala
+++ b/test/scala/matchers/LanguageToolMatcherTest.scala
@@ -8,50 +8,63 @@ import services.MatcherRequest
 
 class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
   val exampleCategory = Category("EXAMPLE_CAT", "Example Category")
-  val exampleRule =  LTRule(
+  val exampleRuleXml = """
+    <pattern>
+        <token postag="CD" />
+        <token postag="NNS">
+            <exception regexp="yes">centuries|decades|years|months|days|hours|minutes|seconds|stars</exception>
+        </token>
+        <token>or</token>
+        <marker>
+            <token>less</token>
+        </marker>
+    </pattern>
+    <message>Did you mean <suggestion>fewer</suggestion>? The noun \2 is countable.</message>
+    <short>Grammatical error</short>
+    <example correction="fewer">Ten items or <marker>less</marker></example>
+    <example>It typically takes 30 seconds or <marker>less</marker></example>
+    <example>I would only give that hotel 3 stars or <marker>less</marker>.</example>
+  """
+  val exampleRule =  LTRuleXML(
     "EXAMPLE_RULE",
+    exampleRuleXml,
     exampleCategory,
-    None,
-    None,
-    None,
-    "Example description",
-    "Example message",
-    None,
-    Nil
+    "An example rule with custom XML"
   )
 
   "getInstance" should "provide no rules by default" in {
     val ltFactory = new LanguageToolFactory(None)
-    val (instance, _) = ltFactory.createInstance(exampleCategory, Nil, Nil)
+    val (instance, _) = ltFactory.createInstance(exampleCategory, Nil)
     instance.getRules() shouldBe Nil
   }
 
   "getInstance" should "include the rules we provide by id via `defaultRules`" in {
     val ltFactory = new LanguageToolFactory(None)
     val defaultRules = List("FEWER_LESS", "DOES_YOU")
-    val (instance, _) = ltFactory.createInstance(exampleCategory, Nil, defaultRules)
+    val (instance, errors) = ltFactory.createInstance(exampleCategory, Nil, defaultRules)
     // These rule ids map to rule groups, which contain two rules each.
     // This is weird, as we'd assume ids to be unique. We may want to alter
     // this to reflect rule groupings to ensure id uniqueness, for example.
+    errors shouldBe Nil
     instance.getRules().map(_.id) shouldBe List("FEWER_LESS", "FEWER_LESS", "DOES_YOU", "DOES_YOU")
   }
 
-  // "getInstance" should "include the rules we provide via LTRules via `rules`" in {
-  //   val ltFactory = new LanguageToolFactory(None)
-  //   val exampleRules = List(exampleRule)
-  //   val (instance, _) = ltFactory.createInstance(exampleCategory, exampleRules, Nil)
-  //   instance.getRules().map(_.id) shouldBe List("EXAMPLE_RULE")
-  // }
+  "getInstance" should "include the XML-based rules we provide via `rules`" in {
+    val ltFactory = new LanguageToolFactory(None)
+    val exampleRules = List(exampleRule)
+    val (instance, errors) = ltFactory.createInstance(exampleCategory, exampleRules)
+    errors shouldBe Nil
+    instance.getRules().map(_.id) shouldBe List("EXAMPLE_RULE")
+  }
 
   "getInstance" should "handle cases where no novel rules are available" in {
     val ltFactory = new LanguageToolFactory(None)
-    val exampleRules = List(exampleRule)
-    val (instance, errors) = ltFactory.createInstance(exampleCategory, List.empty, Nil)
+    val (instance, errors) = ltFactory.createInstance(exampleCategory, List.empty)
     instance.getRules().map(_.id) shouldBe List.empty
     errors shouldBe List.empty
   }
 
-  "check" should "apply LanguageTool rules" in {
+  "check" should "apply LanguageTool default rules" in {
     val ltFactory = new LanguageToolFactory(None)
     val defaultRules = List("FEWER_LESS")
     val (instance, _) = ltFactory.createInstance(exampleCategory, Nil, defaultRules)
@@ -59,6 +72,19 @@ class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
 
     val eventuallyMatches = instance.check(request)
     val expectedMatchMessages = List("Did you mean <suggestion>fewer</suggestion>? The noun tests is countable.")
+    eventuallyMatches map { matches =>
+      matches.map(_.message) shouldBe expectedMatchMessages
+    }
+  }
+
+  "check" should "apply LanguageTool custom rules" in {
+    val ltFactory = new LanguageToolFactory(None)
+    val exampleRules = List(exampleRule)
+    val (instance, _) = ltFactory.createInstance(exampleCategory, List(exampleRule))
+    val request = MatcherRequest(List(TextBlock("id-1", "Three mistakes or less", 0, 29)))
+
+    val eventuallyMatches = instance.check(request)
+    val expectedMatchMessages = List("Did you mean <suggestion>fewer</suggestion>? The noun mistakes is countable.")
     eventuallyMatches map { matches =>
       matches.map(_.message) shouldBe expectedMatchMessages
     }

--- a/test/scala/matchers/LanguageToolMatcherTest.scala
+++ b/test/scala/matchers/LanguageToolMatcherTest.scala
@@ -7,7 +7,7 @@ import com.softwaremill.diffx.scalatest.DiffMatcher._
 import services.MatcherRequest
 
 class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
-  val exampleCategory = Category("EXAMPLE_CAT", "Example Category", "puce")
+  val exampleCategory = Category("EXAMPLE_CAT", "Example Category")
   val exampleRule =  LTRule(
     "EXAMPLE_RULE",
     exampleCategory,

--- a/test/scala/matchers/RegexMatcherTest.scala
+++ b/test/scala/matchers/RegexMatcherTest.scala
@@ -12,14 +12,14 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     textsToMatch.zipWithIndex.map { case (text, index) =>
       RegexRule(
         id = s"example-rule-$index",
-        category = Category("new-category", "New Category", "puce"),
+        category = Category("new-category", "New Category"),
         description = s"Example rule $index",
         suggestions = List(TextSuggestion(s"Suggestion for rule $index")),
         regex = text.r
       )
     }
   }
-  val exampleCategory = Category("example-category", "Example category", "puce")
+  val exampleCategory = Category("example-category", "Example category")
   val exampleRule = createRules(List("text"))(0)
 
   val regexValidator = new RegexMatcher(exampleCategory, List(exampleRule))
@@ -119,7 +119,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
   "check" should "use substitions when generating replacements" in {
     val rule = RegexRule(
       id = s"example-rule",
-      category = Category("new-category", "New Category", "puce"),
+      category = Category("new-category", "New Category"),
       description = s"Example rule",
       replacement = Some(TextSuggestion("tea$1")),
       regex = "\\btea-? ?(shop|bag|leaf|leaves|pot)".r
@@ -141,7 +141,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
    "check" should "handle multiple substitions" in {
     val rule = RegexRule(
       id = s"example-rule",
-      category = Category("new-category", "New Category", "puce"),
+      category = Category("new-category", "New Category"),
       description = s"Example rule",
       replacement = Some(TextSuggestion("$1-$2-long")),
       regex = "\\b(one|two|three|four|five|six|seven|eight|nine|\\d)-? (year|day|month|week|mile)-? long".r

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -26,7 +26,7 @@ class MockMatcher(id: Int) extends Matcher {
   private var maybeResponse: Option[Either[String, List[RuleMatch]]] = None
 
   def getType = s"mock-matcher-$id"
-  def getCategory = Category(s"mock-category-$id", "Mock category", "puce")
+  def getCategory = Category(s"mock-category-$id", "Mock category")
   def getRules = List.empty
 
   def check(request: MatcherRequest)(implicit ec: ExecutionContext) = {
@@ -61,7 +61,7 @@ class MockMatcher(id: Int) extends Matcher {
 
 class MockMatcherThatThrows(e: Throwable) extends Matcher {
   def getType = s"mock-matcher-that-throws"
-  def getCategory = Category("mock-category", "Mock category", "puce")
+  def getCategory = Category("mock-category", "Mock category")
   def getRules = List.empty
 
   def check(request: MatcherRequest)(implicit ec: ExecutionContext) = {
@@ -92,7 +92,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     }.toList
   }
 
-  private def getCategory(id: Int) = Category(s"mock-category-$id", "Mock category", "puce")
+  private def getCategory(id: Int) = Category(s"mock-category-$id", "Mock category")
 
   private def getPool(
     matchers: List[Matcher],

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -255,12 +255,14 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
 
   it should "correctly check multiple categories for a single job" in {
     val matchers = getMatchers(2)
-    val pool = getPool(matchers)
-    val futureResult = pool.check(getCheck(text = "Example text"))
     val firstMatch = getResponses(List((0, 5, "test-response")), 0)
     val secondMatch = getResponses(List((6, 10, "test-response")), 1)
     matchers(0).completeWith(firstMatch)
     matchers(1).completeWith(secondMatch)
+
+    val pool = getPool(matchers)
+    val futureResult = pool.check(getCheck(text = "Example text"))
+
     futureResult.map { result =>
       result.contains(firstMatch.head) shouldBe true
       result.contains(secondMatch.head) shouldBe true


### PR DESCRIPTION
**NB:** please review and merge #81 first, which'll slim down the diff a bit!

## What does this change?

[Trello card](https://trello.com/c/jG3f0kCp/459-add-custom-languagetool-rules-to-our-google-sheet)

Adds the ability to add LanguageTool rules from our rules sheet. For an example of the way these rules are constructed within LanguageTool directly, see e.g. [this xml](https://raw.githubusercontent.com/languagetool-org/languagetool/master/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml).

These rules look much the same as the regex rules. The key differences:
- the 'pattern' section accepts an XML description of everything that's possible to add to a LanguageTool rule definition, within the `<rule / >` tag.
- the 'replacement' field isn't used – the XML takes care of that.

## How to test

Add a new rule to the CODE sheet and test this, either locally or in CODE.

<details><summary>An example rule, taken from the LT defaults.</summary>

Rule type | Pattern | Replacement? | Name | Category |   | Description | Tags (separate with commas) | Ignore? | Notes | ID
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- 
lt | ```<pattern> <token postag="CD"/> <token postag="NNS"><exception regexp="yes">centuries\|decades\|years\|months\|days\|hours\|minutes\|seconds\|stars</exception></token> <token>or</token> <marker> <token>less</token> </marker> </pattern> <message>Did you mean <suggestion>fewer</suggestion>? The noun \2 is countable.</message> <short>Grammatical error</short> <example correction="fewer">Ten items or <marker>less</marker></example> <example>It typically takes 30 seconds or <marker>less</marker></example> <example>I would only give that hotel 3 stars or <marker>less</marker>.</example>``` |   | Fewer / less | Grammar |   | An example LT rule to get us started. | Grammar | FALSE |   | FEWER_LESS_CUSTOM 

</details>

This rule should match the `less` part of the phrase, `Three mistakes or less`.

Bear in mind that adding this rule in the CODE sheet will break other users of the CODE sheet, which includes DEV! I found this out to my cost whilst testing 😬 – it's not catastrophic, but worth letting other devs know what you're up to.

## How can we measure success?

We can add LanguageTool custom rules via that spreadsheet. 

They report correctly in the UI, including descriptions, ranges, and suggestions.

## Notes

WRT

> the 'pattern' section accepts an XML description of everything that's possible to add to a LanguageTool rule definition, within the `<rule / >` tag.

this may prove to be too restrictive over time, as it means user defined rules don't get access to the rule attributes, or any tags that might be adjacent or contain them, e.g.`rulegroup`. The advantage of this approach is that we can keep the ID, description properties etc. in the sheet, which makes the rules easier to audit at a glance, but we can change tack if it becomes clear our rule authors require more flexibility.

