### PR TITLE
Add project for common dependencies

### DIFF
--- a/apps/checker/app/AppComponents.scala
+++ b/apps/checker/app/AppComponents.scala
@@ -20,7 +20,7 @@ import play.filters.cors.CORSComponents
 import router.Routes
 import rules.{BucketRuleManager, SheetsRuleManager}
 import services._
-import utils.Loggable
+import com.gu.typerighter.lib.{Loggable, ElkLogging}
 import matchers.LanguageToolFactory
 import utils.CloudWatchClient
 
@@ -63,11 +63,11 @@ class AppComponents(context: Context, identity: AppIdentity, creds: AWSCredentia
     case _ => "code"
   }
   val typerighterBucket = s"typerighter-${stage}"
- 
+
   val cloudWatchClient = identity match {
     case identity: AwsIdentity => new CloudWatchClient(stage, false)
     case _ : DevIdentity => new CloudWatchClient(stage, true)
-  } 
+  }
 
   val matcherPoolDispatcher = actorSystem.dispatchers.lookup("matcher-pool-dispatcher")
   val defaultFutures = new DefaultFutures(actorSystem)

--- a/apps/checker/app/controllers/ApiController.scala
+++ b/apps/checker/app/controllers/ApiController.scala
@@ -5,7 +5,8 @@ import com.gu.pandomainauth.PublicSettings
 import model.{Check, MatcherResponse}
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc._
-import services.{PandaAuthentication, MatcherPool}
+import services.MatcherPool
+import com.gu.typerighter.lib.PandaAuthentication
 
 import scala.concurrent.{ExecutionContext, Future}
 import utils.Timer

--- a/apps/checker/app/controllers/AuditController.scala
+++ b/apps/checker/app/controllers/AuditController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import play.api.mvc._
 import com.gu.pandomainauth.PublicSettings
