### PR TITLE
RegexMatcher: address capitalisation problems at sentence starts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,10 @@ val checker = (project in file("checker")).enablePlugins(PlayScala, GatlingPlugi
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "pan-domain-auth-verification" % "0.9.1",
     "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.29" % Test,
-    "biz.k11i" % "xgboost-predictor" % "0.3.1"
+    "biz.k11i" % "xgboost-predictor" % "0.3.1",
+    "edu.stanford.nlp" % "stanford-corenlp" % "3.4",
+    "edu.stanford.nlp" % "stanford-corenlp" % "3.4" classifier "models",
+    "edu.stanford.nlp" % "stanford-parser" % "3.4",
   ),
   libraryDependencies ++= Seq(
     "io.circe" %% "circe-core",

--- a/checker/app/matchers/RegexMatcher.scala
+++ b/checker/app/matchers/RegexMatcher.scala
@@ -50,12 +50,9 @@ class RegexMatcher(rules: List[RegexRule]) extends Matcher {
     }
   }
 
-  private def doesMatchCoverSentenceStart(sentenceStarts: List[WordInSentence], range: TextRange) = {
+  private def doesMatchCoverSentenceStart(sentenceStarts: List[WordInSentence], range: TextRange): Boolean = {
     sentenceStarts.exists(sentenceStart =>
-      sentenceStart.range.getIntersection(range) match {
-        case Some(_) => true
-        case _ => false
-      }
+      sentenceStart.range.from == range.from
     )
   }
 }

--- a/checker/app/model/BaseRule.scala
+++ b/checker/app/model/BaseRule.scala
@@ -83,14 +83,13 @@ case class RegexRule(
     // A kludge to get around start-of-sentence casing. If the suggestion doesn't
     // match the whole matchedText, but does match the first character, preserve that
     // casing in the suggestion. This is to ensure that e.g. a case-insensitive suggestion
-    // to replace 'end of sentence. [Mediavel]' with 'medieval' does not incorrectly replace
+    // to replace e.g. 'end of sentence. [Mediavel]' with 'medieval' does not incorrectly replace
     // the uppercase 'M'.
     //
     // These sorts of rules are better off as dictionary matches, which we hope to add soon.
-    case TextSuggestion(text)
-      if isStartOfSentence && text.charAt(0).toLower == matchedText.charAt(0).toLower => {
-        TextSuggestion(text = matchedText.charAt(0) + text.slice(1, text.length))
-      }
+    case TextSuggestion(text) if isStartOfSentence => {
+      TextSuggestion(text = matchedText.charAt(0).toUpper + text.slice(1, text.length))
+    }
     case suggestion => suggestion
   }
 }

