### PR TITLE
Do not discard legitimate word starts in SentenceHelper

### DIFF
--- a/apps/checker/app/services/SentenceHelpers.scala
+++ b/apps/checker/app/services/SentenceHelpers.scala
@@ -14,9 +14,9 @@ case class WordInSentence(sentence: String, word: String, range: TextRange)
 
 object SentenceHelpers {
   // These tokens can contain multiple quotes – we only need to detect the presence of one.
-  val NON_WORD_TOKEN_CHARS = List("`", "'", "-")
+  val NON_WORD_TOKEN_CHARS = Set('`', '\'', '-')
   // These tokens are discrete. LSB == Left Square Bracket, etc.
-  val NON_WORD_TOKENS = List("-LSB-", "-LRB-", "-LCB-")
+  val NON_WORD_TOKENS = Set("-LSB-", "-LRB-", "-LCB-")
 }
 
 /**
@@ -43,13 +43,7 @@ class SentenceHelpers() {
   def maybeGetFirstWordFromSentence(sentence: CoreMap) = {
     val tokens = sentence.get(classOf[TokensAnnotation]).asScala.toList
     val maybeFirstValidToken = tokens.find { token =>
-      val tokenDoesNotContainNonWordToken = !SentenceHelpers.NON_WORD_TOKENS.contains(token.value())
-      val tokenWithNonWordCharsRemoved = SentenceHelpers.NON_WORD_TOKEN_CHARS.foldLeft(token.value()) {
-        (remainingToken, nonWordChar) => remainingToken.replace(nonWordChar, "")
-      }
-      val tokenContainsWordCharacters = tokenWithNonWordCharsRemoved.size > 0
-
-      tokenDoesNotContainNonWordToken && tokenContainsWordCharacters
+      tokenDoesNotContainNonWordToken(token) && tokenContainsWordCharacters(token)
     }
 
     maybeFirstValidToken.map { token =>
@@ -60,5 +54,15 @@ class SentenceHelpers() {
         TextRange(token.beginPosition(), token.endPosition())
       )
     }
+  }
+
+  private def tokenDoesNotContainNonWordToken(token: CoreLabel) =
+    !SentenceHelpers.NON_WORD_TOKENS.contains(token.value)
+
+  private def tokenContainsWordCharacters(token: CoreLabel) = {
+    val tokenWithNonWordCharsRemoved = token.value.filterNot(
+      SentenceHelpers.NON_WORD_TOKEN_CHARS.contains
+    )
+    tokenWithNonWordCharsRemoved.size > 0
   }
 }

--- a/apps/checker/app/services/SentenceHelpers.scala
+++ b/apps/checker/app/services/SentenceHelpers.scala
@@ -43,8 +43,13 @@ class SentenceHelpers() {
   def maybeGetFirstWordFromSentence(sentence: CoreMap) = {
     val tokens = sentence.get(classOf[TokensAnnotation]).asScala.toList
     val maybeFirstValidToken = tokens.find { token =>
-      !SentenceHelpers.NON_WORD_TOKENS.contains(token.value()) &&
-      !SentenceHelpers.NON_WORD_TOKEN_CHARS.exists(token.value().contains(_))
+      val tokenDoesNotContainNonWordToken = !SentenceHelpers.NON_WORD_TOKENS.contains(token.value())
+      val tokenWithNonWordCharsRemoved = SentenceHelpers.NON_WORD_TOKEN_CHARS.foldLeft(token.value()) {
+        (remainingToken, nonWordChar) => remainingToken.replace(nonWordChar, "")
+      }
+      val tokenContainsWordCharacters = tokenWithNonWordCharsRemoved.size > 0
+
+      tokenDoesNotContainNonWordToken && tokenContainsWordCharacters
     }
 
     maybeFirstValidToken.map { token =>

--- a/apps/checker/test/scala/services/SentenceHelperTest.scala
+++ b/apps/checker/test/scala/services/SentenceHelperTest.scala
@@ -40,6 +40,14 @@ class SentenceHelperTest extends AsyncFlatSpec with Matchers {
         WordInSentence(s"${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(103, 108)),
       ))
     }
+
+    it should s"not ignore words that contain non-word tokens when finding sentence starts: $nonWordChar" in {
+      val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Other${nonWordChar} cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
+      firstWordsInSentences should matchTo(List(
+        WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
+        WordInSentence(s"Other${nonWordChar} cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Other", TextRange(102, 107)),
+      ))
+    }
   }
 
   charactersThatProduceNonWordTokens.foreach { nonWordChar =>


### PR DESCRIPTION
## What does this change?

We use sentence chunking in Typerighter to detect sentence starts. This helps us figure out when to cap up suggestions. For example, when detecting a typo like

`... to holiday accomodation. cafs, bars, and ...`

We would want to provide the suggestion `Cafes` – to accommodate both the typo and the fact that words at the start of a sentence should be capitalised.

Our sentence helper tokenises our sentence and discovers its first word to enable this feature. This lets us compare our suggestion to the first word in the sentence. If our suggestion case-insensitively matches the first word and its position, we can be sure that we're suggesting something at the start of a sentence, and capitalise accordingly.

The first word is not always the first token. For example, the tokens for the fragment `(Oh no` would be `-LRB-` `Oh` `no`, where `LRB` stands for Left Round Bracket. So in order to detect the first word, we must discard any tokens which are entirely comprised of non-word characters.

This PR fixes a bug where if we detected _any_ non-word characters in a token, we'd discard it. This meant that, in an example given to us from Editorial, the sentence helper thought the first word in the sentence `Anti-immigrant flyers` was `flyers`, because `Anti-immigrant` contained a non-word character.

## How to test

Deploy this branch to CODE and test the following sentence:

`As politics kept us from one home, it marginalised us in the other. The Dursleys of Essex nailed their racism to the mast time and again. Anti-immigrant flyers landed on the doorstep, Ukip banners appeared in windows, two of the top five “vote Leave” constituencies were within a few miles of our family home.`

Before this change, you should see `flyers` flagged as red, with a suggestion `Flyers`.

After it, `flyers` should be green.
