### PR TITLE
Improve error handling for LanguageTool xml parsing

### DIFF
--- a/app/controllers/RulesController.scala
+++ b/app/controllers/RulesController.scala
@@ -31,7 +31,10 @@ class RulesController(
       maybeRules.left.map { error => List(error.getMessage) }
     } match {
       case Right((ruleResource, lastModified)) => {
-        ruleProvisioner.updateRules(ruleResource, lastModified)
+        val ruleErrors = ruleProvisioner.updateRules(ruleResource, lastModified) match {
+          case Right(()) => Nil
+          case Left(errors) => errors.map(_.getMessage)
+        }
         val currentRules = matcherPool.getCurrentRules
         Ok(views.html.rules(
             sheetId,
@@ -39,7 +42,7 @@ class RulesController(
             matcherPool.getCurrentMatchers,
             Some(true),
             Some(currentRules.size),
-            Nil
+            ruleErrors
         ))
       }
       case Left(errors) => {


### PR DESCRIPTION
**NB**: Depends on #95. Please, gentle reader – review/approve/merge that first!

## What does this change?

This PR improves error handling for LanguageTool xml parsing. Before, LanguageTool rules that contained invalid XML would fail silently to the user, and only emit to logs. Now, the frontend sees the error, correlated with the rule id: 

<img width="755" alt="Screenshot 2020-11-02 at 18 36 42" src="https://user-images.githubusercontent.com/7767575/97905722-5f5a6380-1d3a-11eb-83ee-212abdab4767.png">

## How to test

Write a duff rule in the rules sheet (find an example in the unit tests), and hit 'refresh' on the rule management page at `/rules`. You should see a suitable error message.

## How can we measure success?

Rule-makers have a clearer idea about what's wrong when they're editing LanguageTool xml.

## Have we considered potential risks?

In the messaging, we make it clear that when we're parsing rule XML, if a single rule fails, others for that category will also fail. This is because we create matchers on a per-category basis.

It'd be quite a lot more work to be resilient to errors on a per-rule basis, and that behaviour should be redundant once we move to a separate rule management service, so we should avoid the effort if possible.

