### PR TITLE
Use corrected suggestions when computing markAsCorrect

### DIFF
--- a/checker/app/controllers/ApiController.scala
+++ b/checker/app/controllers/ApiController.scala
@@ -42,7 +42,10 @@ class ApiController(
           }
         } recover {
         case e: Exception =>
-          InternalServerError(Json.obj("error" -> e.getMessage))
+          log.error(checkMarkers, "Error in /check", e)
+          InternalServerError(Json.obj(
+            "error" -> e.getMessage
+          ))
       }
       case Left(error) =>
         Future.successful(BadRequest(s"Invalid request: $error"))

--- a/checker/app/model/BaseRule.scala
+++ b/checker/app/model/BaseRule.scala
@@ -55,6 +55,7 @@ case class RegexRule(
     val (precedingText, subsequentText) = Text.getSurroundingText(block.text, start, end)
     val transformedSuggestions = suggestions.map(preserveMatchCase(_, matchedText))
     val transformedReplacement = replacement.map(replacement => preserveMatchCase(replacement.replaceAllIn(regex, matchedText), matchedText))
+    val markAsCorrect = transformedReplacement.map(_.text).getOrElse("") == block.text.substring(start, end)
 
     RuleMatch(
       rule = this,
@@ -67,7 +68,7 @@ case class RegexRule(
       shortMessage = Some(description),
       suggestions = transformedSuggestions,
       replacement = transformedReplacement,
-      markAsCorrect = replacement.map(_.text).getOrElse("") == block.text.substring(start, end),
+      markAsCorrect = markAsCorrect,
       matchContext = Text.getMatchTextSnippet(precedingText, matchedText, subsequentText),
       matcherType = RegexMatcher.getType
     )

--- a/checker/app/model/BaseRule.scala
+++ b/checker/app/model/BaseRule.scala
@@ -79,7 +79,6 @@ case class RegexRule(
     * excepting case, preserve the original casing.
     */
   private def preserveMatchCase(suggestion: Suggestion, matchedText: String): Suggestion = suggestion match {
-    case suggestion if !isCaseInsensitive => suggestion
     case TextSuggestion(text) if isCaseInsensitive && text.toLowerCase() == matchedText.toLowerCase() => {
       TextSuggestion(matchedText)
     }
@@ -93,6 +92,7 @@ case class RegexRule(
     case TextSuggestion(text) if isCaseInsensitive && text.charAt(0).toLower == matchedText.charAt(0).toLower => {
       TextSuggestion(text = matchedText.charAt(0) + text.slice(1, text.length))
     }
+    case suggestion => suggestion
   }
 }
 

--- a/checker/test/scala/model/BaseRuleTest.scala
+++ b/checker/test/scala/model/BaseRuleTest.scala
@@ -22,6 +22,22 @@ class BaseRuleTest extends AsyncFlatSpec with Matchers {
     ruleMatch.suggestions shouldBe List(TextSuggestion("Medieval"))
   }
 
+  it should "transform suggestions if the regex in question is not case sensitive, correctly reporting when suggestions and the matchedText match" in {
+    val suggestion = TextSuggestion("medieval")
+    val rule = RegexRule(
+      id = "test-rule",
+      description = "test-description",
+      category = Category("test-category", "Test Category"),
+      regex = "(?i)\\bmedia?eval"r,
+      suggestions = List(suggestion),
+      replacement = Some(suggestion)
+    )
+
+    val ruleMatch = rule.toMatch(0, 8, TextBlock("id", "Medieval", 0, 8))
+
+    ruleMatch.markAsCorrect shouldBe true
+  }
+
   it should "transform suggestions if the regex in question is not case sensitive, preserving case when suggestions do not match, but the first character matches case-insensitively, to work around sentence starts" in {
     val suggestion = TextSuggestion("medieval")
     val rule = RegexRule(

--- a/checker/test/scala/model/BaseRuleTest.scala
+++ b/checker/test/scala/model/BaseRuleTest.scala
@@ -69,4 +69,20 @@ class BaseRuleTest extends AsyncFlatSpec with Matchers {
 
     ruleMatch.suggestions shouldBe List(TextSuggestion("medieval"))
   }
+
+  it should "handle replacement failures gracefully" in {
+    val suggestion = TextSuggestion("Man Booker")
+    val rule = RegexRule(
+      id = "test-rule",
+      description = "test-description",
+      category = Category("test-category", "Test Category"),
+      regex = "(?i)\b(Man)? ?Booker prize"r,
+      suggestions = List(suggestion),
+      replacement = Some(suggestion)
+    )
+
+    val ruleMatch = rule.toMatch(0, 11, TextBlock("id", " Man Booker prize", 0, 18))
+
+    ruleMatch.replacement shouldBe Some(TextSuggestion(" Man Booker"))
+  }
 }


### PR DESCRIPTION
## What does this change?

#102 transforms suggestions, but still uses the untransformed suggestion to calculate `markAsCorrect`, leading to misleading rules – the first match in the following should be a 'green' rule.

<img width="346" alt="Screenshot 2020-11-19 at 17 36 39" src="https://user-images.githubusercontent.com/7767575/99702547-d3606f80-2a8d-11eb-89cc-6ea8a5a95666.png">

This PR corrects that oversight.

## How to test

The unit test should pass.

Does the copy in the screenshot now produce the correct colour?