### PR TITLE
Account for quotes at start of sentences when detecting sentence start

### DIFF
--- a/apps/checker/app/services/SentenceHelpers.scala
+++ b/apps/checker/app/services/SentenceHelpers.scala
@@ -28,13 +28,20 @@ class SentenceHelpers() {
 
     for {
       sentence: CoreMap <- sentences
-    } yield {
-      val firstToken = sentence.get(classOf[TokensAnnotation]).asScala.toList.head
-      val word = firstToken.get(classOf[TextAnnotation])
+      wordInSentence <- maybeGetFirstWordFromSentence(sentence)
+    } yield wordInSentence
+  }
+
+  def maybeGetFirstWordFromSentence(sentence: CoreMap) = {
+    val tokens = sentence.get(classOf[TokensAnnotation]).asScala.toList
+    val maybeFirstValidToken = tokens.find(!_.toString().contains("`"))
+
+    maybeFirstValidToken.map { token =>
+      val word = token.get(classOf[TextAnnotation])
       WordInSentence(
         sentence.toString,
         word,
-        TextRange(firstToken.beginPosition(), firstToken.endPosition())
+        TextRange(token.beginPosition(), token.endPosition())
       )
     }
   }

--- a/apps/checker/app/services/SentenceHelpers.scala
+++ b/apps/checker/app/services/SentenceHelpers.scala
@@ -14,7 +14,7 @@ case class WordInSentence(sentence: String, word: String, range: TextRange)
 
 object SentenceHelpers {
   // LSB == Left square bracket, etc.
-  val NON_WORD_TOKENS = List("`", "``", "-LSB-", "-LRB-", "-LCB-")
+  val NON_WORD_TOKENS = List("`", "``", "-", "--", "-LSB-", "-LRB-", "-LCB-")
 }
 
 /**

--- a/apps/checker/app/services/SentenceHelpers.scala
+++ b/apps/checker/app/services/SentenceHelpers.scala
@@ -12,6 +12,11 @@ import model.TextRange
 
 case class WordInSentence(sentence: String, word: String, range: TextRange)
 
+object SentenceHelpers {
+  // LSB == Left square bracket, etc.
+  val NON_WORD_TOKENS = List("`", "``", "-LSB-", "-LRB-", "-LCB-")
+}
+
 /**
   * A service to extract proper names from documents.
   */
