### PR TITLE
Add per-matcher timer logging

### DIFF
--- a/app/matchers/LanguageToolMatcher.scala
+++ b/app/matchers/LanguageToolMatcher.scala
@@ -29,7 +29,7 @@ class LanguageToolFactory(
                            useLanguageModelRules: Boolean = false) extends Logging {
 
   def createInstance(ruleXMLs: List[LTRuleXML], defaultRuleIds: List[String] = Nil)(implicit ec: ExecutionContext): Either[List[Throwable], Matcher] = {
-    val language: Language = Languages.getLanguageForShortCode("en")
+    val language: Language = Languages.getLanguageForShortCode("en-GB")
     val cache: ResultCache = new ResultCache(10000)
     val userConfig: UserConfig = new UserConfig()
 
@@ -46,6 +46,7 @@ class LanguageToolFactory(
     // ... apart from those we'd explicitly like
     val errors = defaultRuleIds.foldLeft(List.empty[Throwable])((acc, ruleId) =>
       if (allRuleIds.contains(ruleId)) {
+        println(s"Enabling rule: ${ruleId}")
         instance.enableRule(ruleId)
         acc
       } else new Exception(s"Attempted to enable a default rule with id ${ruleId}, but the rule was not available on the instance") :: acc
@@ -71,6 +72,8 @@ class LanguageToolFactory(
     val maybeRuleErrors = getLTRulesFromXML(ltRuleXmls) match {
       case Success(rules) => rules.map { rule =>
         val ruleTry = Try {
+          println("Adding custom rule")
+          println(rule)
           instance.addRule(rule)
           instance.enableRule(rule.getId())
         }
@@ -127,7 +130,7 @@ class LanguageToolFactory(
     }
 
     // Temporarily hardcode language settings
-    val ruleXml = <rules lang="en">{rulesXml}</rules>
+    val ruleXml = <rules lang="en-GB">{rulesXml}</rules>
 
     val outputStream = new ByteArrayOutputStream()
     val writer = new OutputStreamWriter(outputStream)

--- a/app/matchers/LanguageToolMatcher.scala
+++ b/app/matchers/LanguageToolMatcher.scala
@@ -29,7 +29,7 @@ class LanguageToolFactory(
                            useLanguageModelRules: Boolean = false) extends Logging {
 
   def createInstance(ruleXMLs: List[LTRuleXML], defaultRuleIds: List[String] = Nil)(implicit ec: ExecutionContext): Either[List[Throwable], Matcher] = {
-    val language: Language = Languages.getLanguageForShortCode("en-GB")
+    val language: Language = Languages.getLanguageForShortCode("en")
     val cache: ResultCache = new ResultCache(10000)
     val userConfig: UserConfig = new UserConfig()
 
@@ -46,7 +46,6 @@ class LanguageToolFactory(
     // ... apart from those we'd explicitly like
     val errors = defaultRuleIds.foldLeft(List.empty[Throwable])((acc, ruleId) =>
       if (allRuleIds.contains(ruleId)) {
-        println(s"Enabling rule: ${ruleId}")
         instance.enableRule(ruleId)
         acc
       } else new Exception(s"Attempted to enable a default rule with id ${ruleId}, but the rule was not available on the instance") :: acc
@@ -72,8 +71,6 @@ class LanguageToolFactory(
     val maybeRuleErrors = getLTRulesFromXML(ltRuleXmls) match {
       case Success(rules) => rules.map { rule =>
         val ruleTry = Try {
-          println("Adding custom rule")
-          println(rule)
           instance.addRule(rule)
           instance.enableRule(rule.getId())
         }
@@ -130,7 +127,7 @@ class LanguageToolFactory(
     }
 
     // Temporarily hardcode language settings
-    val ruleXml = <rules lang="en-GB">{rulesXml}</rules>
+    val ruleXml = <rules lang="en">{rulesXml}</rules>
 
     val outputStream = new ByteArrayOutputStream()
     val writer = new OutputStreamWriter(outputStream)

--- a/app/services/MatcherPool.scala
+++ b/app/services/MatcherPool.scala
@@ -17,6 +17,8 @@ import akka.stream.scaladsl.{Sink, Source}
 import play.api.libs.concurrent.Futures
 import play.api.Logging
 import utils.Timer
+import utils.CloudWatchClient
+import utils.Metrics
 
 case class MatcherRequest(blocks: List[TextBlock])
 
@@ -65,7 +67,8 @@ class MatcherPool(
   val maxQueuedJobs: Int = 1000,
   val checkStrategy: MatcherPool.CheckStrategy = MatcherPool.blockLevelCheckStrategy,
   val futures: Futures,
-  val checkTimeoutDuration: FiniteDuration = 5 seconds
+  val checkTimeoutDuration: FiniteDuration = 10 seconds,
+  val maybeCloudWatchClient: Option[CloudWatchClient] = None
 )(implicit ec: ExecutionContext, implicit val mat: Materializer) extends Logging {
   type JobProgressMap = Map[String, Int]
   type MatcherId = String
@@ -237,7 +240,9 @@ class MatcherPool(
         .check(MatcherRequest(blocksWithSkippedRangesRemoved))
         .map { matches => matches.map(_.mapMatchThroughBlocks(blocks)) }
 
-      Timer.timeAsync(s"MatcherPool.runMatchersForJob (type: ${matcher.getType}, categories: ${matcher.getCategories.map(_.name).mkString(", ")})") {
+      val taskName = s"MatcherPool.runMatchersForJob (type: ${matcher.getType}, categories: ${matcher.getCategories.map(_.name).mkString(", ")})"
+      val onSlowLog = (durationMs: Int) => maybeCloudWatchClient.map(_.putMetric(Metrics.MatcherPoolJobDuration, durationMs))
+      Timer.timeAsync(taskName, slowLogThresholdMs = 5000, onSlowLog = onSlowLog) {
         futures.timeout(checkTimeoutDuration)(eventuallyCheck)
       }
     }

--- a/app/services/MatcherPool.scala
+++ b/app/services/MatcherPool.scala
@@ -242,7 +242,7 @@ class MatcherPool(
         .map { matches => matches.map(_.mapMatchThroughBlocks(blocks)) }
 
       val taskName = s"MatcherPool.runMatchersForJob (type: ${matcher.getType}, categories: ${matcher.getCategories.map(_.name).mkString(", ")})"
-      val onSlowLog = (durationMs: Long) => maybeCloudWatchClient.foreach(_.putMetric(Metrics.MatcherPoolJobDuration, durationMs.toInt))
+      val onSlowLog = (durationMs: Long) => maybeCloudWatchClient.foreach(_.putMetric(Metrics.MatcherPoolJobDurationMs, durationMs.toInt))
       Timer.timeAsync(taskName, slowLogThresholdMs = checkSlowLogDuration.toMillis, onSlowLog = onSlowLog) {
         futures.timeout(checkTimeoutDuration)(eventuallyCheck)
       }

--- a/app/services/MatcherPool.scala
+++ b/app/services/MatcherPool.scala
@@ -237,7 +237,9 @@ class MatcherPool(
         .check(MatcherRequest(blocksWithSkippedRangesRemoved))
         .map { matches => matches.map(_.mapMatchThroughBlocks(blocks)) }
 
-      futures.timeout(checkTimeoutDuration)(eventuallyCheck)
+      Timer.timeAsync(s"MatcherPool.runMatchersForJob (type: ${matcher.getType}, categories: ${matcher.getCategories.map(_.name).mkString(", ")})") {
+        futures.timeout(checkTimeoutDuration)(eventuallyCheck)
+      }
     }
 
     val eventuallyAllMatches = Future.sequence(eventuallyJobResults).map { _.flatten }

--- a/app/utils/CloudWatchClient.scala
+++ b/app/utils/CloudWatchClient.scala
@@ -9,7 +9,7 @@ import com.amazonaws.services.cloudwatch.model.StandardUnit;
 object Metrics {
   val RulesIngested = "RulesIngested"
   val RulesNotFound = "RulesNotFound"
-  val MatcherPoolJobDuration = "MatcherPoolJobDuration"
+  val MatcherPoolJobDurationMs = "MatcherPoolJobDurationMs"
 }
 
 class CloudWatchClient(stage: String, dryRun: Boolean) extends Loggable {
@@ -30,7 +30,7 @@ class CloudWatchClient(stage: String, dryRun: Boolean) extends Loggable {
 
     try {
       cloudWatchClient.map(_.putMetricData(request))
-      log.info(s"Published $metric metric data. ${if (dryRun) "DRY RUN" else ""}")
+      log.info(s"Published $metric metric data with value ${value}. ${if (dryRun) "DRY RUN" else ""}")
     } catch {
       case e: Exception =>
         log.error(s"CloudWatch putMetricData exception message: ${e.getMessage}", e)

--- a/app/utils/CloudWatchClient.scala
+++ b/app/utils/CloudWatchClient.scala
@@ -9,6 +9,7 @@ import com.amazonaws.services.cloudwatch.model.StandardUnit;
 object Metrics {
   val RulesIngested = "RulesIngested"
   val RulesNotFound = "RulesNotFound"
+  val MatcherPoolJobDuration = "MatcherPoolJobDuration"
 }
 
 class CloudWatchClient(stage: String, dryRun: Boolean) extends Loggable {

--- a/app/utils/Timer.scala
+++ b/app/utils/Timer.scala
@@ -7,41 +7,64 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
 import net.logstash.logback.marker.LogstashMarker
 
+/**
+  * A collection of methods to help time synchronous and asynchronous operations.
+  *
+  * Logs the results with the Play logger.
+  */
 object Timer extends Logging {
   /**
     * Time a synchronous task and log the results.
+    *
+    * @param taskName the name of the task, which is added to the written log
+    * @param additionalMarkers any additional markers to add to the log entry
+    * @param slowLogThresholdMs pass to log at `warn` level when the operation exceeds the threshold.
+    * @param onSlowLog evaluated when the operation exceeds the slow log threshold
     */
-  def time[R](taskName: String, additionalMarkers: LogstashMarker = Markers.empty())(block: => R): R = {
+  def time[R](taskName: String, additionalMarkers: LogstashMarker = Markers.empty(), slowLogThresholdMs: Int = Int.MaxValue, onSlowLog: => Unit = {})(block: => R): R = {
     val t0 = System.nanoTime()
     val result = block
     val t1 = System.nanoTime()
-    logTime(taskName, t0, t1, additionalMarkers)
+    logTime(taskName, t0, t1, additionalMarkers, slowLogThresholdMs, onSlowLog)
     result
   }
 
   /**
     * Time an asynchronous task returning a Future, and log the results.
+    *
+    * @param taskName the name of the task, which is added to the written log
+    * @param additionalMarkers any additional markers to add to the log entry
+    * @param slowLogThresholdMs pass to log at `warn` level when the operation exceeds the threshold.
+    * @param onSlowLog evaluated when the operation exceeds the slow log threshold
     */
-  def timeAsync[R](taskName: String, additionalMarkers: LogstashMarker = Markers.empty())(block: => Future[R])(implicit ec: ExecutionContext): Future[R] = {
+  def timeAsync[R](taskName: String, additionalMarkers: LogstashMarker = Markers.empty(), slowLogThresholdMs: Int = Int.MaxValue, onSlowLog: => Unit = {})(block: => Future[R])(implicit ec: ExecutionContext): Future[R] = {
     val t0 = System.nanoTime()
     block.map { result =>
       val t1 = System.nanoTime()
-      logTime(taskName, t0, t1, additionalMarkers)
+      logTime(taskName, t0, t1, additionalMarkers, slowLogThresholdMs, onSlowLog)
       result
     }
   }
 
-  private def logTime(taskName: String, fromInNs: Long, toInNs: Long, additionalMarkers: LogstashMarker) = {
+  private def logTime(taskName: String, fromInNs: Long, toInNs: Long, additionalMarkers: LogstashMarker, slowLogThresholdMs: Int, onSlowLog: => Unit) = {
     val durationInMs = (toInNs - fromInNs) / 1000000
     val markers = Markers.appendEntries((
       Map(
         "taskName" -> taskName,
-        "durationInMs" -> durationInMs
+        "durationInMs" -> durationInMs,
+        "slowLogThresholdMs" -> slowLogThresholdMs
       )
     ).asJava)
     markers.add(additionalMarkers)
 
     val message = s"Task $taskName complete in ${durationInMs}ms"
-    logger.info(message)(markers)
+
+    if (durationInMs > slowLogThresholdMs) {
+      logger.warn(s"$message, exceeding slow log threshold of ${slowLogThresholdMs}")(markers)
+      println("call onSlowlog")
+      onSlowLog
+    } else {
+      logger.info(message)(markers)
+    }
   }
 }

--- a/app/utils/Timer.scala
+++ b/app/utils/Timer.scala
@@ -11,7 +11,7 @@ object Timer extends Logging {
   /**
     * Time a synchronous task and log the results.
     */
-  def time[R](taskName: String, additionalMarkers: LogstashMarker)(block: => R): R = {
+  def time[R](taskName: String, additionalMarkers: LogstashMarker = Markers.empty())(block: => R): R = {
     val t0 = System.nanoTime()
     val result = block
     val t1 = System.nanoTime()
@@ -22,7 +22,7 @@ object Timer extends Logging {
   /**
     * Time an asynchronous task returning a Future, and log the results.
     */
-  def timeAsync[R](taskName: String, additionalMarkers: LogstashMarker)(block: => Future[R])(implicit ec: ExecutionContext): Future[R] = {
+  def timeAsync[R](taskName: String, additionalMarkers: LogstashMarker = Markers.empty())(block: => Future[R])(implicit ec: ExecutionContext): Future[R] = {
     val t0 = System.nanoTime()
     block.map { result =>
       val t1 = System.nanoTime()

--- a/build.sbt
+++ b/build.sbt
@@ -40,8 +40,10 @@ buildInfoKeys := {
   )
 }
 
-resolvers += "Spring IO" at "https://repo.spring.io/plugins-release/"
 resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
+// Used to resolve xgboost-predictor, which is no longer available
+// at spring.io without auth.
+resolvers += "komiya-atsushi Bintray" at "https://dl.bintray.com/komiya-atsushi/maven"
 
 val languageToolVersion = "4.3"
 val awsSdkVersion = "1.11.571"
@@ -72,7 +74,8 @@ libraryDependencies ++= Seq(
   "com.gu" %% "content-api-client-aws" % "0.5",
   "com.gu" %% "content-api-client-default" % capiClientVersion,
   "com.gu" %% "pan-domain-auth-verification" % "0.9.1",
-  "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.29" % Test
+  "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.29" % Test,
+  "biz.k11i" % "xgboost-predictor" % "0.3.1"
 )
 
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,7 @@ libraryDependencies ++= Seq(
   "net.logstash.logback" % "logstash-logback-encoder" % "6.0",
   "com.gu" % "kinesis-logback-appender" % "1.4.4",
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
+  "org.mockito" %% "mockito-scala-scalatest" % "1.16.2",
   "org.webjars" % "bootstrap" % "4.3.1",
   "com.gu" %% "content-api-models-scala" % capiModelsVersion,
   "com.gu" %% "content-api-models-json" % capiModelsVersion,

--- a/test/scala/model/RuleMatchTest.scala
+++ b/test/scala/model/RuleMatchTest.scala
@@ -68,7 +68,7 @@ class RuleMatchTest extends AsyncFlatSpec with Matchers {
     mappedMatch.toPos shouldBe 23
   }
 
-    it should "account for multiple ranges" in {
+  it should "account for multiple ranges" in {
     // E.g. "Example [noted ]text with more [noted ]text"
     val ruleMatch = getRuleMatch(18, 22)
     val skippedRange = List(TextRange(18, 25), TextRange(40, 47))

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -104,7 +104,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     checkTimeoutDuration: FiniteDuration = 100 milliseconds
   ): MatcherPool = {
     val futures = new DefaultFutures(system)
-    val pool = new MatcherPool(maxCurrentJobs, maxQueuedJobs, strategy, futures, checkTimeoutDuration)
+    val pool = new MatcherPool(maxCurrentJobs, maxQueuedJobs, strategy, futures, checkTimeoutDuration = checkTimeoutDuration)
     matchers.zipWithIndex.foreach {
       case (matcher, index) => pool.addMatcher(matcher)
     }

--- a/test/scala/utils/TimerTest.scala
+++ b/test/scala/utils/TimerTest.scala
@@ -16,7 +16,7 @@ class TimerTest extends AnyFlatSpec with Matchers with IdiomaticMockito {
 
   behavior of "time"
 
-  it should "not call `onSlowLog` when a task does not its slow log threshold" in {
+  it should "not call `onSlowLog` when a task does not exceed its slow log threshold" in {
     val mockFunction = spyLambda((d: Long) => ())
 
     Timer.time(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction){}

--- a/test/scala/utils/TimerTest.scala
+++ b/test/scala/utils/TimerTest.scala
@@ -1,4 +1,4 @@
-package scala.utils
+package utils
 
 import model._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -6,7 +6,6 @@ import org.mockito.{ ArgumentMatchersSugar, IdiomaticMockito }
 import org.scalatest.matchers.should.Matchers
 import com.softwaremill.diffx.scalatest.DiffMatcher._
 
-import utils.Timer
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Await
@@ -18,44 +17,46 @@ class TimerTest extends AnyFlatSpec with Matchers with IdiomaticMockito {
   behavior of "time"
 
   it should "not call `onSlowLog` when a task does not its slow log threshold" in {
-    val mockFunction = mock[() => Unit]
+    val mockFunction = spyLambda((d: Long) => ())
 
-    Timer.time(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction.apply()){}
+    Timer.time(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction){}
 
-    mockFunction() wasNever called
+    mockFunction wasNever called
   }
 
   it should "call `onSlowLog` when a task exceeds its slow log threshold" in {
-    val mockFunction = mock[() => Unit]
+    var eventualDuration = 0L
+    val mockFunction = spyLambda((duration: Long) => eventualDuration = duration)
 
-    Timer.time(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction.apply()){
+    Timer.time(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction){
       Thread.sleep(200)
     }
 
-    mockFunction() was called
+    eventualDuration.toInt should be >= 200
   }
 
   behavior of "timeAsync"
 
   it should "not call `onSlowLog` when a task does not its slow log threshold" in {
-    val mockFunction = mock[() => Unit]
+    val mockFunction = spyLambda((d: Long) => ())
 
-    Timer.timeAsync(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction.apply()){
+    Timer.timeAsync(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction){
       Future.successful(())
     }
 
-    mockFunction() wasNever called
+    mockFunction wasNever called
   }
 
   it should "call `onSlowLog` when a task exceeds its slow log threshold" in {
-    val mockFunction = mock[() => Unit]
+    var eventualDuration = 0L
+    val mockFunction = (duration: Long) => eventualDuration = duration
 
-    val task = Timer.timeAsync(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction.apply()){
+    val task = Timer.timeAsync(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction){
       Thread.sleep(200)
       Future.successful(())
     }
     Await.result(task, 1.second)
 
-    mockFunction() was called
+    eventualDuration.toInt should be >= 200
   }
 }

--- a/test/scala/utils/TimerTest.scala
+++ b/test/scala/utils/TimerTest.scala
@@ -1,0 +1,61 @@
+package scala.utils
+
+import model._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.mockito.{ ArgumentMatchersSugar, IdiomaticMockito }
+import org.scalatest.matchers.should.Matchers
+import com.softwaremill.diffx.scalatest.DiffMatcher._
+
+import utils.Timer
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class TimerTest extends AnyFlatSpec with Matchers with IdiomaticMockito {
+  implicit val executionContext = ExecutionContext.Implicits.global
+
+  behavior of "time"
+
+  it should "not call `onSlowLog` when a task does not its slow log threshold" in {
+    val mockFunction = mock[() => Unit]
+
+    Timer.time(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction.apply()){}
+
+    mockFunction() wasNever called
+  }
+
+  it should "call `onSlowLog` when a task exceeds its slow log threshold" in {
+    val mockFunction = mock[() => Unit]
+
+    Timer.time(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction.apply()){
+      Thread.sleep(200)
+    }
+
+    mockFunction() was called
+  }
+
+  behavior of "timeAsync"
+
+  it should "not call `onSlowLog` when a task does not its slow log threshold" in {
+    val mockFunction = mock[() => Unit]
+
+    Timer.timeAsync(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction.apply()){
+      Future.successful(())
+    }
+
+    mockFunction() wasNever called
+  }
+
+  it should "call `onSlowLog` when a task exceeds its slow log threshold" in {
+    val mockFunction = mock[() => Unit]
+
+    val task = Timer.timeAsync(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction.apply()){
+      Thread.sleep(200)
+      Future.successful(())
+    }
+    Await.result(task, 1.second)
+
+    mockFunction() was called
+  }
+}

--- a/test/scala/utils/TimerTest.scala
+++ b/test/scala/utils/TimerTest.scala
@@ -37,7 +37,7 @@ class TimerTest extends AnyFlatSpec with Matchers with IdiomaticMockito {
 
   behavior of "timeAsync"
 
-  it should "not call `onSlowLog` when a task does not its slow log threshold" in {
+  it should "not call `onSlowLog` when a task does not exceed its slow log threshold" in {
     val mockFunction = spyLambda((d: Long) => ())
 
     Timer.timeAsync(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction){


### PR DESCRIPTION
## What does this change?

We could do with a slow log for Typerighter's matcher jobs. This PR adds per-matcher logging to the matcher pool, to help us identify slow-running jobs.

Because we send timing metrics, and because we don't know what 'slow' looks like yet, I haven't added a 'warn' status to slow logs – my hunch is that'll be better to do on the metrics/alerting side, where we can tune in response to system performance.

In addition to this, per @SHession's suggestion, I've added a Cloudwatch metric that's sent when our slow log is triggered in the `matcherPool` service. 

## How to test

The new unit tests for the `Timer` slow-log should pass.

Deploy to CODE. You should see timer logs for the `runMatchersForJob` task in our logging.

Tested on CODE, and I've add a graph (matcher jobs duration percentiles) to our Typerighter metrics radiator.

<img width="659" alt="Screenshot 2020-11-03 at 16 51 22" src="https://user-images.githubusercontent.com/7767575/98015574-d8b68c80-1df4-11eb-8b0c-a6fda74a6081.png">

## How can we measure success?

When performance is problematic, we should be able to identify which matcher type and categories are causing the problem.

## Dev notes

The API of `Timer` has expanded to accommodate slow logging. I've added a callback to delegate an action to the caller when the slowlog is triggered, if supplied, to avoid coupling our Timer to opinions about what slow logging might mean beyond logging.

This does the job and avoids coupling, but I'm not convinced I've done it in a very ergonomic way – comments welcome!

