### PR TITLE
Add performance logging every time we run a matcherPool check

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import scala.collection.JavaConverters._
 import com.gu.pandomainauth.PublicSettings
 import model.{Check, MatcherResponse}
 import play.api.libs.json.{JsValue, Json}
@@ -7,6 +8,8 @@ import play.api.mvc._
 import services.{PandaAuthentication, MatcherPool}
 
 import scala.concurrent.{ExecutionContext, Future}
+import utils.Timer
+import net.logstash.logback.marker.Markers
 
 /**
   * The controller that handles API requests.
@@ -20,19 +23,23 @@ class ApiController(
   def check: Action[JsValue] = ApiAuthAction.async(parse.json) { request =>
     request.body.validate[Check].asEither match {
       case Right(check) =>
-        matcherPool
-          .check(check)
-          .map { matches =>
-            val response = MatcherResponse(
-              matches = matches,
-              blocks = check.blocks,
-              categoryIds = matches.map(_.rule.category.id).toSet
-            )
-            Ok(Json.toJson(response))
-          } recover {
-          case e: Exception =>
-            InternalServerError(Json.obj("error" -> e.getMessage))
+        val markers = check.toMarker
+        markers.add(Markers.appendEntries(Map("userEmail" -> request.user.email).asJava))
+        val eventuallyMatches = Timer.timeAsync("ApiController.check", markers) {
+          matcherPool.check(check)
         }
+
+        eventuallyMatches.map { matches =>
+          val response = MatcherResponse(
+            matches = matches,
+            blocks = check.blocks,
+            categoryIds = matches.map(_.rule.category.id).toSet
+          )
+          Ok(Json.toJson(response))
+        } recover {
+        case e: Exception =>
+          InternalServerError(Json.obj("error" -> e.getMessage))
+      }
       case Left(error) =>
         Future.successful(BadRequest(s"Invalid request: $error"))
     }

--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -23,9 +23,11 @@ class ApiController(
   def check: Action[JsValue] = ApiAuthAction.async(parse.json) { request =>
     request.body.validate[Check].asEither match {
       case Right(check) =>
-        val markers = check.toMarker
-        markers.add(Markers.appendEntries(Map("userEmail" -> request.user.email).asJava))
-        val eventuallyMatches = Timer.timeAsync("ApiController.check", markers) {
+        val checkMarkers = check.toMarker
+        val userMarkers = Markers.appendEntries(Map("userEmail" -> request.user.email).asJava)
+        checkMarkers.add(userMarkers)
+
+        val eventuallyMatches = Timer.timeAsync("ApiController.check", checkMarkers) {
           matcherPool.check(check)
         }
 

--- a/app/services/MatcherPool.scala
+++ b/app/services/MatcherPool.scala
@@ -107,8 +107,6 @@ class MatcherPool(
 
     val eventuallyResponses = jobs.map(offerJobToQueue)
 
-    val totalCharsForCheck = query.blocks.foldLeft(0)((acc, block) => acc + block.text.size)
-
     Future.sequence(eventuallyResponses).map { matchesPerFuture =>
       logger.info(s"Matcher pool query complete")(query.toMarker)
       matchesPerFuture.flatten

--- a/app/services/MatcherPool.scala
+++ b/app/services/MatcherPool.scala
@@ -108,11 +108,10 @@ class MatcherPool(
     val eventuallyResponses = jobs.map(offerJobToQueue)
 
     val totalCharsForCheck = query.blocks.foldLeft(0)((acc, block) => acc + block.text.size)
-    Timer.timeAsync("matcherPool.check", Map("characterCount" -> totalCharsForCheck.toString)) {
-      Future.sequence(eventuallyResponses).map { matchesPerFuture =>
-        logger.info(s"Matcher pool query complete")(query.toMarker)
-        matchesPerFuture.flatten
-      }
+
+    Future.sequence(eventuallyResponses).map { matchesPerFuture =>
+      logger.info(s"Matcher pool query complete")(query.toMarker)
+      matchesPerFuture.flatten
     }
   }
 

--- a/app/utils/Timer.scala
+++ b/app/utils/Timer.scala
@@ -9,7 +9,7 @@ import net.logstash.logback.marker.LogstashMarker
 
 object Timer extends Logging {
   /**
-    * Time a synchronous task and log the results. Warns if the
+    * Time a synchronous task and log the results.
     */
   def time[R](taskName: String, additionalMarkers: LogstashMarker)(block: => R): R = {
     val t0 = System.nanoTime()
@@ -41,7 +41,7 @@ object Timer extends Logging {
     ).asJava)
     markers.add(additionalMarkers)
 
-    val message = s"Task $taskName complete in $durationInMs"
+    val message = s"Task $taskName complete in ${durationInMs}ms"
     logger.info(message)(markers)
   }
 }

--- a/app/utils/Timer.scala
+++ b/app/utils/Timer.scala
@@ -1,0 +1,45 @@
+package utils
+
+import scala.collection.JavaConverters._
+import play.api.Logging
+import net.logstash.logback.marker.Markers
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+
+object Timer extends Logging {
+  /**
+    * Time a synchronous task and log the results. Warns if the
+    */
+  def time[R](taskName: String, additionalMarkers: Map[String, String] = Map.empty[String, String])(block: => R): R = {
+    val t0 = System.nanoTime()
+    val result = block
+    val t1 = System.nanoTime()
+    logTime(taskName, t0, t1, additionalMarkers)
+    result
+  }
+
+  /**
+    * Time an asynchronous task returning a Future, and log the results.
+    */
+  def timeAsync[R](taskName: String, additionalMarkers: Map[String, String] = Map.empty[String, String])(block: => Future[R])(implicit ec: ExecutionContext): Future[R] = {
+    val t0 = System.nanoTime()
+    block.map { result =>
+      val t1 = System.nanoTime()
+      logTime(taskName, t0, t1, additionalMarkers)
+      result
+    }
+  }
+
+  private def logTime(taskName: String, fromInNs: Long, toInNs: Long, additionalMarkers: Map[String, String]) = {
+    val durationInMs = (toInNs - fromInNs) / 1000000
+    val markers = Markers.appendEntries((
+      Map(
+        "taskName" -> taskName,
+        "durationInMs" -> durationInMs
+      ) ++ additionalMarkers
+    ).asJava)
+
+    val message = s"Task $taskName complete in $durationInMs"
+    logger.info(message)(markers)
+  }
+}

--- a/app/utils/Timer.scala
+++ b/app/utils/Timer.scala
@@ -42,6 +42,6 @@ object Timer extends Logging {
     markers.add(additionalMarkers)
 
     val message = s"Task $taskName complete in ${durationInMs}ms"
-    logger.info(message)(markers)
+    logger.debug(message)(markers)
   }
 }


### PR DESCRIPTION
## What does this change?

Adds some logging on the server to give us indexed access to the time it takes to run each request.

We should receive enough information in the context provided in these logs to be able to identify the document, the user concerned, the categories used, and the time it took to run the check.

## How to test

Run a check with this service running in CODE. You should see the relevant metrics appear in the logs.

<img width="928" alt="Screenshot 2020-10-13 at 18 11 32" src="https://user-images.githubusercontent.com/7767575/95893215-8ea33380-0d7f-11eb-8317-1ff65a44821e.png">

We're missing documentIds and categoryIds – the former because we don't yet pass that through to Typerighter on the client, and the latter because we aren't asking for specific categories (yet).

## How can we measure success?

We know whether our tool is performing timely checks, and have enough information to narrow down the users affected when it's not performing as expected.
