### PR TITLE
ci: Switch to a more direct upload to Riff-Raff

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -135,3 +135,5 @@ riffRaffArtifactResources := Seq(
   baseDirectory.value / "riff-raff.yaml" -> "riff-raff.yaml",
   baseDirectory.value / "cdk/cdk.out/typerighter.template.json" -> "typerighter-cloudformation/typerighter.template.json"
 )
+
+riffRaffManifestProjectName := s"Editorial Tools::Typerighter"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.11")
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 addSbtPlugin("io.gatling" % "gatling-sbt" % "3.0.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")

--- a/script/citest
+++ b/script/citest
@@ -68,7 +68,7 @@ buildClients() {
 buildSbt() {
   (
     cd $ROOT_DIR
-    sbt clean compile test riffRaffNotifyTeamcity
+    sbt clean compile test riffRaffUpload
   )
 }
 


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We've, somewhat randomly (see #200, and #199), started seeing builds fail when uploading artifacts.

The [`riffRaffNotifyTeamcity`](https://github.com/guardian/typerighter/blob/05e3b077b192b2d9f05f84027095519a7fb30be4/script/citest#L71) task is a proxy to [TeamCity's `publishArtifacts` service message](https://www.jetbrains.com/help/teamcity/service-messages.html#Publishing+Artifacts+While+Build+is+in+Progress), which allows:

> You can publish the build artifacts while the build is still running, immediately after the artifacts are built.

In this change, we switch to the `riffRaffUpload` task, which uploads artifacts at the _end_ of a build,  rather than as they are created.

The hope is this fixes the build, or provides more information to diagnose the underlying issue.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

CI should produce a deployable build.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

CI is fixed.