### PR TITLE
Allow rules and rule groups in sheet

### DIFF
--- a/app/matchers/LanguageToolMatcher.scala
+++ b/app/matchers/LanguageToolMatcher.scala
@@ -16,7 +16,7 @@ import model.Category
 import org.languagetool.rules.patterns.PatternRuleLoader
 import org.languagetool.rules.patterns.PatternRule
 import org.languagetool.rules.patterns.AbstractPatternRule
-import scala.xml.XML
+import scala.xml.{XML, MetaData, Attribute, Null, Text}
 import scala.util.Try
 import scala.util.Success
 import scala.util.Failure
@@ -99,10 +99,9 @@ class LanguageToolFactory(
       case (category, rules) =>
         <category id={category.id} name={category.name} type="grammar">
           {rules.map { rule =>
-            <rule id={rule.id} name={rule.description}>
-              {XML.loadString(s"<temp>${rule.xml}</temp>").child}
-            </rule>
-          }}
+              XML.loadString(rule.xml) % Attribute(None, "id", Text(rule.id), Null) % Attribute(None, "name", Text(rule.description), Null)
+            }
+          }
         </category>
     }
 

--- a/test/scala/matchers/LanguageToolMatcherTest.scala
+++ b/test/scala/matchers/LanguageToolMatcherTest.scala
@@ -33,6 +33,53 @@ class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
     exampleCategory,
     "An example rule with custom XML"
   )
