### PR TITLE
chore: Add snapshot tests for CDK stacks

### DIFF
--- a/cdk/jest.config.js
+++ b/cdk/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  roots: ['<rootDir>/test'],
+  roots: ['<rootDir>/lib'],
   testMatch: ['**/*.test.ts'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest'

--- a/cdk/lib/rule-manager/__snapshots__/rule-manager-db.test.ts.snap
+++ b/cdk/lib/rule-manager/__snapshots__/rule-manager-db.test.ts.snap
@@ -1,0 +1,241 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The rule manager db stack matches the snapshot 1`] = `
+Object {
+  "Parameters": Object {
+    "AccessSecurityGroupID": Object {
+      "Description": "Id of the security group from which access to the DB will be allowed",
+      "Type": "AWS::EC2::SecurityGroup::Id",
+    },
+    "MasterDBUsername": Object {
+      "Default": "rule_manager",
+      "Description": "Master DB username",
+      "Type": "String",
+    },
+    "PrivateSubnets": Object {
+      "Default": "/account/vpc/default/private.subnets",
+      "Description": "Subnets to run the ASG and instances within",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+    "VPC": Object {
+      "Default": "/account/vpc/default/id",
+      "Description": "Virtual Private Cloud to run EC2 instances within",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
+  },
+  "Resources": Object {
+    "DBSecurityGroup": Object {
+      "Properties": Object {
+        "GroupDescription": "DB security group servers",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "typerighter-rule-manager",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "0.39.2",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "flexible",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VPC",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "DBSecurityGroupfromrulemanagerdbAccessSecurityGroup1C2D2DCD5432C3E322DD": Object {
+      "Properties": Object {
+        "Description": "from rulemanagerdbAccessSecurityGroup1C2D2DCD:5432",
+        "FromPort": 5432,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "DBSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": Object {
+          "Ref": "AccessSecurityGroupID",
+        },
+        "ToPort": 5432,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "DBSubnetGroup": Object {
+      "Properties": Object {
+        "DBSubnetGroupDescription": "Private subnet for typerighter rule-manager database",
+        "SubnetIds": Object {
+          "Ref": "PrivateSubnets",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "typerighter-rule-manager",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "0.39.2",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "flexible",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::RDS::DBSubnetGroup",
+    },
+    "RuleManagerRDSEBF20BD9": Object {
+      "DeletionPolicy": "Snapshot",
+      "Properties": Object {
+        "AllocatedStorage": "50",
+        "AllowMajorVersionUpgrade": true,
+        "AutoMinorVersionUpgrade": true,
+        "BackupRetentionPeriod": 10,
+        "CopyTagsToSnapshot": true,
+        "DBInstanceClass": "db.t3.micro",
+        "DBInstanceIdentifier": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "typerighter-rule-manager-db-",
+              Object {
+                "Ref": "Stage",
+              },
+            ],
+          ],
+        },
+        "DBParameterGroupName": Object {
+          "Ref": "RuleManagerRDSRDSParameterGroupE6969C6C",
+        },
+        "DBSubnetGroupName": Object {
+          "Ref": "DBSubnetGroup",
+        },
+        "DeletionProtection": true,
+        "Engine": "postgres",
+        "EngineVersion": "11",
+        "MasterUserPassword": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{{resolve:ssm-secure:/",
+              Object {
+                "Ref": "Stage",
+              },
+              "/flexible/typerighter-rule-manager/db.default.password:1}}",
+            ],
+          ],
+        },
+        "MasterUsername": Object {
+          "Ref": "MasterDBUsername",
+        },
+        "MultiAZ": true,
+        "Port": "5432",
+        "PreferredBackupWindow": "02:00-02:30",
+        "PreferredMaintenanceWindow": "Mon:06:30-Mon:07:00",
+        "PubliclyAccessible": false,
+        "StorageEncrypted": true,
+        "StorageType": "gp2",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "typerighter-rule-manager",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "0.39.2",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "flexible",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VPCSecurityGroups": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "DBSecurityGroup",
+              "GroupId",
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::RDS::DBInstance",
+      "UpdateReplacePolicy": "Snapshot",
+    },
+    "RuleManagerRDSRDSParameterGroupE6969C6C": Object {
+      "Properties": Object {
+        "Description": "Parameter group for postgres11",
+        "Family": "postgres11",
+        "Parameters": Object {
+          "checkpoint_completion_target": "0.9",
+          "effective_cache_size": "393216",
+          "maintenance_work_mem": "245760",
+          "max_connections": "100",
+          "random_page_cost": "1.1",
+          "shared_buffers": "131072",
+          "synchronous_commit": "off",
+          "work_mem": "38912",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "typerighter-rule-manager",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "0.39.2",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "flexible",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::RDS::DBParameterGroup",
+    },
+  },
+}
+`;

--- a/cdk/lib/rule-manager/__snapshots__/rule-manager.test.ts.snap
+++ b/cdk/lib/rule-manager/__snapshots__/rule-manager.test.ts.snap
@@ -1,0 +1,802 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The rule manager stack matches the snapshot 1`] = `
+Object {
+  "Mappings": Object {
+    "stagemapping": Object {
+      "CODE": Object {
+        "maxInstances": 2,
+        "minInstances": 1,
+      },
+      "PROD": Object {
+        "maxInstances": 2,
+        "minInstances": 1,
+      },
+    },
+  },
+  "Parameters": Object {
+    "AMI": Object {
+      "Description": "AMI ID",
+      "Type": "AWS::EC2::Image::Id",
+    },
+    "ClusterName": Object {
+      "Default": "elk",
+      "Description": "The value of the ElasticSearchCluster tag that this instance should join",
+      "Type": "String",
+    },
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "LoggingStreamName": Object {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "PrivateSubnets": Object {
+      "Default": "/account/vpc/default/private.subnets",
+      "Description": "Subnets to run the ASG and instances within",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+    "PublicSubnets": Object {
+      "Default": "/account/vpc/default/public.subnets",
+      "Description": "Subnets to run load balancer within",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+    "TLSCert": Object {
+      "AllowedPattern": "arn:aws:[a-z0-9]*:[a-z0-9\\\\-]*:[0-9]{12}:.*",
+      "ConstraintDescription": "Must be a valid ARN, eg: arn:partition:service:region:account-id:resource-id",
+      "Description": "ARN of a TLS certificate to install on the load balancer",
+      "Type": "String",
+    },
+    "VPC": Object {
+      "Default": "/account/vpc/default/id",
+      "Description": "Virtual Private Cloud to run EC2 instances within",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
+  },
+  "Resources": Object {
+    "ApplicationSecurityGroup3903A0DC": Object {
+      "Properties": Object {
+        "GroupDescription": "HTTP",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "typerighter-rule-manager",
+          },
+          Object {
+            "Key": "ElasticSearchCluster",
+            "Value": Object {
+              "Ref": "ClusterName",
+            },
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "0.39.2",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "flexible",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VPC",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "ApplicationSecurityGroupfromrulemanagerLoadBalancerSecurityGroup0693FB7E9000782854DA": Object {
+      "Properties": Object {
+        "Description": "Port 9000 LB to fleet",
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "ApplicationSecurityGroup3903A0DC",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "LoadBalancerSecurityGroup3036A0FC",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "AutoscalingGroupASG25987EFB": Object {
+      "Properties": Object {
+        "HealthCheckGracePeriod": 300,
+        "HealthCheckType": "ELB",
+        "LaunchConfigurationName": Object {
+          "Ref": "AutoscalingGroupLaunchConfigEBD75746",
+        },
+        "MaxSize": Object {
+          "Fn::FindInMap": Array [
+            "stagemapping",
+            Object {
+              "Ref": "Stage",
+            },
+            "maxInstances",
+          ],
+        },
+        "MinSize": Object {
+          "Fn::FindInMap": Array [
+            "stagemapping",
+            Object {
+              "Ref": "Stage",
+            },
+            "minInstances",
+          ],
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": "typerighter-rule-manager",
+          },
+          Object {
+            "Key": "ElasticSearchCluster",
+            "PropagateAtLaunch": true,
+            "Value": Object {
+              "Ref": "ClusterName",
+            },
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "0.39.2",
+          },
+          Object {
+            "Key": "Name",
+            "PropagateAtLaunch": true,
+            "Value": "rule-manager/AutoscalingGroup",
+          },
+          Object {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "flexible",
+          },
+          Object {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "TargetGroupARNs": Array [
+          Object {
+            "Ref": "PublicTargetGroup4BB97343",
+          },
+        ],
+        "VPCZoneIdentifier": Object {
+          "Ref": "PrivateSubnets",
+        },
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "AutoscalingGroupInstanceProfile010878FF": Object {
+      "Properties": Object {
+        "Roles": Array [
+          Object {
+            "Ref": "RuleManagerRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+    "AutoscalingGroupLaunchConfigEBD75746": Object {
+      "DependsOn": Array [
+        "RuleManagerRole",
+      ],
+      "Properties": Object {
+        "AssociatePublicIpAddress": false,
+        "IamInstanceProfile": Object {
+          "Ref": "AutoscalingGroupInstanceProfile010878FF",
+        },
+        "ImageId": Object {
+          "Ref": "AMI",
+        },
+        "InstanceType": "t4g.micro",
+        "SecurityGroups": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "GuHttpsEgressSecurityGroupF63CDA96",
+              "GroupId",
+            ],
+          },
+          Object {
+            "Fn::GetAtt": Array [
+              "ApplicationSecurityGroup3903A0DC",
+              "GroupId",
+            ],
+          },
+        ],
+        "UserData": Object {
+          "Fn::Base64": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "#!/bin/bash -ev
+mkdir /etc/gu
+
+cat > /etc/gu/typerighter-rule-manager.conf <<-'EOF'
+    include \\"application\\"
+EOF
+
+aws --quiet --region ",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                " s3 cp s3://composer-dist/flexible/",
+                Object {
+                  "Ref": "Stage",
+                },
+                "/typerighter-rule-manager/typerighter-rule-manager.deb /tmp/package.deb
+dpkg -i /tmp/package.deb",
+              ],
+            ],
+          },
+        },
+      },
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+    },
+    "DescribeEC2PolicyFF5F9295": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "RuleManagerRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GetDistributablePolicyC6B4A871": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3:::",
+                    Object {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/flexible/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/typerighter-rule-manager/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyC6B4A871",
+        "Roles": Array [
+          Object {
+            "Ref": "RuleManagerRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuHttpsEgressSecurityGroupF63CDA96": Object {
+      "Properties": Object {
+        "GroupDescription": "Allow all outbound traffic on port 443",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "from 0.0.0.0/0:443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "typerighter-rule-manager",
+          },
+          Object {
+            "Key": "ElasticSearchCluster",
+            "Value": Object {
+              "Ref": "ClusterName",
+            },
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "0.39.2",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "flexible",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VPC",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupfromrulemanagerLoadBalancerSecurityGroup0693FB7E9000532EBAF0": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "GuHttpsEgressSecurityGroupF63CDA96",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "LoadBalancerSecurityGroup3036A0FC",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "GuLogShippingPolicy981BFE5A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:kinesis:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    Object {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": Array [
+          Object {
+            "Ref": "RuleManagerRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "LoadBalancerSecurityGroup3036A0FC": Object {
+      "Properties": Object {
+        "GroupDescription": "Allows internet access on 443",
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "GLOBAL_ACCESS",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "typerighter-rule-manager",
+          },
+          Object {
+            "Key": "ElasticSearchCluster",
+            "Value": Object {
+              "Ref": "ClusterName",
+            },
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "0.39.2",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "flexible",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VPC",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerSecurityGrouptorulemanagerApplicationSecurityGroupC33492BD900062D3FDE5": Object {
+      "Properties": Object {
+        "Description": "Port 9000 LB to fleet",
+        "DestinationSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "ApplicationSecurityGroup3903A0DC",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "LoadBalancerSecurityGroup3036A0FC",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "LoadBalancerSecurityGrouptorulemanagerGuHttpsEgressSecurityGroup3739534E9000D1488ABA": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "GuHttpsEgressSecurityGroupF63CDA96",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "LoadBalancerSecurityGroup3036A0FC",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "PandaAuthPolicy4E029301": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3:::pan-domain-auth-settings/*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PandaAuthPolicy4E029301",
+        "Roles": Array [
+          Object {
+            "Ref": "RuleManagerRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ParameterStoreRead9D2F4FAB": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/flexible/typerighter-rule-manager",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "RuleManagerRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PublicListener4F0719E4": Object {
+      "Properties": Object {
+        "Certificates": Array [
+          Object {
+            "CertificateArn": Object {
+              "Ref": "TLSCert",
+            },
+          },
+        ],
+        "DefaultActions": Array [
+          Object {
+            "TargetGroupArn": Object {
+              "Ref": "PublicTargetGroup4BB97343",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": Object {
+          "Ref": "PublicLoadBalancer5116A438",
+        },
+        "Port": 443,
+        "Protocol": "HTTPS",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "PublicLoadBalancer5116A438": Object {
+      "Properties": Object {
+        "LoadBalancerAttributes": Array [
+          Object {
+            "Key": "deletion_protection.enabled",
+            "Value": "true",
+          },
+        ],
+        "Scheme": "internet-facing",
+        "SecurityGroups": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LoadBalancerSecurityGroup3036A0FC",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": Object {
+          "Ref": "PublicSubnets",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "typerighter-rule-manager",
+          },
+          Object {
+            "Key": "ElasticSearchCluster",
+            "Value": Object {
+              "Ref": "ClusterName",
+            },
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "0.39.2",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "flexible",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "PublicTargetGroup4BB97343": Object {
+      "Properties": Object {
+        "HealthCheckIntervalSeconds": 30,
+        "HealthCheckPath": "/healthcheck",
+        "HealthCheckPort": "9000",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 10,
+        "HealthyThresholdCount": 2,
+        "Port": 9000,
+        "Protocol": "HTTP",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "typerighter-rule-manager",
+          },
+          Object {
+            "Key": "ElasticSearchCluster",
+            "Value": Object {
+              "Ref": "ClusterName",
+            },
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "0.39.2",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "flexible",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "TargetGroupAttributes": Array [
+          Object {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+        ],
+        "TargetType": "instance",
+        "UnhealthyThresholdCount": 5,
+        "VpcId": Object {
+          "Ref": "VPC",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "RuleManagerRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "ec2.",
+                      Object {
+                        "Ref": "AWS::URLSuffix",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Path": "/",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "typerighter-rule-manager",
+          },
+          Object {
+            "Key": "ElasticSearchCluster",
+            "Value": Object {
+              "Ref": "ClusterName",
+            },
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "0.39.2",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "flexible",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "SSMRunCommandPolicy244E1613": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply",
+                "ssm:UpdateInstanceInformation",
+                "ssm:ListInstanceAssociations",
+                "ssm:DescribeInstanceProperties",
+                "ssm:DescribeDocumentParameters",
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ssm-run-command-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "RuleManagerRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+  },
+}
+`;

--- a/cdk/lib/rule-manager/rule-manager-db.test.ts
+++ b/cdk/lib/rule-manager/rule-manager-db.test.ts
@@ -1,0 +1,16 @@
+import "@aws-cdk/assert/jest";
+import { SynthUtils } from "@aws-cdk/assert";
+import { App } from "@aws-cdk/core";
+import { RuleManagerDB } from "./rule-manager-db";
+
+describe("The rule manager db stack", () => {
+    it("matches the snapshot", () => {
+        const app = new App();
+        const stack = new RuleManagerDB(app, "rule-manager-db", {
+            app: "typerighter-rule-manager",
+            stack: "flexible",
+        });
+
+        expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+    })
+})

--- a/cdk/lib/rule-manager/rule-manager.test.ts
+++ b/cdk/lib/rule-manager/rule-manager.test.ts
@@ -1,0 +1,16 @@
+import "@aws-cdk/assert/jest";
+import { SynthUtils } from "@aws-cdk/assert";
+import { App } from "@aws-cdk/core";
+import { RuleManager } from "./rule-manager";
+
+describe("The rule manager stack", () => {
+    it("matches the snapshot", () => {
+        const app = new App();
+        const stack = new RuleManager(app, "rule-manager", {
+            app: "typerighter-rule-manager",
+            stack: "flexible",
+        });
+
+        expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+    })
+})

--- a/script/build-cdk
+++ b/script/build-cdk
@@ -31,5 +31,6 @@ source_nvm() {
   # See https://github.com/yarnpkg/yarn/issues/6312
   yarn --network-concurrency 1 --frozen-lockfile
 
+  yarn test
   yarn synth
 )


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Snapshot tests make it easier to see what changes are made when the version of @guardian/cdk is changed.

This is a no-op.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Observe CI?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We have confidence in future PRs that update @guardian/cdk as we can see the exact changes they make.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

n/a

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