-import services.PandaAuthentication
+import com.gu.typerighter.lib.PandaAuthentication
 import scala.concurrent.ExecutionContext
 
 /**

--- a/apps/checker/app/controllers/CapiProxyController.scala
+++ b/apps/checker/app/controllers/CapiProxyController.scala
@@ -4,7 +4,10 @@ import com.gu.contentapi.json.CirceEncoders._
 import io.circe.syntax._
 import play.api.mvc._
 import com.gu.pandomainauth.PublicSettings
-import services.{ContentClient, PandaAuthentication}
+import com.gu.typerighter.lib.PandaAuthentication
+
+import services.ContentClient
+
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/apps/checker/app/controllers/HomeController.scala
+++ b/apps/checker/app/controllers/HomeController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import play.api.mvc._
 import com.gu.pandomainauth.PublicSettings
-import services.PandaAuthentication
+import com.gu.typerighter.lib.PandaAuthentication
 
 import scala.concurrent.ExecutionContext
 

--- a/apps/checker/app/controllers/RulesController.scala
+++ b/apps/checker/app/controllers/RulesController.scala
@@ -2,8 +2,10 @@ package controllers
 
 import matchers.{LanguageToolFactory, RegexMatcher}
 import com.gu.pandomainauth.PublicSettings
-import model.{Category, RegexRule}
+import com.gu.typerighter.lib.PandaAuthentication
 import play.api.mvc._
+
+import model.{Category, RegexRule}
 import rules.{BucketRuleManager, SheetsRuleManager}
 import services._
 

--- a/apps/checker/app/utils/CloudWatchClient.scala
+++ b/apps/checker/app/utils/CloudWatchClient.scala
@@ -6,6 +6,8 @@ import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
 import com.amazonaws.services.cloudwatch.model.StandardUnit;
 
+import com.gu.typerighter.lib.Loggable
+
 object Metrics {
   val RulesIngested = "RulesIngested"
   val RulesNotFound = "RulesNotFound"

--- a/apps/common-lib/README.md
+++ b/apps/common-lib/README.md
@@ -1,0 +1,5 @@
+## common-lib
+
+This folder is for dependencies that are common to all projects – for example, authentication and logging.
+
+Think carefully before adding things to this folder – does every part of what you're adding truly belong here?

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/lib/ElkLogging.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/lib/ElkLogging.scala
@@ -1,4 +1,4 @@
-package services
+package com.gu.typerighter.lib
 
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.{AsyncAppender, Logger, LoggerContext}
@@ -13,7 +13,8 @@ import org.slf4j.{LoggerFactory, Logger => SLFLogger}
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.json.{Json => PlayJson}
 import typerighter.BuildInfo
-import utils.Loggable
+
+import com.gu.typerighter.lib
 
 import scala.util.control.NonFatal
 

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/lib/Loggable.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/lib/Loggable.scala
@@ -1,4 +1,4 @@
-package utils
+package com.gu.typerighter.lib
 
 import org.slf4j.{Logger, LoggerFactory}
 

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/lib/PandaAuthentication.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/lib/PandaAuthentication.scala
@@ -1,9 +1,10 @@
-package services
+package com.gu.typerighter.lib
 
 import com.gu.pandomainauth.model.{Authenticated, AuthenticatedUser, AuthenticationStatus, User}
 import com.gu.pandomainauth.{PanDomain, PublicKey, PublicSettings}
 import play.api.mvc._
-import utils.Loggable
+
+import com.gu.typerighter.lib.Loggable
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ val commonSettings = Seq(
     s"-Dconfig.file=/etc/gu/${packageName.value}.conf"
   ),
   buildInfoPackage := "typerighter",
+  resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms",
   buildInfoKeys := {
     lazy val buildInfo = BuildInfo(baseDirectory.value)
     Seq[BuildInfoKey](
@@ -46,70 +47,87 @@ val commonSettings = Seq(
     "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
     "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.29" % Test,
     "org.mockito" %% "mockito-scala-scalatest" % "1.16.2",
-  )
-)
-
-val checker = (project in file(s"$appsFolder/checker")).enablePlugins(PlayScala, GatlingPlugin, BuildInfoPlugin, JDebPackaging, SystemdPlugin).settings(
-  packageName := "typerighter-checker",
-  PlayKeys.devSettings += "play.server.http.port" -> "9100",
-  commonSettings,
-  resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms",
-  // Used to resolve xgboost-predictor, which is no longer available
-  // at spring.io without auth.
-  resolvers += "komiya-atsushi Bintray" at "https://dl.bintray.com/komiya-atsushi/maven",
-  libraryDependencies ++= Seq(
-    ws,
-    "com.gu" %% "simple-configuration-ssm" % "1.5.0",
-    "org.languagetool" % "languagetool-core" % languageToolVersion,
-    "org.languagetool" % "language-en" % languageToolVersion,
-    "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
-    "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
-    "com.amazonaws" % "aws-java-sdk-ssm" % awsSdkVersion,
-    "com.amazonaws" % "aws-java-sdk-kinesis" % awsSdkVersion,
-    "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
-    "com.google.api-client" % "google-api-client" % "1.23.0",
-    "com.google.oauth-client" % "google-oauth-client-jetty" % "1.23.0",
-    "com.google.apis" % "google-api-services-sheets" % "v4-rev516-1.23.0",
-    "net.logstash.logback" % "logstash-logback-encoder" % "6.0",
     "com.gu" % "kinesis-logback-appender" % "1.4.4",
-    "org.webjars" % "bootstrap" % "4.3.1",
-    "com.gu" %% "content-api-models-scala" % capiModelsVersion,
-    "com.gu" %% "content-api-models-json" % capiModelsVersion,
-    "com.gu" %% "content-api-client-aws" % "0.5",
-    "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "pan-domain-auth-verification" % "0.9.1",
-    "biz.k11i" % "xgboost-predictor" % "0.3.1",
-    "edu.stanford.nlp" % "stanford-corenlp" % "3.4",
-    "edu.stanford.nlp" % "stanford-corenlp" % "3.4" classifier "models",
-    "edu.stanford.nlp" % "stanford-parser" % "3.4",
-  ),
-  libraryDependencies ++= Seq(
-    "io.circe" %% "circe-core",
-    "io.circe" %% "circe-generic",
-    "io.circe" %% "circe-parser"
-  ).map(_ % circeVersion),
-  libraryDependencies += "io.gatling.highcharts" % "gatling-charts-highcharts" % "3.0.2" % "test,it",
-  libraryDependencies += "io.gatling"            % "gatling-test-framework"    % "3.0.2" % "test,it"
-)
-
-val ruleManager = (project in file(s"$appsFolder/rule-manager")).enablePlugins(PlayScala, BuildInfoPlugin, JDebPackaging, SystemdPlugin, ScalikejdbcPlugin).settings(
-  packageName := "typerighter-rule-manager",
-  PlayKeys.devSettings += "play.server.http.port" -> "9101",
-  commonSettings,
-  libraryDependencies ++= Seq(
-    ws,
-    guice,
-    jdbc,
-    evolutions,
-    "org.postgresql" % "postgresql" % "42.2.5",
-    "org.scalikejdbc" %% "scalikejdbc" % scalikejdbcVersion,
-    "org.scalikejdbc" %% "scalikejdbc-config" % scalikejdbcVersion,
-    "org.scalikejdbc" %% "scalikejdbc-play-initializer" % scalikejdbcPlayVersion,
-    "org.scalikejdbc" %% "scalikejdbc-test" % "3.5.0" % Test,
+    "com.gu" %% "simple-configuration-ssm" % "1.5.0"
   )
 )
 
-val root = (project in file(".")).aggregate(checker, ruleManager).enablePlugins(RiffRaffArtifact)
+val commonLib = (project in file(s"$appsFolder/common-lib"))
+  .enablePlugins(BuildInfoPlugin)
+  .settings(
+    packageName := "common-lib",
+    commonSettings,
+    libraryDependencies ++= Seq(
+      // @todo – we're repeating ourselves. Can we derive this from the plugin?
+      "com.typesafe.play" %% "play" % "2.8.0",
+      "com.gu" % "kinesis-logback-appender" % "1.4.2"
+    )
+  )
+
+val checker = (project in file(s"$appsFolder/checker"))
+  .dependsOn(commonLib)
+  .enablePlugins(PlayScala, GatlingPlugin, BuildInfoPlugin, JDebPackaging, SystemdPlugin)
+  .settings(
+    packageName := "typerighter-checker",
+    PlayKeys.devSettings += "play.server.http.port" -> "9100",
+    commonSettings,
+    // Used to resolve xgboost-predictor, which is no longer available
+    // at spring.io without auth.
+    resolvers += "komiya-atsushi Bintray" at "https://dl.bintray.com/komiya-atsushi/maven",
+    libraryDependencies ++= Seq(
+      ws,
+      "org.languagetool" % "languagetool-core" % languageToolVersion,
+      "org.languagetool" % "language-en" % languageToolVersion,
+      "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-ssm" % awsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-kinesis" % awsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
+      "com.google.api-client" % "google-api-client" % "1.23.0",
+      "com.google.oauth-client" % "google-oauth-client-jetty" % "1.23.0",
+      "com.google.apis" % "google-api-services-sheets" % "v4-rev516-1.23.0",
+      "net.logstash.logback" % "logstash-logback-encoder" % "6.0",
+      "org.webjars" % "bootstrap" % "4.3.1",
+      "com.gu" %% "content-api-models-scala" % capiModelsVersion,
+      "com.gu" %% "content-api-models-json" % capiModelsVersion,
+      "com.gu" %% "content-api-client-aws" % "0.5",
+      "com.gu" %% "content-api-client-default" % capiClientVersion,
+      "biz.k11i" % "xgboost-predictor" % "0.3.1",
+      "edu.stanford.nlp" % "stanford-corenlp" % "3.4",
+      "edu.stanford.nlp" % "stanford-corenlp" % "3.4" classifier "models",
+      "edu.stanford.nlp" % "stanford-parser" % "3.4",
+    ),
+    libraryDependencies ++= Seq(
+      "io.circe" %% "circe-core",
+      "io.circe" %% "circe-generic",
+      "io.circe" %% "circe-parser"
+    ).map(_ % circeVersion),
+    libraryDependencies += "io.gatling.highcharts" % "gatling-charts-highcharts" % "3.0.2" % "test,it",
+    libraryDependencies += "io.gatling"            % "gatling-test-framework"    % "3.0.2" % "test,it"
+  )
+
+val ruleManager = (project in file(s"$appsFolder/rule-manager"))
+  .dependsOn(commonLib)
+  .enablePlugins(PlayScala, BuildInfoPlugin, JDebPackaging, SystemdPlugin, ScalikejdbcPlugin)
+  .settings(
+    packageName := "typerighter-rule-manager",
+    PlayKeys.devSettings += "play.server.http.port" -> "9101",
+    commonSettings,
+    libraryDependencies ++= Seq(
+      ws,
+      guice,
+      jdbc,
+      evolutions,
+      "org.postgresql" % "postgresql" % "42.2.5",
+      "org.scalikejdbc" %% "scalikejdbc" % scalikejdbcVersion,
+      "org.scalikejdbc" %% "scalikejdbc-config" % scalikejdbcVersion,
+      "org.scalikejdbc" %% "scalikejdbc-play-initializer" % scalikejdbcPlayVersion,
+      "org.scalikejdbc" %% "scalikejdbc-test" % "3.5.0" % Test,
+    )
+  )
+
+val root = (project in file(".")).aggregate(commonLib, checker, ruleManager).enablePlugins(RiffRaffArtifact)
 
 riffRaffArtifactResources := Seq(
   (packageBin in Debian in checker).value  -> s"${(packageName in checker).value}/${(packageName in checker).value}.deb",


### PR DESCRIPTION
## What does this change?

Adds a folder to share common dependencies across projects, and moves the code we expect to share with the rule manager service – Elk logging, shared logging interfaces, and panda authentication.

## How to test

This is a no-op, everything should work as before.

Does everything added to the shared folder belong? Might be worth checking out locally and having a look around.