### PR TITLE
Enable IMDSv2

### DIFF
--- a/apps/checker/cfn/cfn.yaml
+++ b/apps/checker/cfn/cfn.yaml
@@ -98,6 +98,8 @@ Resources:
       ImageId: !Ref AMI
       InstanceType: !FindInMap [ StageVariables, !Ref Stage, InstanceType ]
       IamInstanceProfile: !Ref InstanceProfile
+      MetadataOptions:
+        HttpTokens: required
       SecurityGroups:
       - !Ref InstanceSecurityGroup
       - !Ref WazuhSecurityGroup

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ scalacOptions in ThisBuild := Seq(
   "-feature", "-unchecked", "-language:implicitConversions", "-language:postfixOps")
 
 val languageToolVersion = "4.3"
-val awsSdkVersion = "1.11.571"
+val awsSdkVersion = "1.11.999"
 val capiModelsVersion = "15.8"
 val capiClientVersion = "16.0"
 val circeVersion = "0.12.3"


### PR DESCRIPTION
## What does this change?

Updates cloudformation and upversions aws-sdk to support IMDSv2, to address an issue in AWS security hub. More details [here](https://github.com/guardian/security-hq/blob/main/hq/markdown/guardduty-sechub-common-problems.md#ec2-instances-should-use-imdsv2).

## How to test

The app should work as expected. See the guide above for verification.

Tested in CODE.

## How can we measure success?

One fewer issue in Security Hub. (There are no changes to rule-manager, as CDK [does not yet support this change.](https://github.com/aws/aws-cdk/issues/5137))