@@ -34,7 +39,9 @@ class SentenceHelpers() {
 
   def maybeGetFirstWordFromSentence(sentence: CoreMap) = {
     val tokens = sentence.get(classOf[TokensAnnotation]).asScala.toList
-    val maybeFirstValidToken = tokens.find(!_.toString().contains("`"))
+    val maybeFirstValidToken = tokens.find { token =>
+      !SentenceHelpers.NON_WORD_TOKENS.contains(token.toString())
+    }
 
     maybeFirstValidToken.map { token =>
       val word = token.get(classOf[TextAnnotation])

--- a/apps/checker/test/scala/matchers/RegexMatcherTest.scala
+++ b/apps/checker/test/scala/matchers/RegexMatcherTest.scala
@@ -255,6 +255,21 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     }
   }
 
+  it should "transform suggestions to respect sentence starts, to avoid suggesting capping down – cap up sentence start within quote" in {
+    val eventuallyMatches = checkTextWithRegex(
+      "(?i)\\bcaf(e|é|è|ë|ê)"r,
+      "cafe",
+      "Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. \"Cafes\", bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit"
+    )
+
+    eventuallyMatches.map { matches =>
+      matches.size shouldBe 1
+      val firstMatch = matches(0)
+      firstMatch.replacement shouldBe Some(TextSuggestion("Cafe"))
+      firstMatch.markAsCorrect shouldBe true
+    }
+  }
+
   it should "should not apply capitalisations when the match does not include the start of the word" in {
     val eventuallyMatches = checkTextWithRegex(
       "(?i)af(e|é|è|ë|ê)"r,

--- a/apps/checker/test/scala/services/SentenceHelperTest.scala
+++ b/apps/checker/test/scala/services/SentenceHelperTest.scala
@@ -18,30 +18,24 @@ class SentenceHelperTest extends AsyncFlatSpec with Matchers {
     ))
   }
 
-  it should "ignore quotes when finding sentence starts – double quotes" in {
-    val sentenceTokenizer = new SentenceHelpers()
-    val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. \"Cafes\", bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
-    firstWordsInSentences should matchTo(List(
-      WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
-      WordInSentence("\"Cafes\", bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(103, 108)),
-    ))
-  }
-
-  it should "ignore quotes when finding sentence starts – single quotes" in {
-    val sentenceTokenizer = new SentenceHelpers()
-    val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. 'Cafes', bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
-    firstWordsInSentences should matchTo(List(
-      WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
-      WordInSentence("'Cafes', bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(103, 108)),
-    ))
-  }
-
-  it should "ignore quotes when finding sentence starts – backticks" in {
-    val sentenceTokenizer = new SentenceHelpers()
-    val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. `Cafes`, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
-    firstWordsInSentences should matchTo(List(
-      WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
-      WordInSentence("`Cafes`, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(103, 108)),
-    ))
+  List(
+    ("\"", "\""),
+    ("'", "'"),
+    ("`", "`"),
+    ("{", "}"),
+    ("[", "]"),
+    ("(", ")"),
+    ("“", "”"),
+    ("‘", "’)")
+  ).foreach {
+    case (leftNonWordChar, rightNonWordChar) =>
+      it should s"ignore non-word tokens when finding sentence starts: $leftNonWordChar $rightNonWordChar" in {
+        val sentenceTokenizer = new SentenceHelpers()
+        val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. ${leftNonWordChar}Cafes${rightNonWordChar}, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
+        firstWordsInSentences should matchTo(List(
+          WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
+          WordInSentence(s"${leftNonWordChar}Cafes${rightNonWordChar}, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(103, 108)),
+        ))
+      }
   }
 }

--- a/apps/checker/test/scala/services/SentenceHelperTest.scala
+++ b/apps/checker/test/scala/services/SentenceHelperTest.scala
@@ -17,4 +17,31 @@ class SentenceHelperTest extends AsyncFlatSpec with Matchers {
       WordInSentence("Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(102, 107)),
     ))
   }
+
+  it should "ignore quotes when finding sentence starts – double quotes" in {
+    val sentenceTokenizer = new SentenceHelpers()
+    val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. \"Cafes\", bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
+    firstWordsInSentences should matchTo(List(
+      WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
+      WordInSentence("\"Cafes\", bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(103, 108)),
+    ))
+  }
+
+  it should "ignore quotes when finding sentence starts – single quotes" in {
+    val sentenceTokenizer = new SentenceHelpers()
+    val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. 'Cafes', bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
+    firstWordsInSentences should matchTo(List(
+      WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
+      WordInSentence("'Cafes', bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(103, 108)),
+    ))
+  }
+
+  it should "ignore quotes when finding sentence starts – backticks" in {
+    val sentenceTokenizer = new SentenceHelpers()
+    val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. `Cafes`, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
+    firstWordsInSentences should matchTo(List(
+      WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
+      WordInSentence("`Cafes`, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(103, 108)),
+    ))
+  }
 }

--- a/apps/checker/test/scala/services/SentenceHelperTest.scala
+++ b/apps/checker/test/scala/services/SentenceHelperTest.scala
@@ -7,18 +7,8 @@ import model.TextRange
 
 class SentenceHelperTest extends AsyncFlatSpec with Matchers {
 
-  behavior of "getFirstWordsInSentences"
-
-  it should "return sentence starts, including the word and range covered" in {
-    val sentenceTokenizer = new SentenceHelpers()
-    val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
-    firstWordsInSentences should matchTo(List(
-      WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
-      WordInSentence("Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(102, 107)),
-    ))
-  }
-
-  List(
+  val sentenceTokenizer = new SentenceHelpers()
+  val charactersThatProduceNonWordTokens = List(
     ("\"", "\""),
     ("'", "'"),
     ("`", "`"),
@@ -30,15 +20,43 @@ class SentenceHelperTest extends AsyncFlatSpec with Matchers {
     ("-", ""),
     ("–", ""),
     ("—", "")
-  ).foreach {
+  )
+
+  behavior of "getFirstWordsInSentences"
+
+  it should "return sentence starts, including the word and range covered" in {
+
+    val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
+    firstWordsInSentences should matchTo(List(
+      WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
+      WordInSentence("Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(102, 107)),
+    ))
+  }
+
+  charactersThatProduceNonWordTokens.foreach {
     case (leftNonWordChar, rightNonWordChar) =>
       it should s"ignore non-word tokens when finding sentence starts: $leftNonWordChar $rightNonWordChar" in {
-        val sentenceTokenizer = new SentenceHelpers()
         val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. ${leftNonWordChar}Cafes${rightNonWordChar}, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
         firstWordsInSentences should matchTo(List(
           WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
           WordInSentence(s"${leftNonWordChar}Cafes${rightNonWordChar}, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(103, 108)),
         ))
       }
+  }
+
+  charactersThatProduceNonWordTokens.foreach {
+    case (leftNonWordChar, rightNonWordChar) =>
+      it should s"ignore multiple non-word tokens when finding sentence starts: $leftNonWordChar $rightNonWordChar" in {
+        val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"${leftNonWordChar}${leftNonWordChar}Cafes${rightNonWordChar}${rightNonWordChar}, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
+        firstWordsInSentences should matchTo(List(
+          WordInSentence(s"${leftNonWordChar}${leftNonWordChar}Cafes${rightNonWordChar}${rightNonWordChar}, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(2, 7)),
+        ))
+      }
+  }
+
+  it should s"not give any results if the sentence consists entirely of non word tokens" in {
+    val nonWordChar = charactersThatProduceNonWordTokens.head._1
+    val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"$nonWordChar$nonWordChar$nonWordChar$nonWordChar$nonWordChar$nonWordChar")
+    firstWordsInSentences should matchTo(List.empty[WordInSentence])
   }
 }

--- a/apps/checker/test/scala/services/SentenceHelperTest.scala
+++ b/apps/checker/test/scala/services/SentenceHelperTest.scala
@@ -26,7 +26,10 @@ class SentenceHelperTest extends AsyncFlatSpec with Matchers {
     ("[", "]"),
     ("(", ")"),
     ("“", "”"),
-    ("‘", "’)")
+    ("‘", "’)"),
+    ("-", ""),
+    ("–", ""),
+    ("—", "")
   ).foreach {
     case (leftNonWordChar, rightNonWordChar) =>
       it should s"ignore non-word tokens when finding sentence starts: $leftNonWordChar $rightNonWordChar" in {

--- a/apps/checker/test/scala/services/SentenceHelperTest.scala
+++ b/apps/checker/test/scala/services/SentenceHelperTest.scala
@@ -9,23 +9,22 @@ class SentenceHelperTest extends AsyncFlatSpec with Matchers {
 
   val sentenceTokenizer = new SentenceHelpers()
   val charactersThatProduceNonWordTokens = List(
-    ("\"", "\""),
-    ("'", "'"),
-    ("`", "`"),
-    ("{", "}"),
-    ("[", "]"),
-    ("(", ")"),
-    ("“", "”"),
-    ("‘", "’)"),
-    ("-", ""),
-    ("–", ""),
-    ("—", "")
+    "\"",
+    "'",
+    "`",
+    "{",
+    "[",
+    "(",
+    "“",
+    "‘",
+    "-",
+    "–",
+    "—",
   )
 
   behavior of "getFirstWordsInSentences"
 
   it should "return sentence starts, including the word and range covered" in {
-
     val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
     firstWordsInSentences should matchTo(List(
       WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
@@ -33,29 +32,27 @@ class SentenceHelperTest extends AsyncFlatSpec with Matchers {
     ))
   }
 
-  charactersThatProduceNonWordTokens.foreach {
-    case (leftNonWordChar, rightNonWordChar) =>
-      it should s"ignore non-word tokens when finding sentence starts: $leftNonWordChar $rightNonWordChar" in {
-        val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. ${leftNonWordChar}Cafes${rightNonWordChar}, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
-        firstWordsInSentences should matchTo(List(
-          WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
-          WordInSentence(s"${leftNonWordChar}Cafes${rightNonWordChar}, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(103, 108)),
-        ))
-      }
+  charactersThatProduceNonWordTokens.foreach { nonWordChar =>
+    it should s"ignore non-word tokens when finding sentence starts: $nonWordChar" in {
+      val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. ${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
+      firstWordsInSentences should matchTo(List(
+        WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
+        WordInSentence(s"${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(103, 108)),
+      ))
+    }
   }
 
-  charactersThatProduceNonWordTokens.foreach {
-    case (leftNonWordChar, rightNonWordChar) =>
-      it should s"ignore multiple non-word tokens when finding sentence starts: $leftNonWordChar $rightNonWordChar" in {
-        val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"${leftNonWordChar}${leftNonWordChar}Cafes${rightNonWordChar}${rightNonWordChar}, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
-        firstWordsInSentences should matchTo(List(
-          WordInSentence(s"${leftNonWordChar}${leftNonWordChar}Cafes${rightNonWordChar}${rightNonWordChar}, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(2, 7)),
-        ))
-      }
+  charactersThatProduceNonWordTokens.foreach { nonWordChar =>
+    it should s"ignore multiple non-word tokens when finding sentence starts: $nonWordChar" in {
+      val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"${nonWordChar}${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
+      firstWordsInSentences should matchTo(List(
+        WordInSentence(s"${nonWordChar}${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(2, 7)),
+      ))
+    }
   }
 
   it should s"not give any results if the sentence consists entirely of non word tokens" in {
-    val nonWordChar = charactersThatProduceNonWordTokens.head._1
+    val nonWordChar = charactersThatProduceNonWordTokens.head
     val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"$nonWordChar$nonWordChar$nonWordChar$nonWordChar$nonWordChar$nonWordChar")
     firstWordsInSentences should matchTo(List.empty[WordInSentence])
   }


### PR DESCRIPTION
## What does this change?

Quotes are represented by their own tokens in CoreNLP. Previous to this change, we selected the first token at the sentence boundary as the sentence word start. If this token happens to be a word, our uppercase rules succeed – but if it's a quote, we apply uppercase rules to the quote token instead of the token representing the first word, and get silly suggestions:

`... applies to holiday accomodation. \"Cafes\", bars ...`

`Cafe` -> `cafe`

This patch scans forward for the first word token it sees, finding the first word proper. It also accounts for parentheses, square brackets and dashes of various kinds, which had a similar effect. Other chars should be easy to account for if we think of them.

## How to test

The automated tests should look comprehensive, and pass.

The following text should produce green matches for the words 'Cafe', indicating that we've skipped the first, non-word token in the sentence:

```
“Cafes will open soon”

‘Cafes will open soon’

`Cafes will open soon`

(Cafes will open soon.)

[Cafes will open soon]

Cafes will open soon
```
