### PR TITLE
Change Timer log level to info

### DIFF
--- a/app/utils/Timer.scala
+++ b/app/utils/Timer.scala
@@ -42,6 +42,6 @@ object Timer extends Logging {
     markers.add(additionalMarkers)
 
     val message = s"Task $taskName complete in ${durationInMs}ms"
-    logger.debug(message)(markers)
+    logger.info(message)(markers)
   }
 }


### PR DESCRIPTION
## What does this change?

Changes the timer log level to `info`. `debug` logs aren't sent down the wire without additional configuration, and @sihil makes the case that this isn't really debugging information.

## How to test

Timer data show up in our ELK logs.
