### PR TITLE
chore: Use @guardian/cdk mock for tracking tag

### DIFF
--- a/cdk/.gitignore
+++ b/cdk/.gitignore
@@ -1,5 +1,6 @@
 *.js
 !jest.config.js
+!jest.setup.js
 *.d.ts
 node_modules
 

--- a/cdk/jest.config.js
+++ b/cdk/jest.config.js
@@ -3,5 +3,6 @@ module.exports = {
   testMatch: ['**/*.test.ts'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest'
-  }
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js']
 };

--- a/cdk/jest.setup.js
+++ b/cdk/jest.setup.js
@@ -1,0 +1,1 @@
+jest.mock("@guardian/cdk/lib/constants/tracking-tag");

--- a/cdk/lib/rule-manager/__snapshots__/rule-manager-db.test.ts.snap
+++ b/cdk/lib/rule-manager/__snapshots__/rule-manager-db.test.ts.snap
@@ -50,7 +50,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "12.0.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Stack",
@@ -100,7 +100,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "12.0.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Stack",
@@ -174,7 +174,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "12.0.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Stack",
@@ -220,7 +220,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "12.0.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Stack",

--- a/cdk/lib/rule-manager/__snapshots__/rule-manager.test.ts.snap
+++ b/cdk/lib/rule-manager/__snapshots__/rule-manager.test.ts.snap
@@ -89,7 +89,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "12.0.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Stack",
@@ -170,7 +170,7 @@ Object {
           Object {
             "Key": "gu:cdk:version",
             "PropagateAtLaunch": true,
-            "Value": "12.0.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Name",
@@ -354,7 +354,7 @@ dpkg -i /tmp/package.deb",
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "12.0.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Stack",
@@ -474,7 +474,7 @@ dpkg -i /tmp/package.deb",
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "12.0.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Stack",
@@ -515,7 +515,7 @@ dpkg -i /tmp/package.deb",
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "12.0.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Stack",
@@ -695,7 +695,7 @@ dpkg -i /tmp/package.deb",
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "12.0.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Stack",
@@ -733,7 +733,7 @@ dpkg -i /tmp/package.deb",
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "12.0.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Stack",


### PR DESCRIPTION
Requires #137.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The value of the tracking tag maps to the version of @guardian/cdk used.

This means bumping the version in package.json isn't merely enough as the snapshots will be out of date.
That is, PRs raised by Dependabot to automatically update @guardian/cdk will always fail.

By using the mock, the value of the tracking tag becomes static and thus Dependabot PRs become useful.

See:
  - https://github.com/guardian/cdk/blob/b025f27d562c8897fa0b831612609a7e6b51b057/docs/001-general-usage.md#-mocking-gucdkversion

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See CI?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We unlock Dependabot PRs 🎉 .

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

n/a

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
