### PR TITLE
Removes the buffer property from the getSurroundingText method

### DIFF
--- a/app/model/RuleMatch.scala
+++ b/app/model/RuleMatch.scala
@@ -17,7 +17,7 @@ object RuleMatch {
     // it as a replacement to trigger the 'replacement' behaviour in the client.
     val replacement = if (suggestions.size == 1) Some(suggestions.head) else None
     val matchedText = block.text.substring(lt.getFromPos, lt.getToPos)
-    val (precedingText, subsequentText) = Text.getSurroundingText(block.text, lt.getFromPos, lt.getToPos, 50)
+    val (precedingText, subsequentText) = Text.getSurroundingText(block.text, lt.getFromPos, lt.getToPos)
     RuleMatch(
       rule = LTRule.fromLT(lt.getRule),
       fromPos = lt.getFromPos,

--- a/app/utils/Text.scala
+++ b/app/utils/Text.scala
@@ -1,7 +1,8 @@
 package utils
 
 object Text {
-  def getSurroundingText(text: String, from: Int, to: Int, buffer: Int = 100): (String, String) = {
+  def getSurroundingText(text: String, from: Int, to: Int): (String, String) = {
+    val buffer = 100
     val precedingText = text.substring(scala.math.max(from - buffer, 0), scala.math.max(from, 0))
     val subsequentText = text.substring(scala.math.min(to, text.length), scala.math.min(to + buffer, text.length))
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This is a no-op PR to remove the buffer parameter from the `getSurroundText` method. This change is useful as currently different match types are erroneously returning different length strings. 

The buffer property is no longer useful due to a [change](https://github.com/guardian/typerighter/pull/82) in how match context is provided. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
The Typerighter server should behave as normal.