### PR TITLE
feat: Add Wazuh security group

### DIFF
--- a/cdk/lib/rule-manager/__snapshots__/rule-manager.test.ts.snap
+++ b/cdk/lib/rule-manager/__snapshots__/rule-manager.test.ts.snap
@@ -233,13 +233,13 @@ Object {
           },
           Object {
             "Fn::GetAtt": Array [
-              "ApplicationSecurityGroupTyperighterrulemanagerB7623A9C",
+              "WazuhSecurityGroup",
               "GroupId",
             ],
           },
           Object {
             "Fn::GetAtt": Array [
-              "WazuhSecurityGroup",
+              "ApplicationSecurityGroupTyperighterrulemanagerB7623A9C",
               "GroupId",
             ],
           },

--- a/cdk/lib/rule-manager/__snapshots__/rule-manager.test.ts.snap
+++ b/cdk/lib/rule-manager/__snapshots__/rule-manager.test.ts.snap
@@ -237,6 +237,12 @@ Object {
               "GroupId",
             ],
           },
+          Object {
+            "Fn::GetAtt": Array [
+              "WazuhSecurityGroup",
+              "GroupId",
+            ],
+          },
         ],
         "UserData": Object {
           "Fn::Base64": Object {
@@ -795,6 +801,57 @@ dpkg -i /tmp/package.deb",
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "WazuhSecurityGroup": Object {
+      "Properties": Object {
+        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Wazuh event logging",
+            "FromPort": 1514,
+            "IpProtocol": "tcp",
+            "ToPort": 1514,
+          },
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Wazuh agent registration",
+            "FromPort": 1515,
+            "IpProtocol": "tcp",
+            "ToPort": 1515,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "typerighter-rule-manager",
+          },
+          Object {
+            "Key": "ElasticSearchCluster",
+            "Value": Object {
+              "Ref": "ClusterName",
+            },
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "flexible",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VPC",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
     },
   },
 }

--- a/cdk/lib/rule-manager/rule-manager.ts
+++ b/cdk/lib/rule-manager/rule-manager.ts
@@ -19,6 +19,7 @@ import {
   GuPublicInternetAccessSecurityGroup,
   GuSecurityGroup,
   GuVpc,
+  GuWazuhAccess,
 } from "@guardian/cdk/lib/constructs/ec2";
 import {
   GuApplicationListener,
@@ -167,7 +168,7 @@ dpkg -i /tmp/package.deb`;
         grace: Duration.minutes(5),
       }),
       targetGroup,
-      additionalSecurityGroups: [appSecurityGroup],
+      additionalSecurityGroups: [appSecurityGroup, GuWazuhAccess.getInstance(this, vpc)],
       associatePublicIpAddress: false,
     });
   }

--- a/cdk/lib/rule-manager/rule-manager.ts
+++ b/cdk/lib/rule-manager/rule-manager.ts
@@ -19,7 +19,6 @@ import {
   GuPublicInternetAccessSecurityGroup,
   GuSecurityGroup,
   GuVpc,
-  GuWazuhAccess,
 } from "@guardian/cdk/lib/constructs/ec2";
 import {
   GuApplicationListener,
@@ -168,7 +167,7 @@ dpkg -i /tmp/package.deb`;
         grace: Duration.minutes(5),
       }),
       targetGroup,
-      additionalSecurityGroups: [appSecurityGroup, GuWazuhAccess.getInstance(this, vpc)],
+      additionalSecurityGroups: [appSecurityGroup],
       associatePublicIpAddress: false,
     });
   }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -26,6 +26,6 @@
   },
   "dependencies": {
     "@aws-cdk/core": "1.98.0",
-    "@guardian/cdk": "^12.0.0"
+    "@guardian/cdk": "^13.1.0"
   }
 }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -1076,10 +1076,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@guardian/cdk@^12.0.0":
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-12.0.0.tgz#0ad7b8b21455c13cf3fa7c013c075eca57ac5318"
-  integrity sha512-0nCNBtHq9yZ3D+9b6D43imRtP/JSErgRYWbzBjdoDyrYAVdHRtsmhqi1ubsagULwiB0hN02cSIf6WJ2TX3/CYA==
+"@guardian/cdk@^13.1.0":
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-13.1.0.tgz#60d15c795acc95398295c77cc941dcbf2c4db913"
+  integrity sha512-LZ4PwVXFmRicAnA4yUw6qv6gg1RdKBKRizWClsrem36QO9KMlKzadBlaNvW9eFaG3jJSumKwB4Nj0fi+NFOEBg==
   dependencies:
     "@aws-cdk/assert" "1.98.0"
     "@aws-cdk/aws-apigateway" "1.98.0"


### PR DESCRIPTION
Requires #138.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Wazuh is required to be installed on an EC2 instance as part of our InfoSec program.

This security group allows the Wazuh agent to connect to the server.

See:
  - https://github.com/guardian/security-hq/blob/5e453f456b08763cabdfe5a0717346be8a24d556/hq/markdown/wazuh.md

**UPDATE**
As of [@guardian/cdk 13.1.0](https://github.com/guardian/cdk/releases/tag/v13.1.0), the Wazuh security group comes for free, so this PR simply updates the version.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Deploy the rule manager instances and observe traffic from the app in Wazuh?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Keeping up to date with the InfoSec program.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

~This security group will soon be added by default by @guardian/cdk. That is, this addition will [soon](https://github.com/guardian/cdk/pull/485) become redundant. `GuWazuhAccess` is a singleton however, so removal of it here would be a no-op.~

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

n/a

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
