### PR TITLE
Use transformed replacements when marking rules as correct

### DIFF
--- a/checker/app/model/BaseRule.scala
+++ b/checker/app/model/BaseRule.scala
@@ -51,6 +51,7 @@ case class RegexRule(
 
   def toMatch(start: Int, end: Int, block: TextBlock): RuleMatch = {
     val matchedText = block.text.substring(start, end)
+    val transformedReplacement = replacement.map(_.replaceAllIn(regex, matchedText))
     val (precedingText, subsequentText) = Text.getSurroundingText(block.text, start, end)
     RuleMatch(
       rule = this,
@@ -62,8 +63,8 @@ case class RegexRule(
       message = description,
       shortMessage = Some(description),
       suggestions = suggestions,
-      replacement = replacement.map(_.replaceAllIn(regex, matchedText)),
-      markAsCorrect = replacement.map(_.text).getOrElse("") == block.text.substring(start, end),
+      replacement = transformedReplacement,
+      markAsCorrect = transformedReplacement.map(_.text).getOrElse("") == block.text.substring(start, end),
       matchContext = Text.getMatchTextSnippet(precedingText, matchedText, subsequentText),
       matcherType = RegexMatcher.getType
     )


### PR DESCRIPTION
## What does this change?

At the moment, we use untransformed suggestion to calculate `markAsCorrect`, leading to a misleading red rule when the suggestion isn't offering a change:

<img width="295" alt="Screenshot 2020-11-20 at 18 01 04" src="https://user-images.githubusercontent.com/7767575/99833807-80082300-2b5a-11eb-82b7-fe5f3bfcefee.png">

This PR corrects that oversight:

<img width="296" alt="Screenshot 2020-11-20 at 18 02 16" src="https://user-images.githubusercontent.com/7767575/99833830-8ac2b800-2b5a-11eb-9995-47dc40d445df.png">

## How to test

The unit test should pass.

Does the copy in the screenshot now produce the correct colour?