### PR TITLE
Add edit permissions

### DIFF
--- a/apps/checker/app/AppComponents.scala
+++ b/apps/checker/app/AppComponents.scala
@@ -36,7 +36,7 @@ class AppComponents(context: Context, identity: AppIdentity, creds: AWSCredentia
 
   override def httpFilters: Seq[EssentialFilter] = corsFilter +: super.httpFilters.filterNot(allowedHostsFilter ==)
 
-  val config = new CheckerConfig(configuration, identity)
+  val config = new CheckerConfig(configuration, identity, creds)
 
   // initialise log shipping if we are in AWS
   private val logShipping = Some(identity).collect{ case awsIdentity: AwsIdentity =>

--- a/apps/checker/app/utils/CheckerConfig.scala
+++ b/apps/checker/app/utils/CheckerConfig.scala
@@ -1,0 +1,15 @@
+package utils
+
+import java.io.File
+
+import com.gu.AppIdentity
+import com.gu.typerighter.lib.CommonConfig
+import play.api.Configuration
+import com.amazonaws.auth.AWSCredentialsProvider
+
+class CheckerConfig(playConfig: Configuration, identity: AppIdentity, creds: AWSCredentialsProvider) extends CommonConfig(playConfig, identity, creds) {
+  val ngramPath: Option[File] = playConfig.getOptional[String]("typerighter.ngramPath").map(new File(_))
+  val capiApiKey = playConfig.get[String]("capi.apiKey")
+  val credentials = playConfig.get[String]("typerighter.google.credentials")
+  val spreadsheetId = playConfig.get[String]("typerighter.sheetId")
+}

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/lib/CommonConfig.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/lib/CommonConfig.scala
@@ -4,18 +4,24 @@ import play.api.Configuration
 import com.gu.AppIdentity
 import com.gu.AwsIdentity
 import com.gu.DevIdentity
+import com.amazonaws.auth.AWSCredentialsProvider
 
 /**
   * A class to store configuration that's common across projects.
   *
   * Fails fast with an exception if properties aren't found.
   */
-abstract class CommonConfig(playConfig: Configuration, identity: AppIdentity) {
-  val dbUrl = playConfig.get[String]("db.default.url")
-  val dbUsername = playConfig.get[String]("db.default.username")
-  val dbPassword = playConfig.get[String]("db.default.password")
-
+abstract class CommonConfig(playConfig: Configuration, identity: AppIdentity, credentials: AWSCredentialsProvider) {
+  val awsCredentials = credentials
+  val awsRegion = playConfig.getOptional[String]("aws.region").getOrElse("eu-west-1")
   val loggingStreamName = playConfig.getOptional[String]("typerighter.loggingStreamName")
+
+  val permissionsBucket = playConfig.getOptional[String]("permissions.bucket").getOrElse("permissions-cache")
+
+  val stage = identity match {
+    case identity: AwsIdentity => identity.stage.toLowerCase
+    case _ => "code"
+  }
 
   val stageDomain = identity match {
     case identity: AwsIdentity if identity.stage == "PROD" => "gutools.co.uk"

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/lib/CommonConfig.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/lib/CommonConfig.scala
@@ -1,0 +1,30 @@
+package com.gu.typerighter.lib
+
+import play.api.Configuration
+import com.gu.AppIdentity
+import com.gu.AwsIdentity
+import com.gu.DevIdentity
+
+/**
+  * A class to store configuration that's common across projects.
+  *
+  * Fails fast with an exception if properties aren't found.
+  */
+abstract class CommonConfig(playConfig: Configuration, identity: AppIdentity) {
+  val dbUrl = playConfig.get[String]("db.default.url")
+  val dbUsername = playConfig.get[String]("db.default.username")
+  val dbPassword = playConfig.get[String]("db.default.password")
+
+  val loggingStreamName = playConfig.getOptional[String]("typerighter.loggingStreamName")
+
+  val stageDomain = identity match {
+    case identity: AwsIdentity if identity.stage == "PROD" => "gutools.co.uk"
+    case identity: AwsIdentity => s"${identity.stage.toLowerCase}.dev-gutools.co.uk"
+    case _: DevIdentity => "local.dev-gutools.co.uk"
+  }
+
+  val appName = identity match {
+    case identity: AwsIdentity => identity.app
+    case identity: DevIdentity => identity.app
+  }
+}

--- a/apps/rule-manager/app/AppComponents.scala
+++ b/apps/rule-manager/app/AppComponents.scala
@@ -5,6 +5,7 @@ import play.api.BuiltInComponentsFromContext
 import play.api.http.PreferredMediaTypeHttpErrorHandler
 import play.api.http.JsonHttpErrorHandler
 import play.api.http.DefaultHttpErrorHandler
+import play.api.libs.ws.ahc.AhcWSComponents
 import controllers.AssetsComponents
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.auth.AWSCredentialsProvider
@@ -16,15 +17,14 @@ import com.gu.DevIdentity
 import router.Routes
 import controllers.HomeController
 import db.RuleManagerDB
-import play.api.libs.ws.ahc.AhcWSComponents
-import com.gu.typerighter.lib.CommonConfig
+import utils.RuleManagerConfig
 
 class AppComponents(context: Context, identity: AppIdentity, creds: AWSCredentialsProvider)
   extends BuiltInComponentsFromContext(context)
   with HttpFiltersComponents
   with AssetsComponents
   with AhcWSComponents {
-  val config = new RuleManagerConfig(configuration, identity)
+  val config = new RuleManagerConfig(configuration, identity, creds)
   val db = new RuleManagerDB(config.dbUrl, config.dbUsername, config.dbPassword)
 
   private val s3Client = AmazonS3ClientBuilder.standard().withCredentials(creds).withRegion(AppIdentity.region).build()
@@ -51,7 +51,7 @@ class AppComponents(context: Context, identity: AppIdentity, creds: AWSCredentia
     db,
     panDomainSettings,
     wsClient,
-    stageDomain
+    config
   )
 
   lazy val router = new Routes(

--- a/apps/rule-manager/app/AppComponents.scala
+++ b/apps/rule-manager/app/AppComponents.scala
@@ -17,16 +17,15 @@ import router.Routes
 import controllers.HomeController
 import db.RuleManagerDB
 import play.api.libs.ws.ahc.AhcWSComponents
+import com.gu.typerighter.lib.CommonConfig
 
 class AppComponents(context: Context, identity: AppIdentity, creds: AWSCredentialsProvider)
   extends BuiltInComponentsFromContext(context)
   with HttpFiltersComponents
   with AssetsComponents
   with AhcWSComponents {
-  val dbUrl = configuration.get[String]("db.default.url")
-  val dbUsername = configuration.get[String]("db.default.username")
-  val dbPassword = configuration.get[String]("db.default.password")
-  val db = new RuleManagerDB(dbUrl, dbUsername, dbPassword)
+  val config = new RuleManagerConfig(configuration, identity)
+  val db = new RuleManagerDB(config.dbUrl, config.dbUsername, config.dbPassword)
 
   private val s3Client = AmazonS3ClientBuilder.standard().withCredentials(creds).withRegion(AppIdentity.region).build()
   val stageDomain = identity match {

--- a/apps/rule-manager/app/controllers/AuthActions.scala
+++ b/apps/rule-manager/app/controllers/AuthActions.scala
@@ -6,9 +6,10 @@ import com.gu.pandomainauth.model.AuthenticatedUser
 import com.gu.typerighter.lib.Loggable
 import org.slf4j.LoggerFactory
 import play.api.{Configuration}
+import com.gu.typerighter.lib.CommonConfig
 
 trait AppAuthActions extends AuthActions with Loggable {
-  val authDomain: String
+  def config: CommonConfig
 
   override def validateUser(authedUser: AuthenticatedUser): Boolean = {
     log.info(s"Validating user $authedUser")
@@ -22,5 +23,5 @@ trait AppAuthActions extends AuthActions with Loggable {
     */
   override def cacheValidation = false
 
-  override def authCallbackUrl: String = s"https://typerighter.${authDomain}/oauthCallback"
+  override def authCallbackUrl: String = s"https://typerighter.${config.stageDomain}/oauthCallback"
 }

--- a/apps/rule-manager/app/controllers/HomeController.scala
+++ b/apps/rule-manager/app/controllers/HomeController.scala
@@ -11,14 +11,20 @@ import com.gu.typerighter.lib.Loggable
 
 import _root_.db.RuleManagerDB
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import utils.PermissionsHandler
+import com.gu.permissions.PermissionDefinition
+import utils.RuleManagerConfig
 
 class HomeController(
   val controllerComponents: ControllerComponents,
   val db: RuleManagerDB,
   override val panDomainSettings: PanDomainAuthSettingsRefresher,
   override val wsClient: WSClient,
-  override val authDomain: String
-) extends BaseController with Loggable with AppAuthActions {
+  override val config: RuleManagerConfig
+) extends BaseController
+  with Loggable
+  with AppAuthActions
+  with PermissionsHandler {
 
   def index() = AuthAction { implicit request: Request[AnyContent] =>
     Ok(views.html.index())
@@ -37,6 +43,13 @@ class HomeController(
             "error" -> e.getMessage()
           )
         )
+    }
+  }
+
+  def editPermissionCheck() = AuthAction { implicit request =>
+    hasPermission(request.user, PermissionDefinition("manage_rules", "typerighter")) match {
+      case true => Ok("Permission granted")
+      case false => Unauthorized("You don't have permission to edit rules")
     }
   }
 

--- a/apps/rule-manager/app/utils/Permissions.scala
+++ b/apps/rule-manager/app/utils/Permissions.scala
@@ -1,0 +1,27 @@
+package utils
+
+import com.gu.permissions._
+
+import scala.concurrent.duration._
+import com.gu.pandomainauth.model.User
+import com.gu.typerighter.lib.CommonConfig
+
+object PermissionDeniedError extends Throwable("Permission denied")
+
+trait PermissionsHandler {
+  def config: CommonConfig
+
+  private val permissionsStage = if(config.stage == "prod" ) { "PROD" } else { "CODE" }
+  private val permissions = PermissionsProvider(PermissionsConfig(permissionsStage, config.awsRegion, config.awsCredentials, config.permissionsBucket))
+
+  def storeIsEmpty: Boolean = {
+    permissions.storeIsEmpty
+  }
+
+  def hasPermission(user: User, permission: PermissionDefinition): Boolean = {
+    user match {
+      case User(_, _, email, _) => permissions.hasPermission(permission, email)
+      case _ => false
+    }
+  }
+}

--- a/apps/rule-manager/app/utils/RuleManagerConfig.scala
+++ b/apps/rule-manager/app/utils/RuleManagerConfig.scala
@@ -1,0 +1,9 @@
+package utils
+
+import play.api.Configuration
+import com.gu.typerighter.lib.CommonConfig
+package utils
+
+import com.gu.AppIdentity
+
+class RuleManagerConfig(playConfig: Configuration, identity: AppIdentity) extends CommonConfig(playConfig, identity)

--- a/apps/rule-manager/app/utils/RuleManagerConfig.scala
+++ b/apps/rule-manager/app/utils/RuleManagerConfig.scala
@@ -2,8 +2,11 @@ package utils
 
 import play.api.Configuration
 import com.gu.typerighter.lib.CommonConfig
-package utils
-
 import com.gu.AppIdentity
+import com.amazonaws.auth.AWSCredentialsProvider
 
-class RuleManagerConfig(playConfig: Configuration, identity: AppIdentity) extends CommonConfig(playConfig, identity)
+class RuleManagerConfig(playConfig: Configuration, identity: AppIdentity, creds: AWSCredentialsProvider) extends CommonConfig(playConfig, identity, creds) {
+  val dbUrl = playConfig.get[String]("db.default.url")
+  val dbUsername = playConfig.get[String]("db.default.username")
+  val dbPassword = playConfig.get[String]("db.default.password")
+}

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -10,3 +10,6 @@ GET     /assets/*file               controllers.Assets.versioned(path="/public",
 GET     /                           controllers.HomeController.index
 GET     /healthcheck                controllers.HomeController.healthcheck
 GET     /oauthCallback              controllers.HomeController.oauthCallback
+
+# A temporary endpoint to test permissions
+GET     /editPermissionCheck        controllers.HomeController.editPermissionCheck

--- a/build.sbt
+++ b/build.sbt
@@ -124,7 +124,8 @@ val ruleManager = (project in file(s"$appsFolder/rule-manager"))
       "org.scalikejdbc" %% "scalikejdbc-config" % scalikejdbcVersion,
       "org.scalikejdbc" %% "scalikejdbc-play-initializer" % scalikejdbcPlayVersion,
       "org.scalikejdbc" %% "scalikejdbc-test" % "3.5.0" % Test,
-      "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.4"
+      "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.4",
+      "com.gu" %% "editorial-permissions-client" % "2.3"
     )
   )
 


### PR DESCRIPTION
## What does this change?

Adds edit permissions to a temporary endpoint, `/editPermissionCheck`, via our [permissions](https://github.com/guardian/permissions) service. Production use will depend on an [open PR](https://github.com/guardian/permissions/pull/129) in that service. (edit: this is now merged.)

## How to test

Locally, hit the `/editPermissionCheck` endpoint whilst running the rule manager service (`sbt ruleManager / run`). You should be denied permission.

Add CODE permissions for the `manage_rules` permission, and wait a few minutes for them to be published and for your local perm cache to clear (or restart the app!). You should be granted permission.

## How can we measure success?

We can use permissions as we please in the project.

## Dev notes

I've used a config DTO as per [e.g. Grid](https://github.com/guardian/grid/blob/main/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala) to easily pass along configuration settings without increasing the arity of common class constructors – I hope this pattern makes sense!