### PR TITLE
Generate (more) correct suggestions for case-insensitive regexes

### DIFF
--- a/checker/app/matchers/RegexMatcher.scala
+++ b/checker/app/matchers/RegexMatcher.scala
@@ -1,11 +1,14 @@
 package matchers
 
-import model.{RegexRule, RuleMatch, Category}
-import services.MatcherRequest
-import utils.{Matcher, MatcherCompanion, RuleMatchHelpers}
+import java.util.regex.Pattern
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
+import scala.util.matching.Regex
+import model.{RegexRule, RuleMatch}
+import services.MatcherRequest
+import utils.{Matcher, MatcherCompanion, RuleMatchHelpers}
+
 
 object RegexMatcher extends MatcherCompanion {
   def getType() = "regex"

--- a/checker/app/model/BaseRule.scala
+++ b/checker/app/model/BaseRule.scala
@@ -62,7 +62,7 @@ case class RegexRule(
       matchedText = matchedText,
       message = description,
       shortMessage = Some(description),
-      suggestions = transformSuggestions(suggestions, matchedText),
+      suggestions = preserveMatchCase(suggestions, matchedText),
       replacement = replacement.map(_.replaceAllIn(regex, matchedText)),
       markAsCorrect = replacement.map(_.text).getOrElse("") == block.text.substring(start, end),
       matchContext = Text.getMatchTextSnippet(precedingText, matchedText, subsequentText),
@@ -71,11 +71,10 @@ case class RegexRule(
   }
 
   /**
-    *
     * If the regex is case-insensitive, and the suggestion is identical
     * excepting case, preserve the original casing.
     */
-  private def transformSuggestions(suggestions: List[TextSuggestion], matchedText: String): List[Suggestion] = if (isCaseInsensitive) {
+  private def preserveMatchCase(suggestions: List[TextSuggestion], matchedText: String): List[Suggestion] = if (isCaseInsensitive) {
     suggestions.map {
       case suggestion if suggestion.text.toLowerCase() == matchedText.toLowerCase() => {
         suggestion.copy(text = matchedText)

--- a/checker/app/model/BaseRule.scala
+++ b/checker/app/model/BaseRule.scala
@@ -53,6 +53,9 @@ case class RegexRule(
   def toMatch(start: Int, end: Int, block: TextBlock): RuleMatch = {
     val matchedText = block.text.substring(start, end)
     val (precedingText, subsequentText) = Text.getSurroundingText(block.text, start, end)
+    val transformedSuggestions = suggestions.map(preserveMatchCase(_, matchedText))
+    val transformedReplacement = replacement.map(replacement => preserveMatchCase(replacement.replaceAllIn(regex, matchedText), matchedText))
+
     RuleMatch(
       rule = this,
       fromPos = start + block.from,
@@ -62,8 +65,8 @@ case class RegexRule(
       matchedText = matchedText,
       message = description,
       shortMessage = Some(description),
-      suggestions = preserveMatchCase(suggestions, matchedText),
-      replacement = replacement.map(_.replaceAllIn(regex, matchedText)),
+      suggestions = transformedSuggestions,
+      replacement = transformedReplacement,
       markAsCorrect = replacement.map(_.text).getOrElse("") == block.text.substring(start, end),
       matchContext = Text.getMatchTextSnippet(precedingText, matchedText, subsequentText),
       matcherType = RegexMatcher.getType
@@ -74,24 +77,22 @@ case class RegexRule(
     * If the regex is case-insensitive, and the suggestion is identical
     * excepting case, preserve the original casing.
     */
-  private def preserveMatchCase(suggestions: List[TextSuggestion], matchedText: String): List[Suggestion] = if (isCaseInsensitive) {
-    suggestions.map {
-      case suggestion if suggestion.text.toLowerCase() == matchedText.toLowerCase() => {
-        suggestion.copy(text = matchedText)
-      }
-      // A kludge to get around start-of-sentence casing. If the suggestion doesn't
-      // match the whole matchedText, but does match the first character, preserve that
-      // casing in the suggestion. This is to ensure that e.g. a case-insensitive suggestion
-      // to replace 'end of sentence. [Mediavel]' with 'medieval' does not incorrectly replace
-      // the uppercase 'M'.
-      //
-      // These sorts of rules are better off as dictionary matches, which we hope to add soon.
-      case suggestion if suggestion.text.charAt(0).toLower == matchedText.charAt(0).toLower => {
-        suggestion.copy(text = matchedText.charAt(0) + suggestion.text.slice(1, suggestion.text.length))
-      }
-      case suggestion => suggestion
+  private def preserveMatchCase(suggestion: Suggestion, matchedText: String): Suggestion = suggestion match {
+    case suggestion if !isCaseInsensitive => suggestion
+    case TextSuggestion(text) if isCaseInsensitive && text.toLowerCase() == matchedText.toLowerCase() => {
+      TextSuggestion(matchedText)
     }
-  } else suggestions
+    // A kludge to get around start-of-sentence casing. If the suggestion doesn't
+    // match the whole matchedText, but does match the first character, preserve that
+    // casing in the suggestion. This is to ensure that e.g. a case-insensitive suggestion
+    // to replace 'end of sentence. [Mediavel]' with 'medieval' does not incorrectly replace
+    // the uppercase 'M'.
+    //
+    // These sorts of rules are better off as dictionary matches, which we hope to add soon.
+    case TextSuggestion(text) if isCaseInsensitive && text.charAt(0).toLower == matchedText.charAt(0).toLower => {
+      TextSuggestion(text = matchedText.charAt(0) + text.slice(1, text.length))
+    }
+  }
 }
 
 /**

--- a/checker/test/scala/model/BaseRuleTest.scala
+++ b/checker/test/scala/model/BaseRuleTest.scala
@@ -7,12 +7,14 @@ class BaseRuleTest extends AsyncFlatSpec with Matchers {
   behavior of "RegexRule"
 
   it should "transform suggestions if the regex in question is not case sensitive, preserving case when suggestions match case-insensitively" in {
+    val suggestion = TextSuggestion("medieval")
     val rule = RegexRule(
       id = "test-rule",
       description = "test-description",
       category = Category("test-category", "Test Category"),
       regex = "(?i)\\bmedia?eval"r,
-      suggestions = List(TextSuggestion("medieval"))
+      suggestions = List(suggestion),
+      replacement = Some(suggestion)
     )
 
     val ruleMatch = rule.toMatch(0, 8, TextBlock("id", "Medieval", 0, 8))
@@ -21,12 +23,14 @@ class BaseRuleTest extends AsyncFlatSpec with Matchers {
   }
 
   it should "transform suggestions if the regex in question is not case sensitive, preserving case when suggestions do not match, but the first character matches case-insensitively, to work around sentence starts" in {
+    val suggestion = TextSuggestion("medieval")
     val rule = RegexRule(
       id = "test-rule",
       description = "test-description",
       category = Category("test-category", "Test Category"),
       regex = "(?i)\\bmedia?eval"r,
-      suggestions = List(TextSuggestion("medieval"))
+      suggestions = List(suggestion),
+      replacement = Some(suggestion)
     )
 
     val ruleMatch = rule.toMatch(0, 8, TextBlock("id", "Mediaval", 0, 8))
@@ -35,12 +39,14 @@ class BaseRuleTest extends AsyncFlatSpec with Matchers {
   }
 
   it should "not transform suggestions if the regex in question is case sensitive" in {
+    val suggestion = TextSuggestion("medieval")
     val rule = RegexRule(
       id = "test-rule",
       description = "test-description",
       category = Category("test-category", "Test Category"),
       regex = "\\bmedia?eval"r,
-      suggestions = List(TextSuggestion("medieval"))
+      suggestions = List(suggestion),
+      replacement = Some(suggestion)
     )
 
     val ruleMatch = rule.toMatch(0, 7, TextBlock("id", "Medieval", 0, 8))

--- a/checker/test/scala/model/BaseRuleTest.scala
+++ b/checker/test/scala/model/BaseRuleTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 class BaseRuleTest extends AsyncFlatSpec with Matchers {
   behavior of "RegexRule"
 
-  it should "transform suggestions if the regex in question is not case sensitive" in {
+  it should "transform suggestions if the regex in question is not case sensitive, preserving case when suggestions match case-insensitively" in {
     val rule = RegexRule(
       id = "test-rule",
       description = "test-description",
@@ -16,6 +16,20 @@ class BaseRuleTest extends AsyncFlatSpec with Matchers {
     )
 
     val ruleMatch = rule.toMatch(0, 8, TextBlock("id", "Medieval", 0, 8))
+
+    ruleMatch.suggestions shouldBe List(TextSuggestion("Medieval"))
+  }
+
+  it should "transform suggestions if the regex in question is not case sensitive, preserving case when suggestions do not match, but the first character matches case-insensitively, to work around sentence starts" in {
+    val rule = RegexRule(
+      id = "test-rule",
+      description = "test-description",
+      category = Category("test-category", "Test Category"),
+      regex = "(?i)\\bmedia?eval"r,
+      suggestions = List(TextSuggestion("medieval"))
+    )
+
+    val ruleMatch = rule.toMatch(0, 8, TextBlock("id", "Mediaval", 0, 8))
 
     ruleMatch.suggestions shouldBe List(TextSuggestion("Medieval"))
   }

--- a/checker/test/scala/model/BaseRuleTest.scala
+++ b/checker/test/scala/model/BaseRuleTest.scala
@@ -1,0 +1,36 @@
+package model
+
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class BaseRuleTest extends AsyncFlatSpec with Matchers {
+  behavior of "RegexRule"
+
+  it should "transform suggestions if the regex in question is not case sensitive" in {
+    val rule = RegexRule(
+      id = "test-rule",
+      description = "test-description",
+      category = Category("test-category", "Test Category"),
+      regex = "(?i)\\bmedia?eval"r,
+      suggestions = List(TextSuggestion("medieval"))
+    )
+
+    val ruleMatch = rule.toMatch(0, 8, TextBlock("id", "Medieval", 0, 8))
+
+    ruleMatch.suggestions shouldBe List(TextSuggestion("Medieval"))
+  }
+
+  it should "not transform suggestions if the regex in question is case sensitive" in {
+    val rule = RegexRule(
+      id = "test-rule",
+      description = "test-description",
+      category = Category("test-category", "Test Category"),
+      regex = "\\bmedia?eval"r,
+      suggestions = List(TextSuggestion("medieval"))
+    )
+
+    val ruleMatch = rule.toMatch(0, 7, TextBlock("id", "Medieval", 0, 8))
+
+    ruleMatch.suggestions shouldBe List(TextSuggestion("medieval"))
+  }
+}

--- a/checker/test/scala/model/RuleMatchTest.scala
+++ b/checker/test/scala/model/RuleMatchTest.scala
@@ -1,12 +1,8 @@
 package scala.model
 
-
 import model._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
-import com.softwaremill.diffx.scalatest.DiffMatcher._
-
-import utils.Text
 
 class RuleMatchTest extends AsyncFlatSpec with Matchers {
   def getRuleMatch(from: Int, to: Int) = RuleMatch(


### PR DESCRIPTION
## What does this change?

At the moment, when we apply suggestions from regular expressions, there's sometimes an unexpected side effect: we overwrite casing in the matched text.

For example, with regex `(?i)\\bmedia?eval` (note the `(?i)` flag, which means it's case insensitive), we always suggest the word `medieval`. 

This causes problems when words begin sentences, e.g. `end of sentence. Medieval` will produce a match suggesting `medieval`.

This PR preserves case where possible:
- When casing is ignored, if the suggestion matches the matched text, replace the suggestion with the matched text
- When casing is ignored, if the suggestion doesn't match the whole match text, but the first char does, preserve the case of the first char to ensure we don't accidentally correct start-of-sentence casing
- Otherwise, continue as normal

The reason we preserve the suggestion on a perfect caseless match, rather than just stripping it, is to preserve the match's 'mark as correct' behaviour.

## How to test

The unit tests should pass.

E.g. the sentence `End of sentence. Mediaeval` should offer a correction to `Medieval`. Before, it would offer `medieval`.

## How can we measure success?

Fewer complaints about mistakes w/ casing in suggestions.

## Have we considered potential risks?

This is still not perfect – see the 'first character' kludge above! – but the rules to which this apply are probably better addressed in the long run with a dictionary.
