### PR TITLE
Adds a `dryRun` param for local CloudWatch

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -66,7 +66,11 @@ class AppComponents(context: Context, identity: AppIdentity, creds: AWSCredentia
     case _ => "code"
   }
   val typerighterBucket = s"typerighter-${stage}"
-  val cloudWatchClient = new CloudWatchClient(stage)
+ 
+  val cloudWatchClient = identity match {
+    case identity: AwsIdentity => new CloudWatchClient(stage, false)
+    case _ : DevIdentity => new CloudWatchClient(stage, true)
+  } 
 
   val bucketRuleManager = new BucketRuleManager(s3Client, typerighterBucket)
   val ruleProvisioner = new RuleProvisionerService(bucketRuleManager, matcherPool, languageToolFactory, cloudWatchClient)

--- a/app/utils/CloudWatchClient.scala
+++ b/app/utils/CloudWatchClient.scala
@@ -29,7 +29,7 @@ class CloudWatchClient(stage: String, dryRun: Boolean) extends Loggable {
 
     try {
       cloudWatchClient.map(_.putMetricData(request))
-      log.info(s"Published metric data")
+      log.info(s"Published $metric metric data. ${if (dryRun) "DRY RUN" else ""}")
     } catch {
       case e: Exception =>
         log.error(s"CloudWatch putMetricData exception message: ${e.getMessage}", e)

--- a/app/utils/CloudWatchClient.scala
+++ b/app/utils/CloudWatchClient.scala
@@ -11,11 +11,9 @@ object Metrics {
   val RulesNotFound = "RulesNotFound"
 }
 
-class CloudWatchClient(stage: String) extends Loggable {
+class CloudWatchClient(stage: String, dryRun: Boolean) extends Loggable {
 
-  private val builder = AmazonCloudWatchClientBuilder.defaultClient()
-
-  private lazy val cloudWatchClient = builder
+  private val cloudWatchClient = if(dryRun) None else Some(AmazonCloudWatchClientBuilder.defaultClient())
 
   def putMetric(metric: String, value: Int = 1): Unit = {
 
@@ -30,8 +28,8 @@ class CloudWatchClient(stage: String) extends Loggable {
     val request = new PutMetricDataRequest().withNamespace("Typerighter").withMetricData(datum)
 
     try {
-      val result = cloudWatchClient.putMetricData(request)
-      log.info(s"Published metric data: $result")
+      cloudWatchClient.map(_.putMetricData(request))
+      log.info(s"Published metric data")
     } catch {
       case e: Exception =>
         log.error(s"CloudWatch putMetricData exception message: ${e.getMessage}", e)


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR fixes an issue introduced by #94, causing issue with running Typerighter locally. It also prevents custom metrics from being logged when running in a local machine. This is achieved by adding a dry run parameter to the `CloudWatchClient` class.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run TR locally and confirm it works correctly. For other environments this should be a NO-OP.
