### PR TITLE
Update documentation for sheet

### DIFF
--- a/docs/02-google-sheet.md
+++ b/docs/02-google-sheet.md
@@ -15,7 +15,11 @@ Note that there are different sheets for different environments.
 
 ## The sheet format
 
-An example rule sheet with a few instances of rules of different types is available [here](https://docs.google.com/spreadsheets/d/1n5xjfVnvRQBMfmjD_VzFX2ye4pLBmL98whdDqsJhtAs). As currently implemented, only the first sheet is read for custom rules, and the sheet named `languagetoolRules` handles enabling rules that are a part of the default LanguageTool corpus.Here's a snippet to give the [gist](https://en.wiktionary.org/wiki/gist), fields with asterisks are mandatory:
+An example rule sheet with a few instances of rules of different types is available [here](https://docs.google.com/spreadsheets/d/1n5xjfVnvRQBMfmjD_VzFX2ye4pLBmL98whdDqsJhtAs).
+
+As currently implemented, only the first sheet is read for custom rules, and the sheet named `languagetoolRules` handles enabling rules that are a part of the default LanguageTool corpus.
+
+Here's a snippet to give the [gist](https://en.wiktionary.org/wiki/gist), fields with asterisks are mandatory:
 
 | Type* | Pattern*   | Replacement | Colour (deprecated) | Category* | Additional data (deprecated) | Description* | Tags | Ignore? | Notes | ID*                     |
 |-------|------------|------------------------------------------------------------|---------------------|---------------------|------------------------------|----------------------------------------|-----------------------------|---------|--------------------------------------------------|--------------------------------------|

--- a/docs/02-google-sheet.md
+++ b/docs/02-google-sheet.md
@@ -13,15 +13,14 @@ https://docs.google.com/document/d/<ID>/edit
 
 Note that there are different sheets for different environments.
 
-## Interpreting the Google sheet.
+## The sheet format.
 
-As currently implemented, the first sheet only is read.
+An example rule sheet with a few instances of rules of different types is available [here](https://docs.google.com/spreadsheets/d/1n5xjfVnvRQBMfmjD_VzFX2ye4pLBmL98whdDqsJhtAs/edit#gid=0). Here's a snippet to give the [gist](https://en.wiktionary.org/wiki/gist):
 
-The columns are:
- * Unused
- * Correct Value
- * Regex (search string)
- * Colour
- * Category ID
- * Unused
- * Description
+| Type* | Pattern*   | Replacement (regex type only – can include capture groups) | Colour (deprecated) | Category            | Additional data (deprecated) | Description (can use Markdown syntax)* | Tags (separate with commas) | Ignore? | Notes (not processed, just for maintainance use) | ID (any string)*                     |
+|-------|------------|------------------------------------------------------------|---------------------|---------------------|------------------------------|----------------------------------------|-----------------------------|---------|--------------------------------------------------|--------------------------------------|
+| regex | \b(j\|g)ist | gist                                                       | 00ffff              | Guardian convention |                              | gist, according to Guardian convention | Guardian convention         | FALSE   |                                                  | 658184fb-d1d4-4962-aba1-de3d31946cbc |
+
+As currently implemented, only the first sheet is read for custom rules, and the sheet named `languagetoolRules` handles enabling rules that are a part of the default LanguageTool corpus.
+
+

--- a/docs/02-google-sheet.md
+++ b/docs/02-google-sheet.md
@@ -42,4 +42,6 @@ Here's a snippet to give the [gist](https://en.wiktionary.org/wiki/gist), fields
 | Notes | General notes for rule maintenance, not currently used by the system |
 | ID | An id to uniquely identify the rule within the corpus. |
 
+The contents of the sheet are validated when the rules are re-ingested. To do this, navigate to `<base-url>/rules` on a running Typerighter instance, and click 'refresh'. Any validation errors will appear when the process is complete.
+
 

--- a/docs/02-google-sheet.md
+++ b/docs/02-google-sheet.md
@@ -1,4 +1,4 @@
-# Getting the google sheet.
+# Getting the ID of the current google sheet
 
 Get the identity of the google sheet with the following:
 ```
@@ -13,14 +13,29 @@ https://docs.google.com/document/d/<ID>/edit
 
 Note that there are different sheets for different environments.
 
-## The sheet format.
+## The sheet format
 
-An example rule sheet with a few instances of rules of different types is available [here](https://docs.google.com/spreadsheets/d/1n5xjfVnvRQBMfmjD_VzFX2ye4pLBmL98whdDqsJhtAs/edit#gid=0). Here's a snippet to give the [gist](https://en.wiktionary.org/wiki/gist):
+An example rule sheet with a few instances of rules of different types is available [here](https://docs.google.com/spreadsheets/d/1n5xjfVnvRQBMfmjD_VzFX2ye4pLBmL98whdDqsJhtAs). As currently implemented, only the first sheet is read for custom rules, and the sheet named `languagetoolRules` handles enabling rules that are a part of the default LanguageTool corpus.Here's a snippet to give the [gist](https://en.wiktionary.org/wiki/gist), fields with asterisks are mandatory:
 
-| Type* | Pattern*   | Replacement (regex type only – can include capture groups) | Colour (deprecated) | Category            | Additional data (deprecated) | Description (can use Markdown syntax)* | Tags (separate with commas) | Ignore? | Notes (not processed, just for maintainance use) | ID (any string)*                     |
+| Type* | Pattern*   | Replacement | Colour (deprecated) | Category* | Additional data (deprecated) | Description* | Tags | Ignore? | Notes | ID*                     |
 |-------|------------|------------------------------------------------------------|---------------------|---------------------|------------------------------|----------------------------------------|-----------------------------|---------|--------------------------------------------------|--------------------------------------|
 | regex | \b(j\|g)ist | gist                                                       | 00ffff              | Guardian convention |                              | gist, according to Guardian convention | Guardian convention         | FALSE   |                                                  | 658184fb-d1d4-4962-aba1-de3d31946cbc |
 
-As currently implemented, only the first sheet is read for custom rules, and the sheet named `languagetoolRules` handles enabling rules that are a part of the default LanguageTool corpus.
+
+
+
+| Field | Description |
+|-|-|
+| Type | The type of matcher to use. At the moment, this is either `regex` or `lt`, where `lt` is the LanguageTool matcher. |
+| Pattern | The pattern for the matcher. For `regex` matchers, this will be a regular expression. For `lt`, this will be the XML for a `rule` or `rulegroup`. |
+| Replacement | Used by the `regex` matcher only. Can include capture groups, e.g `$1` |
+| Colour | Deprecated |
+| Category | The category of the match. Often used for display purposes.  |
+| Additional data | Deprecated |
+| Description | A description of the rule. Can use markdown syntax. Used when displaying matches to users. |
+| Tags | Comma-separated tags to identify the rule in the corpus. Currently unused, but likely to be important in any future rule-management system. |
+| Ignore? | Should this rule be ignored? (FALSE\|TRUE) |
+| Notes | General notes for rule maintenance, not currently used by the system |
+| ID | An id to uniquely identify the rule within the corpus. |
 
 


### PR DESCRIPTION
## What does this change?

Our documentation covering the Google Sheet integration lacks an example. This PR adds a link to a readonly example sheet, with a snippet added to the markdown to provide a brief inline example, and a description for each field.

## How can we measure success?

Does this make things clearer for developers new to the project? Is there anything else we can add?

