### PR TITLE
Calculate percentage complete and return in check result

### DIFF
--- a/apps/checker/app/model/Check.scala
+++ b/apps/checker/app/model/Check.scala
@@ -35,4 +35,4 @@ object CheckResult {
   implicit val writes: Writes[CheckResult] = Json.writes[CheckResult]
 }
 
-case class CheckResult(categoryIds: Set[String], blocks: List[TextBlock], matches: List[RuleMatch])
+case class CheckResult(categoryIds: Set[String], blocks: List[TextBlock], matches: List[RuleMatch], percentageRequestComplete: Option[Float] = None)

--- a/apps/checker/test/scala/services/MatcherPoolTest.scala
+++ b/apps/checker/test/scala/services/MatcherPoolTest.scala
@@ -420,4 +420,17 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
       case Failure(e) => e.getMessage shouldBe errorMessage
     }
   }
+
+  it should "report on the percentage of completed jobs in each result" in {
+    val matchers = getMatchers(10)
+    matchers.foreach(_.completeWith(responses))
+
+    val pool = getPool(matchers)
+    val futureResult: Future[Seq[CheckResult]] = pool.checkStream(getCheck(text = "Example text")).runWith(Sink.seq)
+
+    futureResult map { result =>
+      val percentages = result.flatMap(_.percentageRequestComplete)
+      percentages shouldBe Seq(10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0)
+    }
+  }
 }


### PR DESCRIPTION
## What does this change?
This updates the chunked/streamed response in the Typerighter API to return an indication of what percentage of jobs have been completed in a check request. This percentage is currently calculated on the client-side and by calculating this value on the server we will be able to simplify our client-side code.

## How to test
Deploy and run this branch locally and run the accompanying branch in [prosemirror-typerighter](https://github.com/guardian/prosemirror-typerighter/pull/233). You should be able to see the loading bar in the right hand side results panel continue to work as expected.