### PR TITLE
Specify major version of RDS only

### DIFF
--- a/cdk/lib/__snapshots__/index.test.ts.snap
+++ b/cdk/lib/__snapshots__/index.test.ts.snap
@@ -1513,7 +1513,7 @@ dpkg -i /tmp/package.deb",
         },
         "DeletionProtection": true,
         "Engine": "postgres",
-        "EngineVersion": "13.3",
+        "EngineVersion": "13",
         "MasterUserPassword": Object {
           "Fn::Join": Array [
             "",

--- a/cdk/lib/__snapshots__/index.test.ts.snap
+++ b/cdk/lib/__snapshots__/index.test.ts.snap
@@ -1492,7 +1492,7 @@ dpkg -i /tmp/package.deb",
       "DeletionPolicy": "Snapshot",
       "Properties": Object {
         "AllocatedStorage": "50",
-        "AllowMajorVersionUpgrade": true,
+        "AllowMajorVersionUpgrade": false,
         "AutoMinorVersionUpgrade": true,
         "BackupRetentionPeriod": 10,
         "CopyTagsToSnapshot": true,

--- a/cdk/lib/index.ts
+++ b/cdk/lib/index.ts
@@ -292,7 +292,7 @@ dpkg -i /tmp/package.deb`,
       vpc: ruleManagerApp.vpc,
       vpcSubnets: { subnetType: SubnetType.PRIVATE_WITH_NAT },
       allocatedStorage: 50,
-      allowMajorVersionUpgrade: true,
+      allowMajorVersionUpgrade: false,
       autoMinorVersionUpgrade: true,
       backupRetention: Duration.days(10),
       engine: DatabaseInstanceEngine.postgres({

--- a/cdk/lib/index.ts
+++ b/cdk/lib/index.ts
@@ -296,7 +296,7 @@ dpkg -i /tmp/package.deb`,
       autoMinorVersionUpgrade: true,
       backupRetention: Duration.days(10),
       engine: DatabaseInstanceEngine.postgres({
-        version: PostgresEngineVersion.VER_13_3,
+        version: PostgresEngineVersion.VER_13,
       }),
       instanceType: "t3.micro",
       instanceIdentifier: `typerighter-rule-manager-store-${this.stage}`,


### PR DESCRIPTION
## What does this change?

Our RDS database is configured to auto update, and has bumped to 13.4. Meanwhile our CDK is hardcoded to 13.3, and AWS sensibly refuses to downgrade when the CFN is deployed.

This PR specifies a major version for the RDS only, letting it drift up minor versions.

## How to test

Deploy to CODE. The deployment should succeed.