### PR TITLE
Enable wazuh

### DIFF
--- a/apps/checker/cfn/cfn.yaml
+++ b/apps/checker/cfn/cfn.yaml
@@ -142,7 +142,7 @@ Resources:
   DescribeEC2Policy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: describe-ec2-policy
+      PolicyName: DescribeEC2Policy
       PolicyDocument:
         Statement:
         - Effect: Allow

--- a/apps/checker/cfn/cfn.yaml
+++ b/apps/checker/cfn/cfn.yaml
@@ -100,6 +100,7 @@ Resources:
       IamInstanceProfile: !Ref InstanceProfile
       SecurityGroups:
       - !Ref InstanceSecurityGroup
+      - !Ref WazuhSecurityGroup
       BlockDeviceMappings:
       - DeviceName: /dev/sda1
         Ebs:
@@ -387,6 +388,17 @@ Resources:
       - IpProtocol: tcp
         FromPort: 443
         ToPort: 443
+        CidrIp: 0.0.0.0/0
+
+  WazuhSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow outbound traffic from wazuh agent to manager
+      VpcId: !Ref Vpc
+      SecurityGroupEgress:
+      - IpProtocol: tcp
+        FromPort: 1514
+        ToPort: 1515
         CidrIp: 0.0.0.0/0
 
   Bucket:

--- a/apps/checker/cfn/cfn.yaml
+++ b/apps/checker/cfn/cfn.yaml
@@ -138,6 +138,22 @@ Resources:
           Action:
           - sts:AssumeRole
 
+  DescribeEC2Policy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: describe-ec2-policy
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Resource: "*"
+          Action:
+          - ec2:DescribeTags
+          - ec2:DescribeInstances
+          - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeAutoScalingInstances
+      Roles:
+      - !Ref AppRole
+
   GetDistributablesPolicy:
     Type: AWS::IAM::Policy
     Properties:


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds the necessary configuration for Wazuh to work correctly on the checker instances. The rule-manager instances should already work, as they are using Guardian CDK.

[Guardian Wazuh guide](https://github.com/guardian/security-hq/blob/main/hq/markdown/wazuh.md#testing)

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Deploy to CODE, check Wazuh is reporting health by using SSM:
`ssm cmd -c "service wazuh-agent status | grep Active && journalctl -u wazuh-agent | grep Valid" -i {instance id} -p composer`

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![image](https://user-images.githubusercontent.com/4633246/112832750-ad775700-908d-11eb-919e-ee72cfcd6d4e.png)

