### PR TITLE
Add a postgres database to the rule management service

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,10 @@ val commonSettings = Seq(
     )
   },
   libraryDependencies ++= Seq(
-    "net.logstash.logback" % "logstash-logback-encoder" % "6.0"
+    "net.logstash.logback" % "logstash-logback-encoder" % "6.0",
+    "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
+    "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.29" % Test,
+    "org.mockito" %% "mockito-scala-scalatest" % "1.16.2",
   )
 )
 
@@ -68,15 +71,12 @@ val checker = (project in file("checker")).enablePlugins(PlayScala, GatlingPlugi
     "com.google.apis" % "google-api-services-sheets" % "v4-rev516-1.23.0",
     "net.logstash.logback" % "logstash-logback-encoder" % "6.0",
     "com.gu" % "kinesis-logback-appender" % "1.4.4",
-    "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
-    "org.mockito" %% "mockito-scala-scalatest" % "1.16.2",
     "org.webjars" % "bootstrap" % "4.3.1",
     "com.gu" %% "content-api-models-scala" % capiModelsVersion,
     "com.gu" %% "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "content-api-client-aws" % "0.5",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "pan-domain-auth-verification" % "0.9.1",
-    "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.29" % Test,
     "biz.k11i" % "xgboost-predictor" % "0.3.1",
     "edu.stanford.nlp" % "stanford-corenlp" % "3.4",
     "edu.stanford.nlp" % "stanford-corenlp" % "3.4" classifier "models",

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,8 @@ val awsSdkVersion = "1.11.571"
 val capiModelsVersion = "15.8"
 val capiClientVersion = "16.0"
 val circeVersion = "0.12.3"
+val scalikejdbcVersion = scalikejdbc.ScalikejdbcBuildInfo.version
+val scalikejdbcPlayVersion = "2.8.0-scalikejdbc-3.5"
 
 val commonSettings = Seq(
   javaOptions in Universal ++= Seq(
@@ -89,14 +91,20 @@ val checker = (project in file("checker")).enablePlugins(PlayScala, GatlingPlugi
   libraryDependencies += "io.gatling"            % "gatling-test-framework"    % "3.0.2" % "test,it"
 )
 
-val ruleManager = (project in file("rule-manager")).enablePlugins(PlayScala, BuildInfoPlugin, JDebPackaging, SystemdPlugin).settings(
+val ruleManager = (project in file("rule-manager")).enablePlugins(PlayScala, BuildInfoPlugin, JDebPackaging, SystemdPlugin, ScalikejdbcPlugin).settings(
   packageName := "typerighter-rule-manager",
   PlayKeys.devSettings += "play.server.http.port" -> "9101",
   commonSettings,
   libraryDependencies ++= Seq(
     ws,
     guice,
-    "net.logstash.logback" % "logstash-logback-encoder" % "6.0"
+    jdbc,
+    evolutions,
+    "org.postgresql" % "postgresql" % "42.2.5",
+    "org.scalikejdbc" %% "scalikejdbc" % scalikejdbcVersion,
+    "org.scalikejdbc" %% "scalikejdbc-config" % scalikejdbcVersion,
+    "org.scalikejdbc" %% "scalikejdbc-play-initializer" % scalikejdbcPlayVersion,
+    "org.scalikejdbc" %% "scalikejdbc-test" % "3.5.0" % Test,
   )
 )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,11 @@ services:
             - POSTGRES_DB=tr-rule-manager-local
         volumes:
             - postgres-data:/var/lib/postgresql/data
-
+        healthcheck:
+          test: ["CMD-SHELL", "pg_isready -U postgres"]
+          interval: 10s
+          timeout: 5s
+          retries: 5
 volumes:
     postgres-data:
         driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.1'
+
+services:
+    postgres:
+        image: postgres:10.7-alpine
+        container_name: scalikejdbc-postgres-test
+        ports:
+            - 5432:5432
+        environment:
+            - POSTGRES_USER=test
+            - POSTGRES_PASSWORD=test
+            - POSTGRES_DB=test
+        volumes:
+            - postgres-data:/var/lib/postgresql/data
+
+volumes:
+    postgres-data:
+        driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,13 @@ version: '3.1'
 services:
     postgres:
         image: postgres:10.7-alpine
-        container_name: scalikejdbc-postgres-test
+        container_name: typerighter-rule-manager
         ports:
             - 5432:5432
         environment:
-            - POSTGRES_USER=test
-            - POSTGRES_PASSWORD=test
-            - POSTGRES_DB=test
+            - POSTGRES_USER=tr-rule-manager-local
+            - POSTGRES_PASSWORD=tr-rule-manager-local
+            - POSTGRES_DB=tr-rule-manager-local
         volumes:
             - postgres-data:/var/lib/postgresql/data
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,9 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
-
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
-
 addSbtPlugin("io.gatling" % "gatling-sbt" % "3.0.0")
-
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
-
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0") // "2.4.0" is just sbt plugin version
+addSbtPlugin("org.scalikejdbc" %% "scalikejdbc-mapper-generator" % "3.5.0")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.7" artifacts Artifact("jdeb", "jar", "jar")

--- a/rule-manager/app/AppComponents.scala
+++ b/rule-manager/app/AppComponents.scala
@@ -7,10 +7,15 @@ import play.api.http.PreferredMediaTypeHttpErrorHandler
 import play.api.http.JsonHttpErrorHandler
 import play.api.http.DefaultHttpErrorHandler
 import controllers.AssetsComponents
+import db.RuleManagerDB
 
 class AppComponents(context: Context) extends BuiltInComponentsFromContext(context) with HttpFiltersComponents with AssetsComponents {
-  
-  val homeController = new HomeController(controllerComponents)
+  val dbUrl = configuration.get[String]("db.default.url")
+  val dbUsername = configuration.get[String]("db.default.username")
+  val dbPassword = configuration.get[String]("db.default.password")
+  val db = new RuleManagerDB(dbUrl, dbUsername, dbPassword)
+
+  val homeController = new HomeController(controllerComponents, db)
 
   lazy val router = new Routes(
     httpErrorHandler,

--- a/rule-manager/app/controllers/HomeController.scala
+++ b/rule-manager/app/controllers/HomeController.scala
@@ -18,7 +18,7 @@ class HomeController(val controllerComponents: ControllerComponents, db: RuleMan
 
   def healthcheck() = Action { implicit request: Request[AnyContent] =>
     try {
-      db.testConnection()
+      db.connectionHealthy()
       Ok(Json.obj("healthy" -> true))
     } catch {
       case e: Throwable =>

--- a/rule-manager/app/controllers/HomeController.scala
+++ b/rule-manager/app/controllers/HomeController.scala
@@ -2,19 +2,33 @@ package controllers
 
 import play.api._
 import play.api.mvc._
+import _root_.db.RuleManagerDB
+import play.api.libs.json.Json
 
 /**
  * This controller creates an `Action` to handle HTTP requests to the
  * application's home page.
  */
 
-class HomeController(val controllerComponents: ControllerComponents) extends BaseController {
+class HomeController(val controllerComponents: ControllerComponents, db: RuleManagerDB) extends BaseController with Logging {
 
   def index() = Action { implicit request: Request[AnyContent] =>
     Ok(views.html.index())
   }
 
   def healthcheck() = Action { implicit request: Request[AnyContent] =>
-    Ok("""{ "healthy" : "true" }""")
+    try {
+      db.testConnection()
+      Ok(Json.obj("healthy" -> true))
+    } catch {
+      case e: Throwable =>
+        logger.error("Healthcheck failed", e)
+        InternalServerError(
+          Json.obj(
+            "healthy" -> false,
+            "error" -> e.getMessage()
+          )
+        )
+    }
   }
 }

--- a/rule-manager/app/db/RuleManagerDB.scala
+++ b/rule-manager/app/db/RuleManagerDB.scala
@@ -1,0 +1,18 @@
+package db
+
+import scalikejdbc._
+
+class RuleManagerDB(url: String, user: String, password: String) {
+  Class.forName("org.postgresql.Driver")
+  ConnectionPool.singleton(url, user, password)
+
+  def testConnection(): String = {
+    DB localTx { implicit session =>
+      sql""" SELECT 'HELLO WORLD' as hello_world """
+        .map { _.string("hello_world") }
+        .single()
+        .apply()
+        .get
+    }
+  }
+}

--- a/rule-manager/app/db/RuleManagerDB.scala
+++ b/rule-manager/app/db/RuleManagerDB.scala
@@ -6,13 +6,15 @@ class RuleManagerDB(url: String, user: String, password: String) {
   Class.forName("org.postgresql.Driver")
   ConnectionPool.singleton(url, user, password)
 
-  def testConnection(): String = {
-    DB localTx { implicit session =>
+  def connectionHealthy(): Boolean = {
+    val dbString = DB localTx { implicit session =>
       sql""" SELECT 'HELLO WORLD' as hello_world """
         .map { _.string("hello_world") }
         .single()
         .apply()
         .get
     }
+
+    dbString == "HELLO WORLD"
   }
 }

--- a/rule-manager/conf/application.conf
+++ b/rule-manager/conf/application.conf
@@ -1,3 +1,22 @@
 # https://www.playframework.com/documentation/latest/Configuration
 play.application.loader=AppLoader
 play.filters.hosts.allowed = [".dev-gutools.co.uk", ".gutools.co.uk", "localhost:9101"],
+
+db.default.driver="org.postgresql.Driver"
+db.default.url="jdbc:postgresql://localhost:5432/test"
+db.default.username="test"
+db.default.password="test"
+
+db.default.poolInitialSize=5
+db.default.poolMaxSize=7
+db.default.poolConnectionTimeoutMillis=1000
+
+scalikejdbc.global.loggingSQLAndTime.enabled=true
+scalikejdbc.global.loggingSQLAndTime.singleLineMode=false
+scalikejdbc.global.loggingSQLAndTime.logLevel=debug
+scalikejdbc.global.loggingSQLAndTime.warningEnabled=true
+scalikejdbc.global.loggingSQLAndTime.warningThresholdMillis=5
+scalikejdbc.global.loggingSQLAndTime.warningLogLevel=warn
+
+play.modules.enabled += "scalikejdbc.PlayModule"
+play.modules.disabled += "play.api.db.DBModule"

--- a/rule-manager/conf/application.conf
+++ b/rule-manager/conf/application.conf
@@ -3,9 +3,9 @@ play.application.loader=AppLoader
 play.filters.hosts.allowed = [".dev-gutools.co.uk", ".gutools.co.uk", "localhost:9101"],
 
 db.default.driver="org.postgresql.Driver"
-db.default.url="jdbc:postgresql://localhost:5432/test"
-db.default.username="test"
-db.default.password="test"
+db.default.url="jdbc:postgresql://localhost:5432/tr-rule-manager-local"
+db.default.username="tr-rule-manager-local"
+db.default.password="tr-rule-manager-local"
 
 db.default.poolInitialSize=5
 db.default.poolMaxSize=7

--- a/rule-manager/test/db/RuleManagerDBTest.scala
+++ b/rule-manager/test/db/RuleManagerDBTest.scala
@@ -1,0 +1,21 @@
+package db
+
+import scalikejdbc.scalatest.AutoRollback
+import org.scalatest.fixture.FlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RuleManagerDBTest
+  extends FlatSpec
+  with Matchers
+  with AutoRollback {
+  val url ="jdbc:postgresql://localhost:5432/tr-rule-manager-local"
+  val username ="tr-rule-manager-local"
+  val password ="tr-rule-manager-local"
+  val ruleManagerDb = new RuleManagerDB(url, username, password)
+
+  behavior of "Database connection"
+
+  it should "provide a way of testing the DB connection" in { implicit session =>
+    ruleManagerDb.connectionHealthy() shouldBe true
+  }
+}

--- a/script/citest
+++ b/script/citest
@@ -2,38 +2,40 @@
 
 set -e
 
-function setupTestDeps {
+MAX_DB_ATTEMPTS=5
+
+setupTestDeps() {
   docker-compose up -d
   # Ensure localstack is up, and relevant resources have been created
-  for ATTEMPT in {1..5}
+  for ATTEMPT in $(seq 1 $MAX_DB_ATTEMPTS)
   do
     pg_isready -h localhost -p 5432 --quiet -t 5 && echo "Postgres DB – ready" && break
-    echo "Postgres DB – waiting ($ATTEMPT/5)"
+    echo "Postgres DB – waiting ($ATTEMPT/$MAX_DB_ATTEMPTS)"
     sleep 5
   done
 }
 
-function teardownTestDeps {
+teardownTestDeps() {
   docker-compose down
 }
 
-function buildClients {
-  (cd rule-manager/rule-manager-client && npm i && npm run build)
+buildClients() {
   (cd rule-audit-client && npm i && npm run build)
+  (cd rule-manager/rule-manager-client && npm i && npm run build)
 }
 
-function buildSbt {
+buildSbt() {
   sbt clean compile test riffRaffNotifyTeamcity
 }
 
-function setup {
+setup() {
   setupTestDeps
   buildClients
   buildSbt
   teardownTestDeps
 }
 
-function teardown {
+teardown() {
   teardownTestDeps
 }
 

--- a/script/citest
+++ b/script/citest
@@ -1,8 +1,49 @@
 #!/bin/sh -e
 
-(cd rule-audit-client && npm i && npm run build)
+set -e
 
-(cd rule-manager/rule-manager-client && npm i && npm run build)
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR=${DIR}/..
 
+RULE_MANAGEMENT_DIR="$ROOT_DIR/rule-manager"
+MAX_DB_ATTEMPTS=5
 
-sbt clean compile test riffRaffNotifyTeamcity
+function setupTestDeps {
+  docker-compose up -d
+  # Ensure localstack is up, and relevant resources have been created
+  for ATTEMPT in $(seq 1 $MAX_DB_ATTEMPTS)
+  do
+    pg_isready -h localhost -p 5432 --quiet -t 5 && echo "Postgres DB – ready" && break
+    echo "Postgres DB – waiting ($ATTEMPT/$MAX_DB_ATTEMPTS)"
+    sleep 5
+  done
+}
+
+function teardownTestDeps {
+  docker-compose down
+}
+
+function buildClients {
+  (cd rule-manager/rule-manager-client && npm i && npm run build)
+  (cd rule-audit-client && npm i && npm run build)
+}
+
+function buildSbt {
+  sbt clean compile test riffRaffNotifyTeamcity
+}
+
+function setup {
+  setupTestDeps
+  buildClients
+  buildSbt
+  teardownTestDeps
+}
+
+function teardown {
+  teardownTestDeps
+}
+
+trap teardown EXIT
+
+setup
+teardown

--- a/script/citest
+++ b/script/citest
@@ -2,19 +2,13 @@
 
 set -e
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT_DIR=${DIR}/..
-
-RULE_MANAGEMENT_DIR="$ROOT_DIR/rule-manager"
-MAX_DB_ATTEMPTS=5
-
 function setupTestDeps {
   docker-compose up -d
   # Ensure localstack is up, and relevant resources have been created
-  for ATTEMPT in $(seq 1 $MAX_DB_ATTEMPTS)
+  for ATTEMPT in {1..5}
   do
     pg_isready -h localhost -p 5432 --quiet -t 5 && echo "Postgres DB – ready" && break
-    echo "Postgres DB – waiting ($ATTEMPT/$MAX_DB_ATTEMPTS)"
+    echo "Postgres DB – waiting ($ATTEMPT/5)"
     sleep 5
   done
 }

--- a/script/citest
+++ b/script/citest
@@ -6,11 +6,21 @@ MAX_DB_ATTEMPTS=5
 
 setupTestDeps() {
   docker-compose up -d
-  # Ensure localstack is up, and relevant resources have been created
+  # Ensure containers are up
   for ATTEMPT in $(seq 1 $MAX_DB_ATTEMPTS)
   do
-    pg_isready -h localhost -p 5432 --quiet -t 5 && echo "Postgres DB – ready" && break
-    echo "Postgres DB – waiting ($ATTEMPT/$MAX_DB_ATTEMPTS)"
+    HEALTH_STATUS=$(docker inspect --format "{{json .State.Health }}" $(docker-compose ps -q) | jq .Status)
+    if [ $HEALTH_STATUS = "\"healthy\"" ]
+    then
+      echo "Docker containers – started"
+      break
+    fi
+    if [ $ATTEMPT -eq 5 ]
+    then
+      echo "Docker containers did not initialise in $MAX_DB_ATTEMPTS attempts"
+      exit 1
+    fi
+    echo "Docker containers – waiting, as status=$HEALTH_STATUS (expects \"healthy\") ($ATTEMPT/$MAX_DB_ATTEMPTS)"
     sleep 5
   done
 }

--- a/script/start
+++ b/script/start
@@ -1,16 +1,5 @@
 #!/bin/bash -e
 
-STATUS=$(aws sts get-caller-identity --profile composer 2>&1 || true)
-if [[ ${STATUS} =~ (ExpiredToken) ]]; then
-  echo -e "${red}Credentials for the composer profile are expired. Please fetch new credentials and run this again.${plain}"
-  exit 1
-elif [[ ${STATUS} =~ ("could not be found") ]]; then
-  echo -e "${red}Credentials for the composer profile are missing. Please ensure you have the right credentials.${plain}"
-  exit 1
-fi
-
-(cd rule-manager/rule-manager-client && npm i && npm run start)
-
 IS_DEBUG=false
 for arg in "$@"
 do
@@ -20,8 +9,35 @@ do
   fi
 done
 
-if [[ "$IS_DEBUG" = true ]] ; then
-  sbt -jvm-debug 5005 run
-else
-  sbt "checker / run"
-fi
+function checkCredentials {
+  STATUS=$(aws sts get-caller-identity --profile composer 2>&1 || true)
+  if [[ ${STATUS} =~ (ExpiredToken) ]]; then
+    echo -e "${red}Credentials for the composer profile are expired. Please fetch new credentials and run this again.${plain}"
+    exit 1
+  elif [[ ${STATUS} =~ ("could not be found") ]]; then
+    echo -e "${red}Credentials for the composer profile are missing. Please ensure you have the right credentials.${plain}"
+    exit 1
+  fi
+}
+
+function setupDependencies {
+  docker-compose up -d
+  (cd rule-manager/rule-manager-client && npm i && npm run start)
+}
+
+function teardownDependencies {
+  docker-compose down
+}
+
+function runApp {
+  if [[ "$IS_DEBUG" = true ]] ; then
+    sbt -jvm-debug 5005 run
+  else
+    sbt "checker / run"
+  fi
+}
+
+trap teardownDependencies EXIT
+
+setupDependencies
+runApp

--- a/script/start
+++ b/script/start
@@ -9,7 +9,7 @@ do
   fi
 done
 
-function checkCredentials {
+checkCredentials() {
   STATUS=$(aws sts get-caller-identity --profile composer 2>&1 || true)
   if [[ ${STATUS} =~ (ExpiredToken) ]]; then
     echo -e "${red}Credentials for the composer profile are expired. Please fetch new credentials and run this again.${plain}"
@@ -20,16 +20,16 @@ function checkCredentials {
   fi
 }
 
-function setupDependencies {
+setupDependencies() {
   docker-compose up -d
   (cd rule-manager/rule-manager-client && npm i && npm run start)
 }
 
-function teardownDependencies {
+teardownDependencies() {
   docker-compose down
 }
 
-function runApp {
+runApp() {
   if [[ "$IS_DEBUG" = true ]] ; then
     sbt -jvm-debug 5005 run
   else

--- a/script/start
+++ b/script/start
@@ -22,7 +22,7 @@ checkCredentials() {
 
 setupDependencies() {
   docker-compose up -d
-  (cd rule-manager/rule-manager-client && npm i && npm run start)
+  (cd rule-manager/rule-manager-client && npm i && npm run build)
 }
 
 teardownDependencies() {


### PR DESCRIPTION
## What does this change?

Adds a DB integration using [scalikejdbc](http://scalikejdbc.org/). Uses the db ops trait pattern found in [facia-tool](https://github.com/guardian/facia-tool/blob/main/app/services/editions/db/EditionsDB.scala).

In light of the issues we've had testing in different CI environments in the Grid (e.g. GHA), we've opted for a docker-compose call within a script for local and CI in place of a Dockerkit based solution. This also means that both local and test rely on the same set of definitions for their environment, but v. happy to consider other solutions if anyone has other suggestions/opinions.

## How to test

The healthcheck should pass, and the tests should pass locally and in CI – they're all now dependent on an active database connection.

## How can we measure success?

We have a database implementation that works in our local and CI environments, and it's easy to test against.

Infra work to follow in a separate PR.