### PR TITLE
Convert typerighter to use graviton instances

### DIFF
--- a/apps/checker/cfn/cfn.yaml
+++ b/apps/checker/cfn/cfn.yaml
@@ -50,13 +50,13 @@ Mappings:
     CODE:
       MaxInstances: 2
       MinInstances: 1
-      InstanceType: t3.small
+      InstanceType: t4g.small
       CloudfrontAliases:
       - api.typerighter.code.dev-gutools.co.uk
     PROD:
       MaxInstances: 6
       MinInstances: 3
-      InstanceType: t3.small
+      InstanceType: t4g.small
       CloudfrontAliases:
       - api.typerighter.gutools.co.uk
   StageLookup:

--- a/cdk/lib/rule-manager/rule-manager.ts
+++ b/cdk/lib/rule-manager/rule-manager.ts
@@ -131,7 +131,7 @@ dpkg -i /tmp/package.deb`;
       role: ruleManagerRole,
       imageId: parameters.AMI.valueAsString,
       userData: userData,
-      instanceType: "t3.micro",
+      instanceType: "t4g.micro",
       minCapacity: 1,
       maxCapacity: 2,
       healthCheck: HealthCheck.elb({

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -14,7 +14,7 @@ deployments:
     app: typerighter
     parameters:
       amiTags:
-        Recipe: editorial-tools-xenial-java8-ngrams
+        Recipe: editorial-tools-xenial-java8-ngrams-ARM
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true
@@ -31,7 +31,7 @@ deployments:
     app: typerighter-rule-manager
     parameters:
       amiTags:
-        Recipe: editorial-tools-xenial-java8-ngrams
+        Recipe: editorial-tools-xenial-java8-ngrams-ARM
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true


### PR DESCRIPTION
## What does this change?
Switch from t3 to t4g class instances which are cheaper but also Graviton (so we need to update the AMI as part of the conversion).

## How to test
Deploy. Should change the AMI and instance type.

## How can we measure success?
Reduction in cost. Possible improvement in performance.

## Have we considered potential risks?
The risk is deemed low. A number of other services have already been switched.