### PR TITLE
Permit auth tokens that are within the grace period – or expired

### DIFF
--- a/apps/common-lib/src/main/scala/com/gu/typerighter/lib/PandaAuthentication.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/lib/PandaAuthentication.scala
@@ -42,6 +42,7 @@ trait PandaAuthentication extends BaseControllerHelpers with Loggable {
             case Authenticated(AuthenticatedUser(user, _, _, _, _)) =>
               block(user, request).map(Right(_))(executionContext)
             case GracePeriod(AuthenticatedUser(user, _, _, _, _)) =>
+              log.info(s"User ${user.email} has made a request with a token within the auth grace period")
               block(user, request).map(Right(_))(executionContext)
             case Expired(AuthenticatedUser(user, _, _, _, _)) =>
               log.info(s"User ${user.email} has made a request with an expired token")

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/lib/PandaAuthentication.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/lib/PandaAuthentication.scala
@@ -1,6 +1,6 @@
 package com.gu.typerighter.lib
 
-import com.gu.pandomainauth.model.{Authenticated, AuthenticatedUser, AuthenticationStatus, GracePeriod, User}
+import com.gu.pandomainauth.model.{Authenticated, AuthenticatedUser, AuthenticationStatus, Expired, GracePeriod, User}
 import com.gu.pandomainauth.{PanDomain, PublicKey, PublicSettings}
 import play.api.mvc._
 
@@ -40,6 +40,11 @@ trait PandaAuthentication extends BaseControllerHelpers with Loggable {
         case (Some(pk), Some(cookie)) =>
           authStatus(cookie, pk) match {
             case Authenticated(AuthenticatedUser(user, _, _, _, _)) =>
+              block(user, request).map(Right(_))(executionContext)
+            case GracePeriod(AuthenticatedUser(user, _, _, _, _)) =>
+              block(user, request).map(Right(_))(executionContext)
+            case Expired(AuthenticatedUser(user, _, _, _, _)) =>
+              log.info(s"User ${user.email} has made a request with an expired token")
               block(user, request).map(Right(_))(executionContext)
             case other =>
               log.info(s"Login response $other")


### PR DESCRIPTION
## What does this change?

Permits auth tokens that are within the grace period – or expired.

## How to test

It might take a little time! The grace period is 2 hours, so if you're testing this using Composer it'll take an hour before your token hits the grace period, and another 2 before it expires.

We should be able to see logging indicating the state of your token, and requests should succeed in both of those states.

Tested on CODE:

- [x] normal auth
- [x] grace period auth
- [ ] expired auth (pending)
