### PR TITLE
RegexMatcher: address capitalisation problems at sentence starts, take 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,10 @@ val checker = (project in file("checker")).enablePlugins(PlayScala, GatlingPlugi
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "pan-domain-auth-verification" % "0.9.1",
     "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.29" % Test,
-    "biz.k11i" % "xgboost-predictor" % "0.3.1"
+    "biz.k11i" % "xgboost-predictor" % "0.3.1",
+    "edu.stanford.nlp" % "stanford-corenlp" % "3.4",
+    "edu.stanford.nlp" % "stanford-corenlp" % "3.4" classifier "models",
+    "edu.stanford.nlp" % "stanford-parser" % "3.4",
   ),
   libraryDependencies ++= Seq(
     "io.circe" %% "circe-core",

--- a/checker/app/matchers/RegexMatcher.scala
+++ b/checker/app/matchers/RegexMatcher.scala
@@ -9,6 +9,7 @@ import scala.concurrent.ExecutionContext
 import services.SentenceHelpers
 import services.WordInSentence
 import model.TextRange
+import model.TextBlock
 
 object RegexMatcher extends MatcherCompanion {
   def getType() = "regex"
@@ -25,8 +26,12 @@ class RegexMatcher(rules: List[RegexRule]) extends Matcher {
 
   override def check(request: MatcherRequest)(implicit ec: ExecutionContext): Future[List[RuleMatch]] = {
     Future {
+      // We compute these per-block and pass them through to avoid duplicating work
+      val blocksAndSentenceStarts = request.blocks.map { block =>
+        (block, sentenceHelper.getFirstWordsInSentences(block.text))
+      }
       rules.foldLeft(List.empty[RuleMatch])((acc, rule) => {
-        val matches = checkRule(request, rule)
+        val matches = checkRule(blocksAndSentenceStarts, rule)
         RuleMatchHelpers.removeOverlappingRules(acc, matches) ++ matches
       })
     }
@@ -36,19 +41,18 @@ class RegexMatcher(rules: List[RegexRule]) extends Matcher {
 
   override def getCategories() = rules.map(_.category).toSet
 
-  private def checkRule(request: MatcherRequest, rule: RegexRule): List[RuleMatch] = {
-    request.blocks.flatMap { block =>
-      val firstWordsInSentences = sentenceHelper.getFirstWordsInSentences(block.text)
-      rule.regex.findAllMatchIn(block.text).map { currentMatch =>
-        rule.toMatch(
-          currentMatch.start,
-          currentMatch.end,
-          block,
-          doesMatchCoverSentenceStart(firstWordsInSentences, TextRange(currentMatch.start, currentMatch.end))
-        )
-      }
+  private def checkRule(blocksAndSentenceStarts: List[(TextBlock, List[WordInSentence])], rule: RegexRule): List[RuleMatch] =
+    blocksAndSentenceStarts.flatMap {
+      case (block, firstWordsInSentences) =>
+        rule.regex.findAllMatchIn(block.text).map { currentMatch =>
+          rule.toMatch(
+            currentMatch.start,
+            currentMatch.end,
+            block,
+            doesMatchCoverSentenceStart(firstWordsInSentences, TextRange(currentMatch.start, currentMatch.end))
+          )
+        }
     }
-  }
 
   private def doesMatchCoverSentenceStart(sentenceStarts: List[WordInSentence], range: TextRange): Boolean = {
     sentenceStarts.exists(sentenceStart =>

--- a/checker/app/matchers/RegexMatcher.scala
+++ b/checker/app/matchers/RegexMatcher.scala
@@ -6,6 +6,9 @@ import utils.{Matcher, MatcherCompanion, RuleMatchHelpers}
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
+import services.SentenceHelpers
+import services.WordInSentence
+import model.TextRange
 
 object RegexMatcher extends MatcherCompanion {
   def getType() = "regex"
@@ -16,6 +19,7 @@ object RegexMatcher extends MatcherCompanion {
   * A Matcher for rules based on regular expressions.
   */
 class RegexMatcher(rules: List[RegexRule]) extends Matcher {
+  val sentenceHelper = new SentenceHelpers()
 
   def getType() = RegexMatcher.getType
 
@@ -34,13 +38,21 @@ class RegexMatcher(rules: List[RegexRule]) extends Matcher {
 
   private def checkRule(request: MatcherRequest, rule: RegexRule): List[RuleMatch] = {
     request.blocks.flatMap { block =>
+      val firstWordsInSentences = sentenceHelper.getFirstWordsInSentences(block.text)
       rule.regex.findAllMatchIn(block.text).map { currentMatch =>
         rule.toMatch(
           currentMatch.start,
           currentMatch.end,
-          block
+          block,
+          doesMatchCoverSentenceStart(firstWordsInSentences, TextRange(currentMatch.start, currentMatch.end))
         )
       }
     }
+  }
+
+  private def doesMatchCoverSentenceStart(sentenceStarts: List[WordInSentence], range: TextRange): Boolean = {
+    sentenceStarts.exists(sentenceStart =>
+      sentenceStart.range.from == range.from
+    )
   }
 }

--- a/checker/app/model/BaseRule.scala
+++ b/checker/app/model/BaseRule.scala
@@ -49,10 +49,15 @@ case class RegexRule(
     regex: Regex
 ) extends BaseRule {
 
-  def toMatch(start: Int, end: Int, block: TextBlock): RuleMatch = {
+  def toMatch(start: Int, end: Int, block: TextBlock, isStartOfSentence: Boolean = false): RuleMatch = {
     val matchedText = block.text.substring(start, end)
-    val transformedReplacement = replacement.map(_.replaceAllIn(regex, matchedText))
+    val transformedReplacement = replacement.map { r =>
+      r
+        .replaceAllIn(regex, matchedText)
+        .ensureCorrectCase(isStartOfSentence)
+    }
     val (precedingText, subsequentText) = Text.getSurroundingText(block.text, start, end)
+
     RuleMatch(
       rule = this,
       fromPos = start + block.from,

--- a/checker/app/model/Suggestion.scala
+++ b/checker/app/model/Suggestion.scala
@@ -13,6 +13,16 @@ object Suggestion {
 sealed trait Suggestion {
   val `type`: String
   val text: String
+
+  /**
+    * If our suggestion is at the start of a sentence, cap up the first letter.
+    */
+  def ensureCorrectCase(isStartOfSentence: Boolean): Suggestion = this match {
+    case TextSuggestion(text) if isStartOfSentence => {
+      TextSuggestion(text = text.charAt(0).toUpper + text.slice(1, text.length))
+    }
+    case suggestion => suggestion
+  }
 }
 
 object TextSuggestion {

--- a/checker/app/services/SentenceHelpers.scala
+++ b/checker/app/services/SentenceHelpers.scala
@@ -16,6 +16,7 @@ case class WordInSentence(sentence: String, word: String, range: TextRange)
   * A service to extract proper names from documents.
   */
 class SentenceHelpers() {
+  println("new sentence annotator")
   val props: Properties = new Properties()
   props.put("annotators", "tokenize, ssplit")
   val pipeline: StanfordCoreNLP = new StanfordCoreNLP(props)
@@ -25,18 +26,17 @@ class SentenceHelpers() {
     pipeline.annotate(document)
 
     val sentences: List[CoreMap] = document.get(classOf[SentencesAnnotation]).asScala.toList
-    val tokensAndEntities = for {
-      sentence: CoreMap <- sentences
-      token: CoreLabel <- sentence.get(classOf[TokensAnnotation]).asScala.toList
-      word: String = token.get(classOf[TextAnnotation])
-    } yield {
-      (sentence, token, word)
-    }
 
-    tokensAndEntities
-      .groupBy { case (sentence, _, _) => sentence }
-      .map { case (_, sentenceAndTokens) => sentenceAndTokens.head }.toList
-      .map { case (sentence, token, word) => WordInSentence(sentence.toString(), word, TextRange(token.beginPosition(), token.endPosition())) }
-      .sortBy(_.range.from)
+    for {
+      sentence: CoreMap <- sentences
+    } yield {
+      val firstToken = sentence.get(classOf[TokensAnnotation]).asScala.toList.head
+      val word = firstToken.get(classOf[TextAnnotation])
+      WordInSentence(
+        sentence.toString,
+        word,
+        TextRange(firstToken.beginPosition(), firstToken.endPosition())
+      )
+    }
   }
 }

--- a/checker/app/services/SentenceHelpers.scala
+++ b/checker/app/services/SentenceHelpers.scala
@@ -1,0 +1,42 @@
+package services
+
+import java.util.Properties
+
+import edu.stanford.nlp.ling.CoreAnnotations.{SentencesAnnotation, TextAnnotation, TokensAnnotation}
+import edu.stanford.nlp.ling.CoreLabel
+import edu.stanford.nlp.pipeline.{Annotation, StanfordCoreNLP}
+import edu.stanford.nlp.util.CoreMap
+
+import scala.collection.JavaConverters._
+import model.TextRange
+
+case class WordInSentence(sentence: String, word: String, range: TextRange)
+
+/**
+  * A service to extract proper names from documents.
+  */
+class SentenceHelpers() {
+  val props: Properties = new Properties()
+  props.put("annotators", "tokenize, ssplit")
+  val pipeline: StanfordCoreNLP = new StanfordCoreNLP(props)
+
+  def getFirstWordsInSentences(text: String): List[WordInSentence] = {
+    val document: Annotation = new Annotation(text)
+    pipeline.annotate(document)
+
+    val sentences: List[CoreMap] = document.get(classOf[SentencesAnnotation]).asScala.toList
+    val tokensAndEntities = for {
+      sentence: CoreMap <- sentences
+      token: CoreLabel <- sentence.get(classOf[TokensAnnotation]).asScala.toList
+      word: String = token.get(classOf[TextAnnotation])
+    } yield {
+      (sentence, token, word)
+    }
+
+    tokensAndEntities
+      .groupBy { case (sentence, _, _) => sentence }
+      .map { case (_, sentenceAndTokens) => sentenceAndTokens.head }.toList
+      .map { case (sentence, token, word) => WordInSentence(sentence.toString(), word, TextRange(token.beginPosition(), token.endPosition())) }
+      .sortBy(_.range.from)
+  }
+}

--- a/checker/app/services/SentenceHelpers.scala
+++ b/checker/app/services/SentenceHelpers.scala
@@ -16,7 +16,6 @@ case class WordInSentence(sentence: String, word: String, range: TextRange)
   * A service to extract proper names from documents.
   */
 class SentenceHelpers() {
-  println("new sentence annotator")
   val props: Properties = new Properties()
   props.put("annotators", "tokenize, ssplit")
   val pipeline: StanfordCoreNLP = new StanfordCoreNLP(props)

--- a/checker/test/scala/matchers/RegexMatcherTest.scala
+++ b/checker/test/scala/matchers/RegexMatcherTest.scala
@@ -7,6 +7,8 @@ import com.softwaremill.diffx.scalatest.DiffMatcher._
 
 import services.MatcherRequest
 import utils.Text
+import scala.util.matching.Regex
+import scala.concurrent.Future
 
 class RegexMatcherTest extends AsyncFlatSpec with Matchers {
   def createRules(textsToMatch: List[String]) = {
@@ -43,6 +45,19 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     markAsCorrect = markAsCorrect
   )
 
+  def checkTextWithRegex(regex: Regex, replacement: String, text: String): Future[List[RuleMatch]] = {
+    val rule = RegexRule(
+      id = "test-rule",
+      description = "test-description",
+      category = Category("test-category", "Test Category"),
+      regex = regex,
+      replacement = Some(TextSuggestion(replacement))
+    )
+
+    val validator = new RegexMatcher(List(rule))
+
+    validator.check(MatcherRequest(getBlocks(text)))
+  }
 
   "check" should "report single matches in short text" in {
     val sampleText = "example text is here"
@@ -205,6 +220,53 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
       val expectedReplacement = Some("nine-month-long")
       val expectedMatch = getMatch("nine month long", 2, 17, "A ", " sabbatical", rule, expectedReplacement)
       matches(0) should matchTo(expectedMatch)
+    }
+  }
+
+  behavior of "capitalisations"
+
+  it should "transform suggestions to respect sentence starts, to avoid suggesting capping down – preserve current case" in {
+    val eventuallyMatches = checkTextWithRegex(
+      "(?i)\\bcaf(e|é|è|ë|ê)"r,
+      "cafe",
+      "Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit"
+    )
+
+    eventuallyMatches.map { matches =>
+      matches.size shouldBe 1
+      val firstMatch = matches(0)
+      firstMatch.replacement shouldBe Some(TextSuggestion("Cafe"))
+      firstMatch.markAsCorrect shouldBe true
+    }
+  }
+
+  it should "transform suggestions to respect sentence starts, to avoid suggesting capping down – cap up sentence start" in {
+    val eventuallyMatches = checkTextWithRegex(
+      "(?i)\\bcaf(e|é|è|ë|ê)"r,
+      "cafe",
+      "Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit"
+    )
+
+    eventuallyMatches.map { matches =>
+      matches.size shouldBe 1
+      val firstMatch = matches(0)
+      firstMatch.replacement shouldBe Some(TextSuggestion("Cafe"))
+      firstMatch.markAsCorrect shouldBe false
+    }
+  }
+
+  it should "should not apply capitalisations when the match does not include the start of the word" in {
+    val eventuallyMatches = checkTextWithRegex(
+      "(?i)af(e|é|è|ë|ê)"r,
+      "afe",
+      "Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit"
+    )
+
+    eventuallyMatches.map { matches =>
+      matches.size shouldBe 1
+      val firstMatch = matches(0)
+      firstMatch.replacement shouldBe Some(TextSuggestion("afe"))
+      firstMatch.markAsCorrect shouldBe true
     }
   }
 }

--- a/checker/test/scala/services/SentenceHelperTest.scala
+++ b/checker/test/scala/services/SentenceHelperTest.scala
@@ -1,0 +1,20 @@
+package services
+
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import com.softwaremill.diffx.scalatest.DiffMatcher._
+import model.TextRange
+
+class SentenceHelperTest extends AsyncFlatSpec with Matchers {
+
+  behavior of "getFirstWordsInSentences"
+
+  it should "return sentence starts, including the word and range covered" in {
+    val sentenceTokenizer = new SentenceHelpers()
+    val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
+    firstWordsInSentences should matchTo(List(
+      WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
+      WordInSentence("Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(102, 107)),
+    ))
+  }
+}

--- a/docs/decision-records/001-regex-matcher-capitalisation.md
+++ b/docs/decision-records/001-regex-matcher-capitalisation.md
@@ -1,0 +1,35 @@
+# Checker: handling capitalisation in the regex matcher at sentence starts
+
+## Context
+
+At the moment, when we apply suggestions from regular expressions, there's sometimes an unexpected side effect: we overwrite casing in the matched text.
+
+For example, with regex (?i)\\bmedia?eval (note the (?i) flag, which means it's case insensitive), we always suggest the word medieval.
+
+This causes problems when words begin sentences, e.g. end of sentence. Medieval will produce a match suggesting medieval.
+
+## Positions
+
+### 1. Refactor the corpus to use capture groups for initial chars where appropriate
+
+... for example, `((i?)m)edieaval` with replacement `$1edieval`.
+
+- (+) Possible to arrive at correctness in this way
+- (-) It'll take a long time, as our corpus is large and we haven't annotated which rules have case-sensitive replacements
+
+### 2. Detect sentence starts and capitalise accordingly
+ 
+- (+) No changes to our corpus
+- (-) Possibly there are edge cases that we haven't yet considered
+
+## Decision
+
+We think detecting sentence starts is a better fit:
+- We have a large corpus that will take a great deal of work to refactor, and it's not possible to automate part of this work, as we must distinguish between replacements that care about capitalisation (e.g. `WhatsApp`, `alsatian` – the dog is always lower case!) and replacements that don't (e.g. `medieval`).
+- Detecting sentence starts allows us to make the correct suggestion when users have missed a capital at a sentence start and we're offering a replacement, which is a bonus.
+- We shouldn't spend too long on the corpus, as the rules that benefit from this case will likely be replaced by a dictionary approach sooner rather than later.
+
+## Consequences
+
+- We don't need to change the corpus
+- We may encounter edge cases as a result of the above approach, e.g. `ee cummings` at the start of a sentence, and as a result may have to a way of enforcing case at sentence starts.


### PR DESCRIPTION
Retry of #108, to address two performance issues – a combinatorial explosion in the sentence helper, and a mistake that meant we were tokenising each document _per-rule_ (😅). There are 13,000 rules. Yeah, this was a bit of a howler!

Our gatling tests are defunct at the moment, so I've run three checks with an article of ~5000 words, in seconds, on the PROD corpus:

Before: 2.73, 1.99, 1.84

First attempt: 54.64 (timeouts), 50.50, 47.70

This attempt: 2.16, 2.08, 1.90

This is a good prompt to add automated performance tests to our CI.

## What does this change?

At the moment, when we apply suggestions from regular expressions, there's sometimes an unexpected side effect: we overwrite casing in the matched text.

For example, with regex `(?i)\\bmedia?eval` (note the `(?i)` flag, which means it's case insensitive), we always suggest the word `medieval`. 

This causes problems when words begin sentences, e.g. `end of sentence. Medieval` will produce a match suggesting `medieval`.

This PR preserves case where possible, by detecting sentence starts. When a regex applies to a sentence start, and the starting characters of the suggestion and the match whilst ignoring case, we keep the casing of the match.

So given the regex `(?i)\bmedia?eval` with the replacement `medieval` where square brackets denote a match:

- `... [mediavel] castles` will produce the suggestion `medieval`
- `end of sentence. [Medieaval] castles` will produce the suggestion `Medieval`
- `end of sentence. [medieaval] castles` will produce the suggestion `Medieval`

The reason we preserve the suggestion on a perfect caseless match, rather than just stripping it, is to preserve the match's 'mark as correct' behaviour.

## How to test

The unit tests should pass.

E.g. the sentence `End of sentence. Mediaeval` should offer a correction to `Medieval`. Before, it would offer `medieval`.

## How can we measure success?

Fewer complaints about mistakes w/ casing in suggestions.

## Have we considered potential risks?

This is probably still not perfect, but the rules to which this apply are probably better addressed in the long run with a dictionary. Wonky edge cases gratefully received.
