### PR TITLE
Bump pan-domain-auth to 1.0.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,7 @@ val ruleManager = (project in file(s"$appsFolder/rule-manager"))
       "org.scalikejdbc" %% "scalikejdbc-config" % scalikejdbcVersion,
       "org.scalikejdbc" %% "scalikejdbc-play-initializer" % scalikejdbcPlayVersion,
       "org.scalikejdbc" %% "scalikejdbc-test" % "3.5.0" % Test,
-      "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.4",
+      "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6",
       "com.gu" %% "editorial-permissions-client" % "2.14"
     )
   )


### PR DESCRIPTION
**NB:** Requires #190. Please review that first!

## What does this change?

Bumps pan-domain-auth to 1.0.6 to patch some security vulnerabilities.

## How to test

The app should continue to accept authenticated requests, and reject unauthenticated ones.

Deploy to CODE and use Typerighter on a document in Composer. Does Typerighter continue to give suggestions? Remove your pan-domain cookies, and try again. Does it give an auth failure?