### PR TITLE
Raise timeout limit

### DIFF
--- a/checker/app/services/MatcherPool.scala
+++ b/checker/app/services/MatcherPool.scala
@@ -68,7 +68,7 @@ class MatcherPool(
   val checkStrategy: MatcherPool.CheckStrategy = MatcherPool.blockLevelCheckStrategy,
   val futures: Futures,
   val checkSlowLogDuration: FiniteDuration = 5 seconds,
-  val checkTimeoutDuration: FiniteDuration = 10 seconds,
+  val checkTimeoutDuration: FiniteDuration = 30 seconds,
   val maybeCloudWatchClient: Option[CloudWatchClient] = None
 )(implicit ec: ExecutionContext, implicit val mat: Materializer) extends Logging {
   type JobProgressMap = Map[String, Int]


### PR DESCRIPTION
## What does this change?

Some of our requests are timing out, but the service is still healthy. Timing out should be a last resort when something's gone wrong, so let's raise the limit.

This is not a substitute for a timely service – it looks like #108 has slowed us up somewhat, and we should investigate.

## How to test

Test with a large document in CODE. You should not see requests time out in 10s.

