### PR TITLE
Changes RDS postgress db version to Major 11

### DIFF
--- a/cdk/lib/rule-manager/rule-manager-db.ts
+++ b/cdk/lib/rule-manager/rule-manager-db.ts
@@ -63,7 +63,7 @@ export class RuleManagerDB extends GuStack {
       autoMinorVersionUpgrade: true,
       backupRetention: Duration.days(10),
       engine: DatabaseInstanceEngine.postgres({
-        version: PostgresEngineVersion.VER_11_8,
+        version: PostgresEngineVersion.VER_11,
       }),
       instanceType: "t3.micro",
       instanceIdentifier: `typerighter-rule-manager-db-${this.stage}`,


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR changes the Postgres engine version to "11" from "11.8". This was necessary due to infra drift, causing failing deploys. The RDS instances are currently on "11.10" and were rejecting deploys due to the downgrade in version. Changing the version to major 11 allows the deploy to continue as normal. 

Please note, there is no 11.10 currently available in the CDK. The highest available version is [11.9](https://docs.aws.amazon.com/cdk/api/latest/typescript/api/aws-rds/postgresengineversion.html#aws_rds_PostgresEngineVersion_VER_11_9)

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Are we able to deploy as normal? We no longer see failed deploys like [this one](https://riffraff.gutools.co.uk/deployment/view/39372a89-acfe-4d71-a8b0-a53022bc45c6).