+  val exampleRulegroupXml = """
+    <rulegroup id="wrong_id" name="wrong_name" other="other_wrong_thing">
+      <rule>
+          <pattern>
+          <token regexp="yes">(?i)[a-z]+</token>
+          <token spacebefore="no" regexp="yes">…</token>
+          <token spacebefore="no" regexp="yes">(?i)[a-z]+</token>
+        </pattern>
+        <message>Have spaces around ellipses</message>
+        <suggestion><match no="1"/> … <match no="3"/></suggestion>
+        <example>This is important – as far as I know.</example>
+        <example correction="…">This is important<marker>...</marker> as far as I know.</example>
+      </rule> 
+      <rule>
+        <pattern>
+          <token regexp="yes">(January|February|March|April|May|June|July|August|September|October|November|December)</token>
+          <token regexp="yes">(\d\d?)(th|rd|nd)?</token>
+        </pattern>
+        <message>Incorrect date format: <suggestion><match no="2" regexp_match="(\d\d?)(th|rd|nd)?" regexp_replace="$1"/> <match no="1"/></suggestion></message>
+        <example correction="">It happened on <marker>3 November</marker> etc</example>
+      </rule>  
+      <rule>
+        <pattern>
+          <token regexp="yes">the</token>
+          <token regexp="yes">(\d\d?)(th|rd|nd)</token>
+          <token regexp="yes">of</token>
+          <token regexp="yes">(January|February|March|April|May|June|July|August|September|October|November|December)</token>
+        </pattern>
+        <message>Incorrect date format: <suggestion><match no="2" regexp_match="(\d\d?)(th|rd|nd)" regexp_replace="$1"/> <match no="4"/></suggestion></message>
+        <example correction="">It happened on <marker>3 November</marker> etc</example>
+      </rule>
+      <rule>
+        <pattern>
+          <token regexp="yes">(\d\d?)(th|rd|nd)</token>
+          <token regexp="yes">(January|February|March|April|May|June|July|August|September|October|November|December)</token>
+        </pattern>
+        <message>Incorrect date format: <suggestion><match no="1" regexp_match="(\d\d?)(th|rd|nd)" regexp_replace="$1"/> <match no="2"/></suggestion></message>
+        <example correction="">It happened on <marker>3 November</marker> etc</example>
+      </rule>
+  </rulegroup>
+  """
+  val exampleRulegroup =  LTRuleXML(
+    "EXAMPLE_RULEGROUP",
+    exampleRulegroupXml,
+    exampleCategory,
+    "An example rulegroup with custom XML"
+  )
 
   "getInstance" should "provide no rules by default" in {
     val ltFactory = new LanguageToolFactory(None)
@@ -55,6 +102,13 @@ class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
     val exampleRules = List(exampleRule)
     val instance = ltFactory.createInstance(exampleRules).getOrElse(fail)
     instance.getRules().map(_.id) shouldBe List("EXAMPLE_RULE")
+  }
+
+  "getInstance" should "include the XML-based rulegroups we provide via `rules`" in {
+    val ltFactory = new LanguageToolFactory(None)
+    val exampleRulegroups = List(exampleRulegroup)
+    val instance = ltFactory.createInstance(exampleRulegroups).getOrElse(fail)
+    instance.getRules().map(_.id) shouldBe List("EXAMPLE_RULEGROUP", "EXAMPLE_RULEGROUP", "EXAMPLE_RULEGROUP", "EXAMPLE_RULEGROUP")
   }
 
   "getInstance" should "report categories both sorts of rules" in {

--- a/test/scala/matchers/LanguageToolMatcherTest.scala
+++ b/test/scala/matchers/LanguageToolMatcherTest.scala
@@ -9,21 +9,23 @@ import services.MatcherRequest
 class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
   val exampleCategory = Category("EXAMPLE_CAT", "Example Category")
   val exampleRuleXml = """
-    <pattern>
-        <token postag="CD" />
-        <token postag="NNS">
-            <exception regexp="yes">centuries|decades|years|months|days|hours|minutes|seconds|stars</exception>
-        </token>
-        <token>or</token>
-        <marker>
-            <token>less</token>
-        </marker>
-    </pattern>
-    <message>Did you mean <suggestion>fewer</suggestion>? The noun \2 is countable.</message>
-    <short>Grammatical error</short>
-    <example correction="fewer">Ten items or <marker>less</marker></example>
-    <example>It typically takes 30 seconds or <marker>less</marker></example>
-    <example>I would only give that hotel 3 stars or <marker>less</marker>.</example>
+    <rule>
+      <pattern>
+          <token postag="CD" />
+          <token postag="NNS">
+              <exception regexp="yes">centuries|decades|years|months|days|hours|minutes|seconds|stars</exception>
+          </token>
+          <token>or</token>
+          <marker>
+              <token>less</token>
+          </marker>
+      </pattern>
+      <message>Did you mean <suggestion>fewer</suggestion>? The noun \2 is countable.</message>
+      <short>Grammatical error</short>
+      <example correction="fewer">Ten items or <marker>less</marker></example>
+      <example>It typically takes 30 seconds or <marker>less</marker></example>
+      <example>I would only give that hotel 3 stars or <marker>less</marker>.</example>
+    </rule>
   """
   val exampleRule =  LTRuleXML(
     "EXAMPLE_RULE",


### PR DESCRIPTION
## What does this change?
Currently, when users create a new LanguageTool custom rule we ingest the rule and wrap in a `<rule>` tag. This however doesn't allow users to add custom rule groups. To allow this, we now ingest the rule pre-wrapped in either a root `<rule>` or `<rulegroup>` tag, and add the `id` and `name` attributes into the root tag.

NOTE: The existing custom LT rules will need to be wrapped in `<rule>` or `<rulegroup>` at the same time that this PR is merged.

## How to test
Run the branch locally and test. The CODE sheet is currently set up with wrapped rules for testing. 

Test the two rulegroups and the individual rules against text with incorrect dates, ellipses and references to 'woman' or 'women' as adjectives to test the new rulegroups, e.g. "The 5th of October, January 3rd, 5th August 2017… three…four…five. There are women electricians."

## How can we measure success?
Rule creators will be able to drop both rules and rule groups into the rules spreadsheet.

## Have we considered potential risks?
Existing custom rules will need to be wrapped in `<rule>` or `<rulegroup>` tags in order to work in future.
