### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Google credentials are fetched from SSM using AWS Credentials or Instance Role.
 
 It's worth noting that, at the moment, there are a fair few assumptions built into this repository that are Guardian-specific:
  - We assume the use of AWS cloud services, and default to the `eu-west-1` region. This is configurable on a [per-project](https://github.com/guardian/typerighter/blob/main/apps/checker/conf/application.conf) basis with the [configuration parameter `aws.region`](https://github.com/guardian/typerighter/blob/fa90ef260cd71e0f4fa1b893d7bba9b87ff828ef/apps/common-lib/src/main/scala/com/gu/typerighter/lib/CommonConfig.scala#L16).
- - Building and deployment is handled by riff-raff, [the Guardian's deployment platform](https://github.com/guardian/riff-raff)
- - Configuration is handled by [simple-configuration](https://github.com/guardian/simple-configuration)
+ - Building and deployment is handled by riff-raff, [the Guardian's deployment platform](https://github.com/guardian/riff-raff).
+ - Configuration is handled by [simple-configuration](https://github.com/guardian/simple-configuration).
 
-We'd be delighted to consider any discussions or PRs that aimed to make Typerighter easier to use in a less institionally-specific context.
+We'd be delighted to participate in discussions, or consider PRs, that aimed to make Typerighter easier to use in a less institionally specific context.
 
 ## Integration
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Both the checker and management services are built in Scala with the Play framew
 
 Google credentials are fetched from SSM using AWS Credentials or Instance Role. 
 
+It's worth noting that, at the moment, there are a fair few assumptions built into this repository that are Guardian-specific:
+ - We assume the use of AWS cloud services, and default to the `eu-west-1` region. This is configurable on a [per-project](https://github.com/guardian/typerighter/blob/main/apps/checker/conf/application.conf) basis with the [configuration parameter `aws.region`](https://github.com/guardian/typerighter/blob/fa90ef260cd71e0f4fa1b893d7bba9b87ff828ef/apps/common-lib/src/main/scala/com/gu/typerighter/lib/CommonConfig.scala#L16).
+ - Building and deployment is handled by riff-raff, [the Guardian's deployment platform](https://github.com/guardian/riff-raff)
+ - Configuration is handled by [simple-configuration](https://github.com/guardian/simple-configuration)
+
+We'd be delighted to consider any discussions or PRs that aimed to make Typerighter easier to use in a less institionally-specific context.
+
 ## Integration
 
 The [prosemirror-typerighter](https://github.com/guardian/prosemirror-typerighter) plugin provides an integration for the [Prosemirror](https://prosemirror.net) rich text editor.


### PR DESCRIPTION
## What does this change?

We've a few issues at the moment detailing errors that are the result of running Typerighter in a non-Guardian context. This PR updates our readme to give a little more detail about the hurdles non-Gu devs are likely to encounter when spinning up Typerighter.

## How to test

Do the new docs adequately address all the Guardian-specific infra used in running the Typerighter project?

## How can we measure success?

Fewer issues raised as a result of clearer guidance for non-Guardian developers.
