### PR TITLE
Remove colour from the Category model – we don't need it any more

### DIFF
--- a/app/model/Category.scala
+++ b/app/model/Category.scala
@@ -3,20 +3,18 @@ package model
 import org.languagetool.rules.{CategoryId, Category => LTCategory}
 import play.api.libs.json.{Json, Writes, Reads}
 
-case class Category(id: String, name: String, colour: String)
+case class Category(id: String, name: String)
 
 /**
   * The application's representation of a LanguageTool Category.
-  *
-  * We use tabName as a temporary place to store colour information.
   */
 object Category {
   def fromLT(lt: LTCategory): Category = {
-    Category(lt.getId.toString, lt.getName, lt.getTabName)
+    Category(lt.getId.toString, lt.getName)
   }
 
   def toLT(category: Category): LTCategory = {
-    new LTCategory(new CategoryId(category.id), category.name, LTCategory.Location.EXTERNAL, true, category.colour)
+    new LTCategory(new CategoryId(category.id), category.name, LTCategory.Location.EXTERNAL, true)
   }
 
   implicit val writes: Writes[Category] = Json.writes[Category]

--- a/app/rules/SheetsRuleManager.scala
+++ b/app/rules/SheetsRuleManager.scala
@@ -142,7 +142,7 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String, matcherP
   ) = {
     RegexRule(
       id = id,
-      category = Category(category, category, colour),
+      category = Category(category, category),
       description = description.getOrElse(""),
       replacement = if (suggestion.isEmpty) None else Some(TextSuggestion(suggestion)),
       regex = pattern.r,

--- a/app/services/RuleProvisionerService.scala
+++ b/app/services/RuleProvisionerService.scala
@@ -43,7 +43,7 @@ class RuleProvisionerService(
       }
     }
 
-    val category = new Category("languagetool-default", "Default LanguageTool rules", "puce")
+    val category = new Category("languagetool-default", "Default LanguageTool rules")
     val (matcher, errors) = languageToolFactory.createInstance(category, Nil, ruleResource.ltDefaultRuleIds)
     matcherPool.addMatcher(matcher)
 

--- a/app/views/rules.scala.html
+++ b/app/views/rules.scala.html
@@ -43,9 +43,6 @@
                 @for((handler, category, ruleCount) <- categories) {
                     <tr>
                         <td>
-                          <span class="badge" style="background-color: #@category.colour; color: white">
-                              &nbsp;
-                          </span>
                           @category.id
                         </td>
                         <td>@category.name</td>

--- a/test/scala/matchers/LanguageToolMatcherTest.scala
+++ b/test/scala/matchers/LanguageToolMatcherTest.scala
@@ -7,7 +7,7 @@ import com.softwaremill.diffx.scalatest.DiffMatcher._
 import services.MatcherRequest
 
 class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
-  val exampleCategory = Category("EXAMPLE_CAT", "Example Category", "puce")
+  val exampleCategory = Category("EXAMPLE_CAT", "Example Category")
   val exampleRule =  LTRule(
     "EXAMPLE_RULE",
     exampleCategory,

--- a/test/scala/matchers/RegexMatcherTest.scala
+++ b/test/scala/matchers/RegexMatcherTest.scala
@@ -12,14 +12,14 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     textsToMatch.zipWithIndex.map { case (text, index) =>
       RegexRule(
         id = s"example-rule-$index",
-        category = Category("new-category", "New Category", "puce"),
+        category = Category("new-category", "New Category"),
         description = s"Example rule $index",
         suggestions = List(TextSuggestion(s"Suggestion for rule $index")),
         regex = text.r
       )
     }
   }
-  val exampleCategory = Category("example-category", "Example category", "puce")
+  val exampleCategory = Category("example-category", "Example category")
   val exampleRule = createRules(List("text"))(0)
 
   val regexValidator = new RegexMatcher(exampleCategory, List(exampleRule))
@@ -119,7 +119,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
   "check" should "use substitions when generating replacements" in {
     val rule = RegexRule(
       id = s"example-rule",
-      category = Category("new-category", "New Category", "puce"),
+      category = Category("new-category", "New Category"),
       description = s"Example rule",
       replacement = Some(TextSuggestion("tea$1")),
       regex = "\\btea-? ?(shop|bag|leaf|leaves|pot)".r
@@ -141,7 +141,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
    "check" should "handle multiple substitions" in {
     val rule = RegexRule(
       id = s"example-rule",
-      category = Category("new-category", "New Category", "puce"),
+      category = Category("new-category", "New Category"),
       description = s"Example rule",
       replacement = Some(TextSuggestion("$1-$2-long")),
       regex = "\\b(one|two|three|four|five|six|seven|eight|nine|\\d)-? (year|day|month|week|mile)-? long".r

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -26,7 +26,7 @@ class MockMatcher(id: Int) extends Matcher {
   private var maybeResponse: Option[Either[String, List[RuleMatch]]] = None
 
   def getType = s"mock-matcher-$id"
-  def getCategory = Category(s"mock-category-$id", "Mock category", "puce")
+  def getCategory = Category(s"mock-category-$id", "Mock category")
   def getRules = List.empty
 
   def check(request: MatcherRequest)(implicit ec: ExecutionContext) = {
@@ -61,7 +61,7 @@ class MockMatcher(id: Int) extends Matcher {
 
 class MockMatcherThatThrows(e: Throwable) extends Matcher {
   def getType = s"mock-matcher-that-throws"
-  def getCategory = Category("mock-category", "Mock category", "puce")
+  def getCategory = Category("mock-category", "Mock category")
   def getRules = List.empty
 
   def check(request: MatcherRequest)(implicit ec: ExecutionContext) = {
@@ -92,7 +92,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     }.toList
   }
 
-  private def getCategory(id: Int) = Category(s"mock-category-$id", "Mock category", "puce")
+  private def getCategory(id: Int) = Category(s"mock-category-$id", "Mock category")
 
   private def getPool(
     matchers: List[Matcher],


### PR DESCRIPTION
## What does this change?

Since we [updated our traffic light model](https://github.com/guardian/prosemirror-typerighter/pull/95), we haven't used our Category colours. Let's remove them. 

## How to test

This is a no-op for our [only known consumer](https://github.com/guardian/prosemirror-typerighter), but in an API response that includes a match, we should no longer see a colour attribute as part of the `category` part of the `rule` definition.

## How can we measure success?

Fewer LOC? 😄 
