### PR TITLE
Remove bintray resolver

### DIFF
--- a/apps/checker/app/AppLoader.scala
+++ b/apps/checker/app/AppLoader.scala
@@ -1,9 +1,15 @@
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProvider, AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
+import software.amazon.awssdk.auth.credentials.{
+  AwsCredentialsProvider => AwsCredentialsProviderV2,
+  ProfileCredentialsProvider => ProfileCredentialsProviderV2,
+  DefaultCredentialsProvider => DefaultCredentialsProviderV2
+}
 import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
 import com.gu.{AppIdentity, AwsIdentity, DevIdentity}
 import play.api.ApplicationLoader.Context
 import play.api._
+
 
 class AppLoader extends ApplicationLoader {
   def load(context: Context): Application = {
@@ -18,7 +24,12 @@ class AppLoader extends ApplicationLoader {
       case _ => DefaultAWSCredentialsProviderChain.getInstance
     }
 
-    val loadedConfig = ConfigurationLoader.load(identity, creds) {
+    val credsV2: AwsCredentialsProviderV2 = identity match {
+      case _: DevIdentity => ProfileCredentialsProviderV2.create("composer")
+      case _ => DefaultCredentialsProviderV2.create()
+    }
+
+    val loadedConfig = ConfigurationLoader.load(identity, credsV2) {
       case identity: AwsIdentity => SSMConfigurationLocation.default(identity)
       case development: DevIdentity => SSMConfigurationLocation(s"/DEV/flexible/${development.app}")
     }

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ scalacOptions in ThisBuild := Seq(
 
 val languageToolVersion = "5.3"
 val awsSdkVersion = "1.11.999"
+// AWS SDK V2 was initially added for simple-configuration, which requires it >v1.5.4.
 val awsSdkVersion2 = "2.16.48"
 val capiModelsVersion = "15.8"
 val capiClientVersion = "16.0"

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,9 @@ scalacOptions in ThisBuild := Seq(
   "-encoding", "UTF-8", "-target:jvm-1.8", "-deprecation",
   "-feature", "-unchecked", "-language:implicitConversions", "-language:postfixOps")
 
-val languageToolVersion = "4.3"
+val languageToolVersion = "5.3"
 val awsSdkVersion = "1.11.999"
+val awsSdkVersion2 = "2.16.48"
 val capiModelsVersion = "15.8"
 val capiClientVersion = "16.0"
 val circeVersion = "0.12.3"
@@ -30,7 +31,6 @@ val commonSettings = Seq(
     s"-Dconfig.file=/etc/gu/${packageName.value}.conf"
   ),
   buildInfoPackage := "typerighter",
-  resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms",
   buildInfoKeys := {
     lazy val buildInfo = BuildInfo(baseDirectory.value)
     Seq[BuildInfoKey](
@@ -42,15 +42,17 @@ val commonSettings = Seq(
       BuildInfoKey.constant("gitCommitId", buildInfo.revision)
     )
   },
-  resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms",
   libraryDependencies ++= Seq(
     "net.logstash.logback" % "logstash-logback-encoder" % "6.0",
     "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
     "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.29" % Test,
     "org.mockito" %% "mockito-scala-scalatest" % "1.16.2",
     "com.gu" % "kinesis-logback-appender" % "1.4.4",
-    "com.gu" %% "simple-configuration-ssm" % "1.5.0",
+    "com.gu" %% "simple-configuration-ssm" % "1.5.5",
     "com.gu" %% "pan-domain-auth-verification" % "0.9.1",
+  ),
+  dependencyOverrides ++= Seq(
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.5.1",
   )
 )
 
@@ -80,6 +82,7 @@ val checker = (project in file(s"$appsFolder/checker"))
       ws,
       "org.languagetool" % "languagetool-core" % languageToolVersion,
       "org.languagetool" % "language-en" % languageToolVersion,
+      "software.amazon.awssdk" % "ssm" % awsSdkVersion2,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-ssm" % awsSdkVersion,
@@ -94,7 +97,6 @@ val checker = (project in file(s"$appsFolder/checker"))
       "com.gu" %% "content-api-models-json" % capiModelsVersion,
       "com.gu" %% "content-api-client-aws" % "0.5",
       "com.gu" %% "content-api-client-default" % capiClientVersion,
-      "biz.k11i" % "xgboost-predictor" % "0.3.1",
       "edu.stanford.nlp" % "stanford-corenlp" % "3.4",
       "edu.stanford.nlp" % "stanford-corenlp" % "3.4" classifier "models",
       "edu.stanford.nlp" % "stanford-parser" % "3.4",

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,6 @@ scalacOptions in ThisBuild := Seq(
 
 val languageToolVersion = "5.3"
 val awsSdkVersion = "1.11.999"
-// AWS SDK V2 was initially added for simple-configuration, which requires it >v1.5.4.
-val awsSdkVersion2 = "2.16.48"
 val capiModelsVersion = "15.8"
 val capiClientVersion = "16.0"
 val circeVersion = "0.12.3"
@@ -49,7 +47,7 @@ val commonSettings = Seq(
     "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.29" % Test,
     "org.mockito" %% "mockito-scala-scalatest" % "1.16.2",
     "com.gu" % "kinesis-logback-appender" % "1.4.4",
-    "com.gu" %% "simple-configuration-ssm" % "1.5.5",
+    "com.gu" %% "simple-configuration-ssm" % "1.5.6",
     "com.gu" %% "pan-domain-auth-verification" % "0.9.1",
   ),
   dependencyOverrides ++= Seq(
@@ -80,7 +78,6 @@ val checker = (project in file(s"$appsFolder/checker"))
       ws,
       "org.languagetool" % "languagetool-core" % languageToolVersion,
       "org.languagetool" % "language-en" % languageToolVersion,
-      "software.amazon.awssdk" % "ssm" % awsSdkVersion2,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-ssm" % awsSdkVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
 import com.gu.riffraff.artifact.BuildInfo
 
 name := """typerighter"""
-ThisBuild / organization := "com.gu"
-ThisBuild / scalaVersion := "2.12.10"
-ThisBuild / version := "1.0-SNAPSHOT"
-ThisBuild / scalacOptions := Seq(
+organization in ThisBuild := "com.gu"
+scalaVersion in ThisBuild := "2.12.10"
+version in ThisBuild := "1.0-SNAPSHOT"
+scalacOptions in ThisBuild := Seq(
   "-encoding", "UTF-8", "-target:jvm-1.8", "-deprecation",
   "-feature", "-unchecked", "-language:implicitConversions", "-language:postfixOps")
 
@@ -20,7 +20,7 @@ val scalikejdbcPlayVersion = "2.8.0-scalikejdbc-3.5"
 val appsFolder = "apps";
 
 val commonSettings = Seq(
-  Universal / javaOptions ++= Seq(
+  javaOptions in Universal ++= Seq(
     s"-Dpidfile.path=/dev/null",
     "-J-XX:MaxRAMFraction=2",
     "-J-XX:InitialRAMFraction=2",
@@ -133,8 +133,8 @@ val ruleManager = (project in file(s"$appsFolder/rule-manager"))
 val root = (project in file(".")).aggregate(commonLib, checker, ruleManager).enablePlugins(RiffRaffArtifact)
 
 riffRaffArtifactResources := Seq(
-  (checker / Debian / packageBin).value  -> s"${(checker / packageName).value}/${(checker / packageName).value}.deb",
-  (ruleManager / Debian / packageBin).value  -> s"${(checker / packageName).value}/${(ruleManager / packageName).value}.deb",
+  (packageBin in Debian in checker).value  -> s"${(packageName in checker).value}/${(packageName in checker).value}.deb",
+  (packageBin in Debian in ruleManager).value  -> s"${(packageName in ruleManager).value}/${(packageName in ruleManager).value}.deb",
   baseDirectory.value / "riff-raff.yaml" -> "riff-raff.yaml",
   baseDirectory.value / "apps/checker/cfn/cfn.yaml" -> "checker-cloudformation/checker.cfn.yaml",
   baseDirectory.value / "cdk/cfn/rule-manager.cfn.yaml" -> "rule-manager-cloudformation/rule-manager.cfn.yaml",

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
 import com.gu.riffraff.artifact.BuildInfo
 
 name := """typerighter"""
-organization in ThisBuild := "com.gu"
-scalaVersion in ThisBuild := "2.12.10"
-version in ThisBuild := "1.0-SNAPSHOT"
-scalacOptions in ThisBuild := Seq(
+ThisBuild / organization := "com.gu"
+ThisBuild / scalaVersion := "2.12.10"
+ThisBuild / version := "1.0-SNAPSHOT"
+ThisBuild / scalacOptions := Seq(
   "-encoding", "UTF-8", "-target:jvm-1.8", "-deprecation",
   "-feature", "-unchecked", "-language:implicitConversions", "-language:postfixOps")
 
@@ -20,7 +20,7 @@ val scalikejdbcPlayVersion = "2.8.0-scalikejdbc-3.5"
 val appsFolder = "apps";
 
 val commonSettings = Seq(
-  javaOptions in Universal ++= Seq(
+  Universal / javaOptions ++= Seq(
     s"-Dpidfile.path=/dev/null",
     "-J-XX:MaxRAMFraction=2",
     "-J-XX:InitialRAMFraction=2",
@@ -76,9 +76,6 @@ val checker = (project in file(s"$appsFolder/checker"))
     packageName := "typerighter-checker",
     PlayKeys.devSettings += "play.server.http.port" -> "9100",
     commonSettings,
-    // Used to resolve xgboost-predictor, which is no longer available
-    // at spring.io without auth.
-    resolvers += "komiya-atsushi Bintray" at "https://dl.bintray.com/komiya-atsushi/maven",
     libraryDependencies ++= Seq(
       ws,
       "org.languagetool" % "languagetool-core" % languageToolVersion,
@@ -136,8 +133,8 @@ val ruleManager = (project in file(s"$appsFolder/rule-manager"))
 val root = (project in file(".")).aggregate(commonLib, checker, ruleManager).enablePlugins(RiffRaffArtifact)
 
 riffRaffArtifactResources := Seq(
-  (packageBin in Debian in checker).value  -> s"${(packageName in checker).value}/${(packageName in checker).value}.deb",
-  (packageBin in Debian in ruleManager).value  -> s"${(packageName in ruleManager).value}/${(packageName in ruleManager).value}.deb",
+  (checker / Debian / packageBin).value  -> s"${(checker / packageName).value}/${(checker / packageName).value}.deb",
+  (ruleManager / Debian / packageBin).value  -> s"${(checker / packageName).value}/${(ruleManager / packageName).value}.deb",
   baseDirectory.value / "riff-raff.yaml" -> "riff-raff.yaml",
   baseDirectory.value / "apps/checker/cfn/cfn.yaml" -> "checker-cloudformation/checker.cfn.yaml",
   baseDirectory.value / "cdk/cfn/rule-manager.cfn.yaml" -> "rule-manager-cloudformation/rule-manager.cfn.yaml",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.5
+sbt.version=1.5.1

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.1
+sbt.version=1.3.5


### PR DESCRIPTION
## What does this change?

Removes the Bintray resolver.

## Details

To accomplish these we needed to bump a few things:

- `simple-configuration-ssm` to >`1.5.5`. This requires aws-sdk v2, which in turn requires us to add credentials objects for both versions in code. This repetition is contained within the AppLoader classes in each project, so it's not too pernicious.
- LanguageTool to `5.3`. This allows us to remove the reference to bintray-hosted `xgboost-predictor`.

## How to test

This should be a no-op – the project should build and work as before.

Tested in CODE.
