### PR TITLE
Correctly reported checked categories

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -31,13 +31,15 @@ class ApiController(
           matcherPool.check(check)
         }
 
-        eventuallyMatches.map { matches =>
-          val response = MatcherResponse(
-            matches = matches,
-            blocks = check.blocks,
-            categoryIds = matches.map(_.rule.category.id).toSet
-          )
-          Ok(Json.toJson(response))
+        eventuallyMatches.map {
+          case (categoryIds, matches) => {
+            val response = MatcherResponse(
+              matches = matches,
+              blocks = check.blocks,
+              categoryIds = categoryIds
+            )
+            Ok(Json.toJson(response))
+          }
         } recover {
         case e: Exception =>
           InternalServerError(Json.obj("error" -> e.getMessage))

--- a/test/scala/matchers/LanguageToolMatcherTest.scala
+++ b/test/scala/matchers/LanguageToolMatcherTest.scala
@@ -190,12 +190,16 @@ class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
     val ltFactory = new LanguageToolFactory(None)
     val defaultRules = List("FEWER_LESS")
     val instance = ltFactory.createInstance(Nil, defaultRules).getOrElse(fail)
+    val rules = instance.getRules()
     val request = MatcherRequest(List(TextBlock("id-1", "Three or less tests passed!", 0, 29)))
 
     val eventuallyMatches = instance.check(request)
+
     val expectedMatchMessages = List("Did you mean <suggestion>fewer</suggestion>? The noun tests is countable.")
+    val expectedMatchCategoryIds = List("GRAMMAR")
     eventuallyMatches map { matches =>
       matches.map(_.message) shouldBe expectedMatchMessages
+      matches.map(_.rule.category.id) shouldBe expectedMatchCategoryIds
     }
   }
 

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -164,7 +164,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
 
   behavior of "check"
 
-  it should "return a list of MatcherResponses" in {
+  it should "return a list of matches and categoryIds checked" in {
     val matchers = getMatchers(1)
     matchers.head.completeWith(responses)
 
@@ -172,6 +172,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     val futureResult = pool.check(getCheck(text = "Example text"))
     futureResult.map { case (categoryIds, matches) =>
       matches shouldBe responses
+      categoryIds should matchTo(Set(getCategory(0).id))
     }
   }
 
@@ -258,7 +259,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     eventualResult
   }
 
-  it should "correctly check multiple categories for a single job" in {
+  it should "correctly check multiple categories for a single job, and report them" in {
     val matchers = getMatchers(2)
     val firstMatch = getResponses(List((0, 5, "test-response")), 0)
     val secondMatch = getResponses(List((6, 10, "test-response")), 1)
@@ -267,10 +268,12 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
 
     val pool = getPool(matchers)
     val futureResult = pool.check(getCheck(text = "Example text"))
+    val expectedCategories = Set(getCategory(0).id, getCategory(1).id)
 
     futureResult.map { case (categoryIds, matches) =>
       matches.contains(firstMatch.head) shouldBe true
       matches.contains(secondMatch.head) shouldBe true
+      categoryIds should matchTo(expectedCategories)
     }
   }
 
@@ -280,9 +283,10 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
 
     val pool = getPool(matchers)
     val futureResult = pool.check(getCheck(text = "Example text"))
+    val expectedCategories = Set(getCategory(0).id)
 
     futureResult.map { case (categoryIds, matches) =>
-      categoryIds shouldBe Set("mock-category-0")
+      categoryIds shouldBe expectedCategories
     }
   }
 

--- a/test/scala/services/MatcherPoolTest.scala
+++ b/test/scala/services/MatcherPoolTest.scala
@@ -170,8 +170,8 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
 
     val pool = getPool(matchers)
     val futureResult = pool.check(getCheck(text = "Example text"))
-    futureResult.map { result =>
-      result shouldBe responses
+    futureResult.map { case (categoryIds, matches) =>
+      matches shouldBe responses
     }
   }
 
@@ -182,8 +182,8 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     val pool = getPool(matchers)
     val futureResult = pool.check(getCheck(text = "Example text"))
 
-    futureResult.map { result =>
-      result.length shouldBe 24
+    futureResult.map { case (categoryIds, matches) =>
+      matches.length shouldBe 24
     }
   }
 
@@ -268,9 +268,21 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     val pool = getPool(matchers)
     val futureResult = pool.check(getCheck(text = "Example text"))
 
-    futureResult.map { result =>
-      result.contains(firstMatch.head) shouldBe true
-      result.contains(secondMatch.head) shouldBe true
+    futureResult.map { case (categoryIds, matches) =>
+      matches.contains(firstMatch.head) shouldBe true
+      matches.contains(secondMatch.head) shouldBe true
+    }
+  }
+
+    it should "report the categories that are checked, even if no matches are found" in {
+    val matchers = getMatchers(1)
+    matchers(0).completeWith(getResponses(List.empty))
+
+    val pool = getPool(matchers)
+    val futureResult = pool.check(getCheck(text = "Example text"))
+
+    futureResult.map { case (categoryIds, matches) =>
+      categoryIds shouldBe Set("mock-category-0")
     }
   }
 
@@ -282,9 +294,9 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     val secondMatch = getResponses(List((0, 5, "test-response-2")), 1)
     matchers(0).completeWith(firstMatch)
     matchers(1).completeWith(secondMatch)
-    futureResult.map { result =>
-      result.size should matchTo(1)
-      result should matchTo(secondMatch)
+    futureResult.map { case (categoryIds, matches) =>
+      matches.size should matchTo(1)
+      matches should matchTo(secondMatch)
     }
   }
 
@@ -352,9 +364,9 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     )
     val futureResult = pool.check(check)
 
-    futureResult.map { results =>
-      val resultRanges = results.map { result => (result.fromPos, result.toPos) }
-      resultRanges shouldBe List((1, 1), (5, 5))
+    futureResult.map { case (categoryIds, matches) =>
+      val matchRanges = matches.map { matches => (matches.fromPos, matches.toPos) }
+      matchRanges shouldBe List((1, 1), (5, 5))
     }
   }
 }


### PR DESCRIPTION
## What does this change?

At the moment, we only report the categories that are checked when they produce matches – a major oversight, as our client depends on the Typerighter service to report the categories it has checked to invalidate matches that may have been affected by document changes.

To reproduce the problem:
- Check the text: `We an hope to address it.` We should get a match for `an`.
- and a `c` to correct.
- Check again. The match will remain, incorrectly.

This PR ensures that we pass back the categories that the `matcherPool` has checked in our API response.

## How to test

Attempt the reproduction above with this change. The match in question should disappear on a re-check.

The unit test added for this issue should pass.

## How can we measure success?

Changes to the document that resolve matches but do not directly touch them should be removed on subsequent checks.