--- a/checker/app/model/BaseRule.scala
+++ b/checker/app/model/BaseRule.scala
@@ -54,7 +54,7 @@ case class RegexRule(
     val transformedReplacement = replacement.map { r =>
       r
         .replaceAllIn(regex, matchedText)
-        .maybePreserveMatchCase(isStartOfSentence)
+        .ensureCorrectCase(isStartOfSentence)
     }
     val (precedingText, subsequentText) = Text.getSurroundingText(block.text, start, end)
 

--- a/checker/app/model/BaseRule.scala
+++ b/checker/app/model/BaseRule.scala
@@ -54,7 +54,7 @@ case class RegexRule(
     val transformedReplacement = replacement.map { r =>
       r
         .replaceAllIn(regex, matchedText)
-        .maybePreserveMatchCase(isStartOfSentence, matchedText)
+        .maybePreserveMatchCase(isStartOfSentence)
     }
     val (precedingText, subsequentText) = Text.getSurroundingText(block.text, start, end)
 

--- a/checker/app/model/BaseRule.scala
+++ b/checker/app/model/BaseRule.scala
@@ -52,11 +52,12 @@ case class RegexRule(
   def toMatch(start: Int, end: Int, block: TextBlock, isStartOfSentence: Boolean = false): RuleMatch = {
     val matchedText = block.text.substring(start, end)
     val transformedReplacement = replacement.map { r =>
-      val replacementWithSubstitions = r.replaceAllIn(regex, matchedText)
-      maybePreserveMatchCase(isStartOfSentence, replacementWithSubstitions, matchedText)
+      r
+        .replaceAllIn(regex, matchedText)
+        .maybePreserveMatchCase(isStartOfSentence, matchedText)
     }
-
     val (precedingText, subsequentText) = Text.getSurroundingText(block.text, start, end)
+
     RuleMatch(
       rule = this,
       fromPos = start + block.from,
@@ -72,25 +73,6 @@ case class RegexRule(
       matchContext = Text.getMatchTextSnippet(precedingText, matchedText, subsequentText),
       matcherType = RegexMatcher.getType
     )
-  }
-
-  /**
-    * If the first character of the suggestion is identical to the first character
-    * of the matched text case, preserve the original casing. Used when our match covers
-    * the start of a sentence to ensure we don't accidentally lowercase sentence starts.
-    */
-  private def maybePreserveMatchCase(isStartOfSentence: Boolean, suggestion: Suggestion, matchedText: String): Suggestion = suggestion match {
-    // A kludge to get around start-of-sentence casing. If the suggestion doesn't
-    // match the whole matchedText, but does match the first character, preserve that
-    // casing in the suggestion. This is to ensure that e.g. a case-insensitive suggestion
-    // to replace e.g. 'end of sentence. [Mediavel]' with 'medieval' does not incorrectly replace
-    // the uppercase 'M'.
-    //
-    // These sorts of rules are better off as dictionary matches, which we hope to add soon.
-    case TextSuggestion(text) if isStartOfSentence => {
-      TextSuggestion(text = matchedText.charAt(0).toUpper + text.slice(1, text.length))
-    }
-    case suggestion => suggestion
   }
 }
 

--- a/checker/app/model/Suggestion.scala
+++ b/checker/app/model/Suggestion.scala
@@ -15,18 +15,9 @@ sealed trait Suggestion {
   val text: String
 
   /**
-    * If the first character of the suggestion is identical to the first character
-    * of the matched text case, preserve the original casing. Used when our match covers
-    * the start of a sentence to ensure we don't accidentally lowercase sentence starts.
+    * If our suggestion is at the start of a sentence, cap up the first letter.
     */
-  def maybePreserveMatchCase(isStartOfSentence: Boolean): Suggestion = this match {
-    // A kludge to get around start-of-sentence casing. If the suggestion doesn't
-    // match the whole matchedText, but does match the first character, preserve that
-    // casing in the suggestion. This is to ensure that e.g. a case-insensitive suggestion
-    // to replace e.g. 'end of sentence. [Mediavel]' with 'medieval' does not incorrectly replace
-    // the uppercase 'M'.
-    //
-    // These sorts of rules are better off as dictionary matches, which we hope to add soon.
+  def ensureCorrectCase(isStartOfSentence: Boolean): Suggestion = this match {
     case TextSuggestion(text) if isStartOfSentence => {
       TextSuggestion(text = text.charAt(0).toUpper + text.slice(1, text.length))
     }

--- a/checker/app/model/Suggestion.scala
+++ b/checker/app/model/Suggestion.scala
@@ -13,6 +13,25 @@ object Suggestion {
 sealed trait Suggestion {
   val `type`: String
   val text: String
+
+  /**
+    * If the first character of the suggestion is identical to the first character
+    * of the matched text case, preserve the original casing. Used when our match covers
+    * the start of a sentence to ensure we don't accidentally lowercase sentence starts.
+    */
+  def maybePreserveMatchCase(isStartOfSentence: Boolean, matchedText: String): Suggestion = this match {
+    // A kludge to get around start-of-sentence casing. If the suggestion doesn't
+    // match the whole matchedText, but does match the first character, preserve that
+    // casing in the suggestion. This is to ensure that e.g. a case-insensitive suggestion
+    // to replace e.g. 'end of sentence. [Mediavel]' with 'medieval' does not incorrectly replace
+    // the uppercase 'M'.
+    //
+    // These sorts of rules are better off as dictionary matches, which we hope to add soon.
+    case TextSuggestion(text) if isStartOfSentence => {
+      TextSuggestion(text = matchedText.charAt(0).toUpper + text.slice(1, text.length))
+    }
+    case suggestion => suggestion
+  }
 }
 
 object TextSuggestion {

--- a/checker/app/model/Suggestion.scala
+++ b/checker/app/model/Suggestion.scala
@@ -19,7 +19,7 @@ sealed trait Suggestion {
     * of the matched text case, preserve the original casing. Used when our match covers
     * the start of a sentence to ensure we don't accidentally lowercase sentence starts.
     */
-  def maybePreserveMatchCase(isStartOfSentence: Boolean, matchedText: String): Suggestion = this match {
+  def maybePreserveMatchCase(isStartOfSentence: Boolean): Suggestion = this match {
     // A kludge to get around start-of-sentence casing. If the suggestion doesn't
     // match the whole matchedText, but does match the first character, preserve that
     // casing in the suggestion. This is to ensure that e.g. a case-insensitive suggestion
@@ -28,7 +28,7 @@ sealed trait Suggestion {
     //
     // These sorts of rules are better off as dictionary matches, which we hope to add soon.
     case TextSuggestion(text) if isStartOfSentence => {
-      TextSuggestion(text = matchedText.charAt(0).toUpper + text.slice(1, text.length))
+      TextSuggestion(text = text.charAt(0).toUpper + text.slice(1, text.length))
     }
     case suggestion => suggestion
   }

--- a/checker/app/services/SentenceHelpers.scala
+++ b/checker/app/services/SentenceHelpers.scala
@@ -1,0 +1,42 @@
+package services
+
+import java.util.Properties
+
+import edu.stanford.nlp.ling.CoreAnnotations.{SentencesAnnotation, TextAnnotation, TokensAnnotation}
+import edu.stanford.nlp.ling.CoreLabel
+import edu.stanford.nlp.pipeline.{Annotation, StanfordCoreNLP}
+import edu.stanford.nlp.util.CoreMap
+
+import scala.collection.JavaConverters._
+import model.TextRange
+
+case class WordInSentence(sentence: String, word: String, range: TextRange)
+
+/**
+  * A service to extract proper names from documents.
+  */
+class SentenceHelpers() {
+  val props: Properties = new Properties()
+  props.put("annotators", "tokenize, ssplit")
+  val pipeline: StanfordCoreNLP = new StanfordCoreNLP(props)
+
+  def getFirstWordsInSentences(text: String): List[WordInSentence] = {
+    val document: Annotation = new Annotation(text)
+    pipeline.annotate(document)
+
+    val sentences: List[CoreMap] = document.get(classOf[SentencesAnnotation]).asScala.toList
+    val tokensAndEntities = for {
+      sentence: CoreMap <- sentences
+      token: CoreLabel <- sentence.get(classOf[TokensAnnotation]).asScala.toList
+      word: String = token.get(classOf[TextAnnotation])
+    } yield {
+      (sentence, token, word)
+    }
+
+    tokensAndEntities
+      .groupBy { case (sentence, _, _) => sentence }
+      .map { case (_, sentenceAndTokens) => sentenceAndTokens.head }.toList
+      .map { case (sentence, token, word) => WordInSentence(sentence.toString(), word, TextRange(token.beginPosition(), token.endPosition())) }
+      .sortBy(_.range.from)
+  }
+}

--- a/checker/test/scala/matchers/RegexMatcherTest.scala
+++ b/checker/test/scala/matchers/RegexMatcherTest.scala
@@ -208,47 +208,71 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     }
   }
 
-   it should "transform suggestions to respect sentence starts, to avoid suggesting capping down – preserve current case" in {
-      val rule = RegexRule(
-        id = "test-rule",
-        description = "test-description",
-        category = Category("test-category", "Test Category"),
-        regex = "(?i)\\bcaf(e|é|è|ë|ê)"r,
-        replacement = Some(TextSuggestion("cafe"))
-      )
+  behavior of "capitalisations"
 
-      val validator = new RegexMatcher(List(rule))
-      val eventuallyMatches = validator.check(
-        MatcherRequest(getBlocks("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit"))
-      )
+  it should "transform suggestions to respect sentence starts, to avoid suggesting capping down – preserve current case" in {
+    val rule = RegexRule(
+      id = "test-rule",
+      description = "test-description",
+      category = Category("test-category", "Test Category"),
+      regex = "(?i)\\bcaf(e|é|è|ë|ê)"r,
+      replacement = Some(TextSuggestion("cafe"))
+    )
 
-      eventuallyMatches.map { matches =>
-        matches.size shouldBe 1
-        val firstMatch = matches(0)
-        firstMatch.replacement shouldBe Some(TextSuggestion("Cafe"))
-        firstMatch.markAsCorrect shouldBe true
-      }
-   }
+    val validator = new RegexMatcher(List(rule))
+    val eventuallyMatches = validator.check(
+      MatcherRequest(getBlocks("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit"))
+    )
 
-   it should "transform suggestions to respect sentence starts, to avoid suggesting capping down – cap up sentence start" in {
-      val rule = RegexRule(
-        id = "test-rule",
-        description = "test-description",
-        category = Category("test-category", "Test Category"),
-        regex = "(?i)\\bcaf(e|é|è|ë|ê)"r,
-        replacement = Some(TextSuggestion("cafe"))
-      )
+    eventuallyMatches.map { matches =>
+      matches.size shouldBe 1
+      val firstMatch = matches(0)
+      firstMatch.replacement shouldBe Some(TextSuggestion("Cafe"))
+      firstMatch.markAsCorrect shouldBe true
+    }
+  }
 
-      val validator = new RegexMatcher(List(rule))
-      val eventuallyMatches = validator.check(
-        MatcherRequest(getBlocks("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit"))
-      )
+  it should "transform suggestions to respect sentence starts, to avoid suggesting capping down – cap up sentence start" in {
+    val rule = RegexRule(
+      id = "test-rule",
+      description = "test-description",
+      category = Category("test-category", "Test Category"),
+      regex = "(?i)\\bcaf(e|é|è|ë|ê)"r,
+      replacement = Some(TextSuggestion("cafe"))
+    )
 
-      eventuallyMatches.map { matches =>
-        matches.size shouldBe 1
-        val firstMatch = matches(0)
-        firstMatch.replacement shouldBe Some(TextSuggestion("Cafe"))
-        firstMatch.markAsCorrect shouldBe false
-      }
-   }
+    val validator = new RegexMatcher(List(rule))
+    val eventuallyMatches = validator.check(
+      MatcherRequest(getBlocks("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit"))
+    )
+
+    eventuallyMatches.map { matches =>
+      matches.size shouldBe 1
+      val firstMatch = matches(0)
+      firstMatch.replacement shouldBe Some(TextSuggestion("Cafe"))
+      firstMatch.markAsCorrect shouldBe false
+    }
+  }
+
+  it should "should not apply capitalisations when the match does not include the start of the word" in {
+    val rule = RegexRule(
+      id = "test-rule",
+      description = "test-description",
+      category = Category("test-category", "Test Category"),
+      regex = "(?i)af(e|é|è|ë|ê)"r,
+      replacement = Some(TextSuggestion("afe"))
+    )
+
+    val validator = new RegexMatcher(List(rule))
+    val eventuallyMatches = validator.check(
+      MatcherRequest(getBlocks("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit"))
+    )
+
+    eventuallyMatches.map { matches =>
+      matches.size shouldBe 1
+      val firstMatch = matches(0)
+      firstMatch.replacement shouldBe Some(TextSuggestion("afe"))
+      firstMatch.markAsCorrect shouldBe true
+    }
+  }
 }

--- a/checker/test/scala/matchers/RegexMatcherTest.scala
+++ b/checker/test/scala/matchers/RegexMatcherTest.scala
@@ -208,7 +208,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     }
   }
 
-   it should "transform suggestions to respect sentence starts, to avoid suggesting capping down" in {
+   it should "transform suggestions to respect sentence starts, to avoid suggesting capping down – preserve current case" in {
       val rule = RegexRule(
         id = "test-rule",
         description = "test-description",
@@ -227,6 +227,28 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
         val firstMatch = matches(0)
         firstMatch.replacement shouldBe Some(TextSuggestion("Cafe"))
         firstMatch.markAsCorrect shouldBe true
+      }
+   }
+
+   it should "transform suggestions to respect sentence starts, to avoid suggesting capping down – cap up sentence start" in {
+      val rule = RegexRule(
+        id = "test-rule",
+        description = "test-description",
+        category = Category("test-category", "Test Category"),
+        regex = "(?i)\\bcaf(e|é|è|ë|ê)"r,
+        replacement = Some(TextSuggestion("cafe"))
+      )
+
+      val validator = new RegexMatcher(List(rule))
+      val eventuallyMatches = validator.check(
+        MatcherRequest(getBlocks("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit"))
+      )
+
+      eventuallyMatches.map { matches =>
+        matches.size shouldBe 1
+        val firstMatch = matches(0)
+        firstMatch.replacement shouldBe Some(TextSuggestion("Cafe"))
+        firstMatch.markAsCorrect shouldBe false
       }
    }
 }

--- a/checker/test/scala/services/SentenceHelperTest.scala
+++ b/checker/test/scala/services/SentenceHelperTest.scala
@@ -1,0 +1,20 @@
+package services
+
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import com.softwaremill.diffx.scalatest.DiffMatcher._
+import model.TextRange
+
+class SentenceHelperTest extends AsyncFlatSpec with Matchers {
+
+  behavior of "getFirstWordsInSentences"
+
+  it should "return sentence starts, including the word and range covered" in {
+    val sentenceTokenizer = new SentenceHelpers()
+    val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
+    firstWordsInSentences should matchTo(List(
+      WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
+      WordInSentence("Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(102, 107)),
+    ))
+  }
+}

--- a/docs/decision-records/001-regex-matcher-capitalisation.md
+++ b/docs/decision-records/001-regex-matcher-capitalisation.md
@@ -1,0 +1,35 @@
+# Regex matcher capitalisation
+
+## Context
+
+At the moment, when we apply suggestions from regular expressions, there's sometimes an unexpected side effect: we overwrite casing in the matched text.
+
+For example, with regex (?i)\\bmedia?eval (note the (?i) flag, which means it's case insensitive), we always suggest the word medieval.
+
+This causes problems when words begin sentences, e.g. end of sentence. Medieval will produce a match suggesting medieval.
+
+## Positions
+
+### 1. Refactor the corpus to use capture groups for initial chars where appropriate
+
+... for example, `((i?)m)edieaval` with replacement `$1edieval`.
+
+- (+) Possible to arrive at correctness in this way
+- (-) It'll take a long time, as our corpus is large and we haven't annotated which rules have case-sensitive replacements
+
+### 2. Detect sentence starts and capitalise accordingly
+ 
+- (+) No changes to our corpus
+- (-) Possibly there are edge cases that we haven't yet considered
+
+## Decision
+
+We think detecting sentence starts is a better fit:
+- We have a large corpus that will take a great deal of work to refactor, and it's not possible to automate part of this work, as we must distinguish between replacements that care about capitalisation (e.g. `WhatsApp`, `alsatian` – the dog is always lower case!) and replacements that don't (e.g. `medieval`).
+- Detecting sentence starts allows us to make the correct suggestion when users have missed a capital at a sentence start and we're offering a replacement, which is a bonus.
+- We shouldn't spend too long on the corpus, as the rules that benefit from this case will likely be replaced by a dictionary approach sooner rather than later.
+
+## Consequences
+
+- We don't need to change the corpus
+- We may encounter edge cases as a result of the above approach, e.g. `ee cummings` at the start of a sentence, and as a result may have to a way of enforcing case at sentence starts.

--- a/docs/decision-records/001-regex-matcher-capitalisation.md
+++ b/docs/decision-records/001-regex-matcher-capitalisation.md
@@ -1,4 +1,4 @@
-# Regex matcher capitalisation
+# Checker: handling capitalisation in the regex matcher at sentence starts
 
 ## Context
 


### PR DESCRIPTION
## What does this change?

At the moment, when we apply suggestions from regular expressions, there's sometimes an unexpected side effect: we overwrite casing in the matched text.

For example, with regex `(?i)\\bmedia?eval` (note the `(?i)` flag, which means it's case insensitive), we always suggest the word `medieval`. 

This causes problems when words begin sentences, e.g. `end of sentence. Medieval` will produce a match suggesting `medieval`.

This PR preserves case where possible, by detecting sentence starts. When a regex applies to a sentence start, and the starting characters of the suggestion and the match whilst ignoring case, we keep the casing of the match.

So given the regex `(?i)\bmedia?eval` with the replacement `medieval` where square brackets denote a match:

- `... [mediavel] castles` will produce the suggestion `medieval`
- `end of sentence. [Medieaval] castles` will produce the suggestion `Medieval`
- `end of sentence. [medieaval] castles` will produce the suggestion `Medieval`

The reason we preserve the suggestion on a perfect caseless match, rather than just stripping it, is to preserve the match's 'mark as correct' behaviour.

## How to test

The unit tests should pass.

E.g. the sentence `End of sentence. Mediaeval` should offer a correction to `Medieval`. Before, it would offer `medieval`.

## How can we measure success?

Fewer complaints about mistakes w/ casing in suggestions.

## Have we considered potential risks?

This is probably still not perfect, but the rules to which this apply are probably better addressed in the long run with a dictionary. Wonky edge cases gratefully received.
