### PR TITLE
Fixes rule ingestion issue by change how last modified is found

### DIFF
--- a/app/controllers/RulesController.scala
+++ b/app/controllers/RulesController.scala
@@ -23,8 +23,10 @@ class RulesController(
 )(implicit ec: ExecutionContext) extends AbstractController(cc) with PandaAuthentication {
   def refresh = ApiAuthAction { implicit request: Request[AnyContent] =>
     sheetsRuleManager.getRules flatMap { ruleResource =>
-      val maybeRules = bucketRuleManager.putRules(ruleResource).map { lastModified =>
-        (ruleResource, lastModified)
+      val maybeRules = bucketRuleManager.putRules(ruleResource).flatMap { _ =>
+        bucketRuleManager.getRulesLastModified.map { lastModified =>
+          (ruleResource, lastModified)
+        }
       }
       maybeRules.left.map { error => List(error.getMessage) }
     } match {

--- a/app/rules/BucketRuleManager.scala
+++ b/app/rules/BucketRuleManager.scala
@@ -17,7 +17,7 @@ import com.amazonaws.services.s3.model.PutObjectResult
 class BucketRuleManager(s3: AmazonS3, bucketName: String) extends Logging {
     private val RULES_KEY = "rules/typerighter-rules.json"
 
-    def putRules(ruleResource: RuleResource): Either[Exception, PutObjectResult] = {
+    def putRules(ruleResource: RuleResource): Either[Exception, Unit] = {
         val ruleJson = Json.toJson(ruleResource)
         val bytes = ruleJson.toString.getBytes(java.nio.charset.StandardCharsets.UTF_8.name)
 

--- a/app/rules/BucketRuleManager.scala
+++ b/app/rules/BucketRuleManager.scala
@@ -12,11 +12,12 @@ import play.api.libs.json.Reads
 
 import model.{RegexRule, RuleResource}
 import play.api.Logging
+import com.amazonaws.services.s3.model.PutObjectResult
 
 class BucketRuleManager(s3: AmazonS3, bucketName: String) extends Logging {
     private val RULES_KEY = "rules/typerighter-rules.json"
 
-    def putRules(ruleResource: RuleResource): Either[Exception, Date] = {
+    def putRules(ruleResource: RuleResource): Either[Exception, PutObjectResult] = {
         val ruleJson = Json.toJson(ruleResource)
         val bytes = ruleJson.toString.getBytes(java.nio.charset.StandardCharsets.UTF_8.name)
 
@@ -25,8 +26,7 @@ class BucketRuleManager(s3: AmazonS3, bucketName: String) extends Logging {
             val metaData = new ObjectMetadata()
             metaData.setContentLength(bytes.length)
             val putObjectRequest = new PutObjectRequest(bucketName, RULES_KEY, stream, metaData)
-            val result = s3.putObject(putObjectRequest)
-            result.getMetadata.getLastModified
+            s3.putObject(putObjectRequest)
         }
     }
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR fixes an issue found with the rule ingestion process. The issue was caused by the metadata on the `putObjectResult` returning null for the `getLastModifiedDate`. As an alternative the existing method for retrieving the last modified date is used. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Load the TR backend client, refresh the rules, observe the minutely rule check continues to work as expected.
