### PR TITLE
Remove unneeded conf file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,7 @@ val commonSettings = Seq(
     "-J-XX:+PrintGCDetails",
     "-J-XX:+PrintGCDateStamps",
     s"-J-Dlogs.home=/var/log/${packageName.value}",
-    s"-J-Xloggc:/var/log/${packageName.value}/gc.log",
-    s"-Dconfig.file=/etc/gu/${packageName.value}.conf"
+    s"-J-Xloggc:/var/log/${packageName.value}/gc.log"
   ),
   buildInfoPackage := "typerighter",
   buildInfoKeys := {
@@ -71,6 +70,7 @@ val checker = (project in file(s"$appsFolder/checker"))
   .dependsOn(commonLib)
   .enablePlugins(PlayScala, GatlingPlugin, BuildInfoPlugin, JDebPackaging, SystemdPlugin)
   .settings(
+    javaOptions in Universal += s"-Dconfig.file=/etc/gu/${packageName.value}.conf",
     packageName := "typerighter-checker",
     PlayKeys.devSettings += "play.server.http.port" -> "9100",
     commonSettings,

--- a/cdk/lib/rule-manager/__snapshots__/rule-manager.test.ts.snap
+++ b/cdk/lib/rule-manager/__snapshots__/rule-manager.test.ts.snap
@@ -244,12 +244,6 @@ Object {
               "",
               Array [
                 "#!/bin/bash -ev
-mkdir /etc/gu
-
-cat > /etc/gu/typerighter-rule-manager.conf <<-'EOF'
-    include \\"application\\"
-EOF
-
 aws --quiet --region ",
                 Object {
                   "Ref": "AWS::Region",

--- a/cdk/lib/rule-manager/rule-manager.ts
+++ b/cdk/lib/rule-manager/rule-manager.ts
@@ -127,12 +127,6 @@ export class RuleManager extends GuStack {
     appSecurityGroup.connections.allowFrom(loadBalancer, Port.tcp(9000), "Port 9000 LB to fleet");
 
     const userData = `#!/bin/bash -ev
-mkdir /etc/gu
-
-cat > /etc/gu/typerighter-rule-manager.conf <<-'EOF'
-    include "application"
-EOF
-
 aws --quiet --region ${this.region} s3 cp s3://composer-dist/${this.stack}/${this.stage}/typerighter-rule-manager/typerighter-rule-manager.deb /tmp/package.deb
 dpkg -i /tmp/package.deb`;
 


### PR DESCRIPTION
## What does this change?

Removes an unneeded conf file from the rule-manager, which (apart from being unnecessary!) will let us use the new GuPlayApp CDK pattern.

## How to test

This is a no-op – everything should work as before.