### PR TITLE
Downgrade LanguageTool to 5.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalacOptions in ThisBuild := Seq(
   "-encoding", "UTF-8", "-target:jvm-1.8", "-deprecation",
   "-feature", "-unchecked", "-language:implicitConversions", "-language:postfixOps")
 
-val languageToolVersion = "5.3"
+val languageToolVersion = "5.1"
 val awsSdkVersion = "1.11.999"
 val capiModelsVersion = "15.8"
 val capiClientVersion = "16.0"


### PR DESCRIPTION
## What does this change?

Downgrades LanguageTool to 5.1. 5.2 introduces XML errors ingesting our LT corpus related to the 'skip' XML attribute. We don't know what's wrong yet specifically.

In the meantime, downgrading solves the problem.

## How to test

Deploy to CODE. In CODE, [this article](https://composer.code.dev-gutools.co.uk/content/6087fcce8f083e40e5d91d10) should have 15 red matches, not 2, as would be the case if we were only using regex rules.

## How can we measure success?

Our rules work as before.

## Dev notes

Once we've separated out the systems that are a) creating the rule bundle and b) consuming it, we should be able to fail a healthcheck when this happens, ensuring that we 
- get alerts via CD failure when it happens again
- avoid any user impact