### PR TITLE
Bump dependencies

### DIFF
--- a/apps/checker/app/AppComponents.scala
+++ b/apps/checker/app/AppComponents.scala
@@ -21,7 +21,6 @@ import matchers.LanguageToolFactory
 import utils.CloudWatchClient
 import utils.CheckerConfig
 
-
 class AppComponents(context: Context, region: String, identity: AppIdentity, creds: AWSCredentialsProvider, credsV2: AwsCredentialsProvider)
   extends BuiltInComponentsFromContext(context)
   with HttpFiltersComponents

--- a/apps/checker/app/AppComponents.scala
+++ b/apps/checker/app/AppComponents.scala
@@ -1,4 +1,5 @@
 import com.amazonaws.auth.AWSCredentialsProvider
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import com.gu.contentapi.client.GuardianContentClient
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.gu.pandomainauth.PublicSettings
@@ -21,7 +22,7 @@ import utils.CloudWatchClient
 import utils.CheckerConfig
 
 
-class AppComponents(context: Context, identity: AppIdentity, creds: AWSCredentialsProvider)
+class AppComponents(context: Context, region: String, identity: AppIdentity, creds: AWSCredentialsProvider, credsV2: AwsCredentialsProvider)
   extends BuiltInComponentsFromContext(context)
   with HttpFiltersComponents
   with CORSComponents
@@ -31,11 +32,11 @@ class AppComponents(context: Context, identity: AppIdentity, creds: AWSCredentia
 
   override def httpFilters: Seq[EssentialFilter] = corsFilter +: super.httpFilters.filterNot(allowedHostsFilter ==)
 
-  val config = new CheckerConfig(configuration, identity, creds)
+  val config = new CheckerConfig(configuration, region, identity, creds)
 
   // initialise log shipping if we are in AWS
-  private val logShipping = Some(identity).collect{ case awsIdentity: AwsIdentity =>
-    new ElkLogging(awsIdentity, config.loggingStreamName, creds, applicationLifecycle)
+  Some(identity).collect { case awsIdentity: AwsIdentity =>
+    new ElkLogging(awsIdentity, config.loggingStreamName, credsV2, applicationLifecycle)
   }
 
   val languageToolFactory = new LanguageToolFactory(config.ngramPath, true)
@@ -43,7 +44,11 @@ class AppComponents(context: Context, identity: AppIdentity, creds: AWSCredentia
   val guardianContentClient = GuardianContentClient(config.capiApiKey)
   val contentClient = new ContentClient(guardianContentClient)
 
-  private val s3Client = AmazonS3ClientBuilder.standard().withCredentials(creds).withRegion(AppIdentity.region).build()
+  private val s3Client = AmazonS3ClientBuilder
+    .standard()
+    .withCredentials(creds)
+    .withRegion(region)
+    .build()
 
   val settingsFile = identity match {
     case identity: AwsIdentity if identity.stage == "PROD" => "gutools.co.uk.settings.public"

--- a/apps/checker/app/AppLoader.scala
+++ b/apps/checker/app/AppLoader.scala
@@ -1,10 +1,6 @@
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
-import software.amazon.awssdk.auth.credentials.{AwsCredentialsProvider => AwsCredentialsProviderV2, DefaultCredentialsProvider => DefaultCredentialsProviderV2, ProfileCredentialsProvider => ProfileCredentialsProviderV2}
-import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
-import com.gu.{AppIdentity, AwsIdentity, DevIdentity}
+
+import com.gu.typerighter.lib.AppSetup
 import play.api.ApplicationLoader.Context
-import play.api.Mode.Dev
 import play.api._
 
 
@@ -14,34 +10,14 @@ class AppLoader extends ApplicationLoader {
       _.configure(context.environment, context.initialConfiguration, Map.empty)
     }
 
-    val region = context.initialConfiguration.getOptional[String]("aws.region").getOrElse("eu-west-1")
-
-    val (creds, credsV2, identity) = context.environment.mode match {
-      case Dev => (
-        new ProfileCredentialsProvider("composer"),
-        ProfileCredentialsProviderV2.create("composer"),
-        DevIdentity("typerighter-checker")
-      )
-      case _ =>
-      val credsV2 = DefaultCredentialsProviderV2.create();
-      (
-        DefaultAWSCredentialsProviderChain.getInstance,
-        credsV2,
-        AppIdentity.whoAmI(defaultAppName = "typerighter-checker", credsV2).get
-      )
-    }
-
-    val loadedConfig = ConfigurationLoader.load(identity, credsV2) {
-      case identity: AwsIdentity => SSMConfigurationLocation.default(identity)
-      case development: DevIdentity => SSMConfigurationLocation(s"/DEV/flexible/${development.app}", region)
-    }
+    val appSetup = AppSetup(context)
 
     new AppComponents(
-      context.copy(initialConfiguration = Configuration(loadedConfig).withFallback(context.initialConfiguration)),
-      region,
-      identity,
-      creds,
-      credsV2
+      context.copy(initialConfiguration = Configuration(appSetup.config).withFallback(context.initialConfiguration)),
+      appSetup.region,
+      appSetup.identity,
+      appSetup.creds,
+      appSetup.credsV2
     ).application
   }
 }

--- a/apps/checker/app/AppLoader.scala
+++ b/apps/checker/app/AppLoader.scala
@@ -1,13 +1,10 @@
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProvider, AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
-import software.amazon.awssdk.auth.credentials.{
-  AwsCredentialsProvider => AwsCredentialsProviderV2,
-  ProfileCredentialsProvider => ProfileCredentialsProviderV2,
-  DefaultCredentialsProvider => DefaultCredentialsProviderV2
-}
+import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
+import software.amazon.awssdk.auth.credentials.{AwsCredentialsProvider => AwsCredentialsProviderV2, DefaultCredentialsProvider => DefaultCredentialsProviderV2, ProfileCredentialsProvider => ProfileCredentialsProviderV2}
 import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
 import com.gu.{AppIdentity, AwsIdentity, DevIdentity}
 import play.api.ApplicationLoader.Context
+import play.api.Mode.Dev
 import play.api._
 
 
@@ -17,27 +14,34 @@ class AppLoader extends ApplicationLoader {
       _.configure(context.environment, context.initialConfiguration, Map.empty)
     }
 
-    val identity = AppIdentity.whoAmI(defaultAppName = "typerighter-checker")
+    val region = context.initialConfiguration.getOptional[String]("aws.region").getOrElse("eu-west-1")
 
-    val creds: AWSCredentialsProvider = identity match {
-      case _: DevIdentity => new ProfileCredentialsProvider("composer")
-      case _ => DefaultAWSCredentialsProviderChain.getInstance
-    }
-
-    val credsV2: AwsCredentialsProviderV2 = identity match {
-      case _: DevIdentity => ProfileCredentialsProviderV2.create("composer")
-      case _ => DefaultCredentialsProviderV2.create()
+    val (creds, credsV2, identity) = context.environment.mode match {
+      case Dev => (
+        new ProfileCredentialsProvider("composer"),
+        ProfileCredentialsProviderV2.create("composer"),
+        DevIdentity("typerighter-checker")
+      )
+      case _ =>
+      val credsV2 = DefaultCredentialsProviderV2.create();
+      (
+        DefaultAWSCredentialsProviderChain.getInstance,
+        credsV2,
+        AppIdentity.whoAmI(defaultAppName = "typerighter-checker", credsV2).get
+      )
     }
 
     val loadedConfig = ConfigurationLoader.load(identity, credsV2) {
       case identity: AwsIdentity => SSMConfigurationLocation.default(identity)
-      case development: DevIdentity => SSMConfigurationLocation(s"/DEV/flexible/${development.app}")
+      case development: DevIdentity => SSMConfigurationLocation(s"/DEV/flexible/${development.app}", region)
     }
 
     new AppComponents(
       context.copy(initialConfiguration = Configuration(loadedConfig).withFallback(context.initialConfiguration)),
+      region,
       identity,
-      creds
+      creds,
+      credsV2
     ).application
   }
 }

--- a/apps/checker/app/utils/CheckerConfig.scala
+++ b/apps/checker/app/utils/CheckerConfig.scala
@@ -7,7 +7,7 @@ import com.gu.typerighter.lib.CommonConfig
 import play.api.Configuration
 import com.amazonaws.auth.AWSCredentialsProvider
 
-class CheckerConfig(playConfig: Configuration, identity: AppIdentity, creds: AWSCredentialsProvider) extends CommonConfig(playConfig, identity, creds) {
+class CheckerConfig(playConfig: Configuration, region: String, identity: AppIdentity, creds: AWSCredentialsProvider) extends CommonConfig(playConfig, region, identity, creds) {
   val ngramPath: Option[File] = playConfig.getOptional[String]("typerighter.ngramPath").map(new File(_))
   val capiApiKey = playConfig.get[String]("capi.apiKey")
   val credentials = playConfig.get[String]("typerighter.google.credentials")

--- a/apps/checker/test/scala/matchers/LanguageToolMatcherTest.scala
+++ b/apps/checker/test/scala/matchers/LanguageToolMatcherTest.scala
@@ -3,7 +3,6 @@ package matchers
 import model._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
-import com.softwaremill.diffx.scalatest.DiffMatcher._
 import services.MatcherRequest
 
 class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {

--- a/apps/checker/test/scala/matchers/RegexMatcherTest.scala
+++ b/apps/checker/test/scala/matchers/RegexMatcherTest.scala
@@ -3,7 +3,8 @@ package matchers
 import model._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
-import com.softwaremill.diffx.scalatest.DiffMatcher._
+import com.softwaremill.diffx.scalatest.DiffShouldMatcher._
+import com.softwaremill.diffx.generic.auto._
 
 import services.MatcherRequest
 import utils.Text
@@ -66,7 +67,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
       MatcherRequest(getBlocks(sampleText))
     )
     eventuallyMatches.map { matches =>
-      matches should matchTo(List(
+      matches shouldMatchTo(List(
         getMatch("text", 8, 12, "example ", " is here")
       ))
     }
@@ -102,7 +103,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
       MatcherRequest(getBlocks(sampleText))
     )
     eventuallyMatches.map { matches =>
-      matches should matchTo(List(
+      matches shouldMatchTo(List(
         getMatch("text", 121, 125, before, after)
       ))
     }
@@ -113,7 +114,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
       MatcherRequest(getBlocks("text text text"))
     )
     eventuallyMatches.map { matches =>
-      matches should matchTo(List(
+      matches shouldMatchTo(List(
         getMatch("text", 0, 4, "", " text text"),
         getMatch("text", 5, 9, "text ", " text"),
         getMatch("text", 10, 14, "text text ", "")
@@ -129,9 +130,9 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     )
     eventuallyMatches.map { matches =>
       matches.size shouldBe 3
-      matches(0) should matchTo(getMatch("ton", 5, 8, "tone ", " goto", overlapRules(1)))
-      matches(1) should matchTo(getMatch("one", 1, 4, "t", " ton goto", overlapRules(2)))
-      matches(2) should matchTo(getMatch("got", 9, 12, "tone ton ", "o", overlapRules(3)))
+      matches(0) shouldMatchTo(getMatch("ton", 5, 8, "tone ", " goto", overlapRules(1)))
+      matches(1) shouldMatchTo(getMatch("one", 1, 4, "t", " ton goto", overlapRules(2)))
+      matches(2) shouldMatchTo(getMatch("got", 9, 12, "tone ton ", "o", overlapRules(3)))
     }
   }
 
@@ -153,7 +154,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
       matches.size shouldBe 1
       val expectedReplacement = Some("teapot")
       val expectedMatch = getMatch("tea pot", 13, 20, "I'm a little ", "", rule, expectedReplacement)
-      matches(0) should matchTo(expectedMatch)
+      matches(0) shouldMatchTo(expectedMatch)
       matches(0).markAsCorrect shouldBe false
     }
   }
@@ -176,7 +177,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
       matches.size shouldBe 1
       val expectedReplacement = Some("teapot")
       val expectedMatch = getMatch("teapot", 13, 19, "I'm a little ", "", rule, expectedReplacement, markAsCorrect = true)
-      matches(0) should matchTo(expectedMatch)
+      matches(0) shouldMatchTo(expectedMatch)
     }
   }
 
@@ -219,7 +220,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
       matches.size shouldBe 1
       val expectedReplacement = Some("nine-month-long")
       val expectedMatch = getMatch("nine month long", 2, 17, "A ", " sabbatical", rule, expectedReplacement)
-      matches(0) should matchTo(expectedMatch)
+      matches(0) shouldMatchTo(expectedMatch)
     }
   }
 

--- a/apps/checker/test/scala/model/RuleMatchTest.scala
+++ b/apps/checker/test/scala/model/RuleMatchTest.scala
@@ -4,7 +4,6 @@ package scala.model
 import model._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
-import com.softwaremill.diffx.scalatest.DiffMatcher._
 
 import utils.Text
 

--- a/apps/checker/test/scala/model/TextBlockTest.scala
+++ b/apps/checker/test/scala/model/TextBlockTest.scala
@@ -3,7 +3,6 @@ package scala.model
 import model._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
-import com.softwaremill.diffx.scalatest.DiffMatcher._
 
 import utils.Text
 

--- a/apps/checker/test/scala/model/TextRangeTest.scala
+++ b/apps/checker/test/scala/model/TextRangeTest.scala
@@ -3,9 +3,6 @@ package scala.model
 import model._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
-import com.softwaremill.diffx.scalatest.DiffMatcher._
-
-import utils.Text
 
 class TextRangeTest extends AsyncFlatSpec with Matchers {
   behavior of "mapAddedRange"

--- a/apps/checker/test/scala/services/MatcherPoolTest.scala
+++ b/apps/checker/test/scala/services/MatcherPoolTest.scala
@@ -4,16 +4,15 @@ import akka.actor.ActorSystem
 import akka.stream.scaladsl.Sink
 import model._
 import org.scalatest.time.SpanSugar._
-import com.softwaremill.diffx.scalatest.DiffMatcher._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
+import com.softwaremill.diffx.scalatest.DiffShouldMatcher._
+import com.softwaremill.diffx.generic.auto._
 import utils.Matcher
-
 import scala.concurrent.{ExecutionContext, Promise}
 import scala.util.Failure
 import scala.util.Success
 import play.api.libs.concurrent.DefaultFutures
-
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Future
 
@@ -178,7 +177,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     val futureResult = pool.check(getCheck(text = "Example text"))
     futureResult.map { result =>
       result.matches shouldBe responses
-      result.categoryIds should matchTo(Set(getCategory(0).id))
+      result.categoryIds shouldMatchTo(Set(getCategory(0).id))
     }
   }
 
@@ -274,7 +273,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     futureResult.map { result =>
       result.matches.contains(firstMatch.head) shouldBe true
       result.matches.contains(secondMatch.head) shouldBe true
-      result.categoryIds should matchTo(expectedCategories)
+      result.categoryIds shouldMatchTo(expectedCategories)
     }
   }
 
@@ -300,8 +299,8 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     matchers(0).completeWith(firstMatch)
     matchers(1).completeWith(secondMatch)
     futureResult.map { result =>
-      result.matches.size should matchTo(1)
-      result.matches should matchTo(secondMatch)
+      result.matches.size shouldMatchTo(1)
+      result.matches shouldMatchTo(secondMatch)
     }
   }
 

--- a/apps/checker/test/scala/services/SentenceHelperTest.scala
+++ b/apps/checker/test/scala/services/SentenceHelperTest.scala
@@ -2,7 +2,8 @@ package services
 
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
-import com.softwaremill.diffx.scalatest.DiffMatcher._
+import com.softwaremill.diffx.scalatest.DiffShouldMatcher._
+import com.softwaremill.diffx.generic.auto._
 import model.TextRange
 
 class SentenceHelperTest extends AsyncFlatSpec with Matchers {
@@ -26,7 +27,7 @@ class SentenceHelperTest extends AsyncFlatSpec with Matchers {
 
   it should "return sentence starts, including the word and range covered" in {
     val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
-    firstWordsInSentences should matchTo(List(
+    firstWordsInSentences shouldMatchTo(List(
       WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
       WordInSentence("Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(102, 107)),
     ))
@@ -35,7 +36,7 @@ class SentenceHelperTest extends AsyncFlatSpec with Matchers {
   charactersThatProduceNonWordTokens.foreach { nonWordChar =>
     it should s"ignore non-word tokens when finding sentence starts: $nonWordChar" in {
       val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. ${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
-      firstWordsInSentences should matchTo(List(
+      firstWordsInSentences shouldMatchTo(List(
         WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
         WordInSentence(s"${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(103, 108)),
       ))
@@ -43,7 +44,7 @@ class SentenceHelperTest extends AsyncFlatSpec with Matchers {
 
     it should s"not ignore words that contain non-word tokens when finding sentence starts: $nonWordChar" in {
       val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Other${nonWordChar} cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
-      firstWordsInSentences should matchTo(List(
+      firstWordsInSentences shouldMatchTo(List(
         WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
         WordInSentence(s"Other${nonWordChar} cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Other", TextRange(102, 107)),
       ))
@@ -53,7 +54,7 @@ class SentenceHelperTest extends AsyncFlatSpec with Matchers {
   charactersThatProduceNonWordTokens.foreach { nonWordChar =>
     it should s"ignore multiple non-word tokens when finding sentence starts: $nonWordChar" in {
       val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"${nonWordChar}${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
-      firstWordsInSentences should matchTo(List(
+      firstWordsInSentences shouldMatchTo(List(
         WordInSentence(s"${nonWordChar}${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(2, 7)),
       ))
     }
@@ -62,6 +63,6 @@ class SentenceHelperTest extends AsyncFlatSpec with Matchers {
   it should s"not give any results if the sentence consists entirely of non word tokens" in {
     val nonWordChar = charactersThatProduceNonWordTokens.head
     val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"$nonWordChar$nonWordChar$nonWordChar$nonWordChar$nonWordChar$nonWordChar")
-    firstWordsInSentences should matchTo(List.empty[WordInSentence])
+    firstWordsInSentences shouldMatchTo(List.empty[WordInSentence])
   }
 }

--- a/apps/checker/test/scala/utils/TimerTest.scala
+++ b/apps/checker/test/scala/utils/TimerTest.scala
@@ -1,10 +1,8 @@
 package utils
 
-import model._
 import org.scalatest.flatspec.AnyFlatSpec
-import org.mockito.{ ArgumentMatchersSugar, IdiomaticMockito }
+import org.mockito.{ IdiomaticMockito }
 import org.scalatest.matchers.should.Matchers
-import com.softwaremill.diffx.scalatest.DiffMatcher._
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/lib/AppSetup.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/lib/AppSetup.scala
@@ -1,0 +1,46 @@
+package com.gu.typerighter.lib
+
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
+import software.amazon.awssdk.auth.credentials.{AwsCredentialsProvider => AwsCredentialsProviderV2, DefaultCredentialsProvider => DefaultCredentialsProviderV2, ProfileCredentialsProvider => ProfileCredentialsProviderV2}
+import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
+import com.gu.{AppIdentity, AwsIdentity, DevIdentity}
+import com.typesafe.config.Config
+import play.api.Mode.Dev
+import play.api.ApplicationLoader
+
+case class AppSetup(
+                     region: String,
+                     creds: AWSCredentialsProvider,
+                     credsV2: AwsCredentialsProviderV2,
+                     identity: AppIdentity,
+                     config: Config
+                   )
+
+object AppSetup {
+  def apply(context: ApplicationLoader.Context): AppSetup = {
+    val region = context.initialConfiguration.getOptional[String]("aws.region").getOrElse("eu-west-1")
+
+    val (creds, credsV2, identity) = context.environment.mode match {
+      case Dev => (
+        new ProfileCredentialsProvider("composer"),
+        ProfileCredentialsProviderV2.create("composer"),
+        DevIdentity("typerighter-checker")
+      )
+      case _ =>
+        val credsV2 = DefaultCredentialsProviderV2.create();
+        (
+          DefaultAWSCredentialsProviderChain.getInstance,
+          credsV2,
+          AppIdentity.whoAmI(defaultAppName = "typerighter-checker", credsV2).get
+        )
+    }
+
+    val config = ConfigurationLoader.load(identity, credsV2) {
+      case identity: AwsIdentity => SSMConfigurationLocation.default(identity)
+      case development: DevIdentity => SSMConfigurationLocation(s"/DEV/flexible/${development.app}", region)
+    }
+
+    AppSetup(region, creds, credsV2, identity, config)
+  }
+}

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/lib/CommonConfig.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/lib/CommonConfig.scala
@@ -5,15 +5,16 @@ import com.gu.AppIdentity
 import com.gu.AwsIdentity
 import com.gu.DevIdentity
 import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.regions.Region
 
 /**
   * A class to store configuration that's common across projects.
   *
   * Fails fast with an exception if properties aren't found.
   */
-abstract class CommonConfig(playConfig: Configuration, identity: AppIdentity, credentials: AWSCredentialsProvider) {
+abstract class CommonConfig(playConfig: Configuration, region: String, identity: AppIdentity, credentials: AWSCredentialsProvider) {
   val awsCredentials = credentials
-  val awsRegion = playConfig.getOptional[String]("aws.region").getOrElse("eu-west-1")
+  val awsRegion = region
   val loggingStreamName = playConfig.getOptional[String]("typerighter.loggingStreamName")
 
   val permissionsBucket = playConfig.getOptional[String]("permissions.bucket").getOrElse("permissions-cache")

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/lib/ElkLogging.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/lib/ElkLogging.scala
@@ -5,7 +5,7 @@ import ch.qos.logback.classic.{AsyncAppender, Logger, LoggerContext}
 import ch.qos.logback.core.Appender
 import ch.qos.logback.core.joran.spi.JoranException
 import ch.qos.logback.core.util.StatusPrinter
-import com.amazonaws.auth.AWSCredentialsProvider
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import com.gu.AwsIdentity
 import com.gu.logback.appender.kinesis.KinesisAppender
 import net.logstash.logback.layout.LogstashLayout
@@ -14,13 +14,11 @@ import play.api.inject.ApplicationLifecycle
 import play.api.libs.json.{Json => PlayJson}
 import typerighter.BuildInfo
 
-import com.gu.typerighter.lib
-
 import scala.util.control.NonFatal
 
 class ElkLogging(identity: AwsIdentity,
                  maybeLoggingStreamName: Option[String],
-                 awsCredentialsProvider: AWSCredentialsProvider,
+                 awsCredentialsProvider: AwsCredentialsProvider,
                  applicationLifecycle: ApplicationLifecycle) extends Loggable {
   def getContextTags(identity: AwsIdentity): Map[String, String] = {
     val effective = Map(

--- a/apps/rule-manager/app/AppComponents.scala
+++ b/apps/rule-manager/app/AppComponents.scala
@@ -27,7 +27,12 @@ class AppComponents(context: Context, region: String, identity: AppIdentity, cre
   val config = new RuleManagerConfig(configuration, region, identity, creds)
   val db = new RuleManagerDB(config.dbUrl, config.dbUsername, config.dbPassword)
 
-  private val s3Client = AmazonS3ClientBuilder.standard().withCredentials(creds).build()
+  private val s3Client = AmazonS3ClientBuilder
+    .standard()
+    .withCredentials(creds)
+    .withRegion(region)
+    .build()
+
   val stageDomain = identity match {
     case identity: AwsIdentity if identity.stage == "PROD" => "gutools.co.uk"
     case identity: AwsIdentity => s"${identity.stage.toLowerCase}.dev-gutools.co.uk"

--- a/apps/rule-manager/app/AppComponents.scala
+++ b/apps/rule-manager/app/AppComponents.scala
@@ -19,15 +19,15 @@ import controllers.HomeController
 import db.RuleManagerDB
 import utils.RuleManagerConfig
 
-class AppComponents(context: Context, identity: AppIdentity, creds: AWSCredentialsProvider)
+class AppComponents(context: Context, region: String, identity: AppIdentity, creds: AWSCredentialsProvider)
   extends BuiltInComponentsFromContext(context)
   with HttpFiltersComponents
   with AssetsComponents
   with AhcWSComponents {
-  val config = new RuleManagerConfig(configuration, identity, creds)
+  val config = new RuleManagerConfig(configuration, region, identity, creds)
   val db = new RuleManagerDB(config.dbUrl, config.dbUsername, config.dbPassword)
 
-  private val s3Client = AmazonS3ClientBuilder.standard().withCredentials(creds).withRegion(AppIdentity.region).build()
+  private val s3Client = AmazonS3ClientBuilder.standard().withCredentials(creds).build()
   val stageDomain = identity match {
     case identity: AwsIdentity if identity.stage == "PROD" => "gutools.co.uk"
     case identity: AwsIdentity => s"${identity.stage.toLowerCase}.dev-gutools.co.uk"

--- a/apps/rule-manager/app/AppLoader.scala
+++ b/apps/rule-manager/app/AppLoader.scala
@@ -1,10 +1,6 @@
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProvider, AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
-import software.amazon.awssdk.auth.credentials.{
-  AwsCredentialsProvider => AwsCredentialsProviderV2,
-  ProfileCredentialsProvider => ProfileCredentialsProviderV2,
-  DefaultCredentialsProvider => DefaultCredentialsProviderV2
-}
+import software.amazon.awssdk.auth.credentials.{AwsCredentialsProvider => AwsCredentialsProviderV2, DefaultCredentialsProvider => DefaultCredentialsProviderV2, ProfileCredentialsProvider => ProfileCredentialsProviderV2}
 import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
 import com.gu.{AppIdentity, AwsIdentity, DevIdentity}
 import play.api.ApplicationLoader.Context
@@ -17,6 +13,7 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.gu.AwsIdentity
 import com.gu.conf.SSMConfigurationLocation
 import com.gu.conf.ConfigurationLoader
+import play.api.Mode.Dev
 
 
 class AppLoader extends ApplicationLoader {
@@ -25,25 +22,28 @@ class AppLoader extends ApplicationLoader {
       _.configure(context.environment, context.initialConfiguration, Map.empty)
     }
 
-    val identity = AppIdentity.whoAmI(defaultAppName = "typerighter-rule-manager")
+    val region = context.initialConfiguration.getOptional[String]("aws.region").getOrElse("eu-west-1")
 
-    val creds: AWSCredentialsProvider = identity match {
-      case _: DevIdentity => new ProfileCredentialsProvider("composer")
+    val creds: AWSCredentialsProvider = context.environment.mode match {
+      case Dev => new ProfileCredentialsProvider("composer")
       case _ => DefaultAWSCredentialsProviderChain.getInstance
     }
 
-    val credsV2: AwsCredentialsProviderV2 = identity match {
-      case _: DevIdentity => ProfileCredentialsProviderV2.create("composer")
+    val credsV2: AwsCredentialsProviderV2 = context.environment.mode match {
+      case Dev => ProfileCredentialsProviderV2.create("composer")
       case _ => DefaultCredentialsProviderV2.create()
     }
 
+    val identity = AppIdentity.whoAmI(defaultAppName = "typerighter-rule-manager", credsV2).get
+
     val loadedConfig = ConfigurationLoader.load(identity, credsV2) {
       case identity: AwsIdentity => SSMConfigurationLocation.default(identity)
-      case development: DevIdentity => SSMConfigurationLocation(s"/DEV/flexible/${development.app}")
+      case development: DevIdentity => SSMConfigurationLocation(s"/DEV/flexible/${development.app}", region)
     }
 
     new AppComponents(
       context.copy(initialConfiguration = Configuration(loadedConfig).withFallback(context.initialConfiguration)),
+      region,
       identity,
       creds
     ).application

--- a/apps/rule-manager/app/utils/RuleManagerConfig.scala
+++ b/apps/rule-manager/app/utils/RuleManagerConfig.scala
@@ -5,7 +5,7 @@ import com.gu.typerighter.lib.CommonConfig
 import com.gu.AppIdentity
 import com.amazonaws.auth.AWSCredentialsProvider
 
-class RuleManagerConfig(playConfig: Configuration, identity: AppIdentity, creds: AWSCredentialsProvider) extends CommonConfig(playConfig, identity, creds) {
+class RuleManagerConfig(playConfig: Configuration, region: String, identity: AppIdentity, creds: AWSCredentialsProvider) extends CommonConfig(playConfig, region, identity, creds) {
   val dbUrl = playConfig.get[String]("db.default.url")
   val dbUsername = playConfig.get[String]("db.default.username")
   val dbPassword = playConfig.get[String]("db.default.password")

--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,11 @@ val checker = (project in file(s"$appsFolder/checker"))
       "io.circe" %% "circe-parser"
     ).map(_ % circeVersion),
     libraryDependencies += "io.gatling.highcharts" % "gatling-charts-highcharts" % "3.7.2" % "test,it",
-    libraryDependencies += "io.gatling"            % "gatling-test-framework"    % "3.7.2" % "test,it"
+    libraryDependencies += "io.gatling"            % "gatling-test-framework"    % "3.7.2" % "test,it",
+    dependencyOverrides ++= Seq(
+      // Necessary to ensure that LanguageTool gets the correct version of Guava.
+      "com.google.guava" % "guava" % "30.1-jre"
+    )
   )
 
 val ruleManager = (project in file(s"$appsFolder/rule-manager"))

--- a/build.sbt
+++ b/build.sbt
@@ -41,9 +41,9 @@ val commonSettings = Seq(
     )
   },
   libraryDependencies ++= Seq(
-    "net.logstash.logback" % "logstash-logback-encoder" % "6.0",
+    "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
     "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
-    "com.softwaremill.diffx" %% "diffx-scalatest" % "0.8.2" % Test,
+    "com.softwaremill.diffx" %% "diffx-scalatest-should" % "0.8.2" % Test,
     "org.mockito" %% "mockito-scala-scalatest" % "1.17.12",
     "com.gu" % "kinesis-logback-appender" % "2.1.0",
     "com.gu" %% "simple-configuration-ssm" % "1.5.7",

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / scalacOptions := Seq(
   "-encoding", "UTF-8", "-target:jvm-1.8", "-deprecation",
   "-feature", "-unchecked", "-language:implicitConversions", "-language:postfixOps")
 
-val languageToolVersion = "5.1"
+val languageToolVersion = "5.9"
 val awsSdkVersion = "1.11.999"
 val capiModelsVersion = "17.4.0"
 val capiClientVersion = "19.1.0"

--- a/build.sbt
+++ b/build.sbt
@@ -123,12 +123,12 @@ val ruleManager = (project in file(s"$appsFolder/rule-manager"))
       guice,
       jdbc,
       evolutions,
-      "org.postgresql" % "postgresql" % "42.2.5",
+      "org.postgresql" % "postgresql" % "42.5.1",
       "org.scalikejdbc" %% "scalikejdbc" % scalikejdbcVersion,
       "org.scalikejdbc" %% "scalikejdbc-config" % scalikejdbcVersion,
       "org.scalikejdbc" %% "scalikejdbc-play-initializer" % scalikejdbcPlayVersion,
       "org.scalikejdbc" %% "scalikejdbc-test" % "3.5.0" % Test,
-      "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6",
+      "com.gu" %% "pan-domain-auth-play_2-8" % "1.2.0",
       "com.gu" %% "editorial-permissions-client" % "2.14"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -10,9 +10,9 @@ ThisBuild / scalacOptions := Seq(
 
 val languageToolVersion = "5.1"
 val awsSdkVersion = "1.11.999"
-val capiModelsVersion = "17.1.1"
-val capiClientVersion = "17.23"
-val circeVersion = "0.12.3"
+val capiModelsVersion = "17.4.0"
+val capiClientVersion = "19.1.0"
+val circeVersion = "0.14.1"
 val scalikejdbcVersion = scalikejdbc.ScalikejdbcBuildInfo.version
 val scalikejdbcPlayVersion = "2.8.0-scalikejdbc-3.5"
 val appsFolder = "apps"
@@ -43,11 +43,11 @@ val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "net.logstash.logback" % "logstash-logback-encoder" % "6.0",
     "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
-    "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.29" % Test,
-    "org.mockito" %% "mockito-scala-scalatest" % "1.16.2",
-    "com.gu" % "kinesis-logback-appender" % "1.4.4",
-    "com.gu" %% "simple-configuration-ssm" % "1.5.6",
-    "com.gu" %% "pan-domain-auth-verification" % "1.0.4",
+    "com.softwaremill.diffx" %% "diffx-scalatest" % "0.8.2" % Test,
+    "org.mockito" %% "mockito-scala-scalatest" % "1.17.12",
+    "com.gu" % "kinesis-logback-appender" % "2.1.0",
+    "com.gu" %% "simple-configuration-ssm" % "1.5.7",
+    "com.gu" %% "pan-domain-auth-verification" % "1.2.0",
   ),
   dependencyOverrides ++= Seq(
     "com.fasterxml.jackson.core" % "jackson-databind" % "2.11.4",

--- a/build.sbt
+++ b/build.sbt
@@ -92,9 +92,11 @@ val checker = (project in file(s"$appsFolder/checker"))
       "com.gu" %% "content-api-models-json" % capiModelsVersion,
       "com.gu" %% "content-api-client-aws" % "0.7",
       "com.gu" %% "content-api-client-default" % capiClientVersion,
-      "edu.stanford.nlp" % "stanford-corenlp" % "3.4",
-      "edu.stanford.nlp" % "stanford-corenlp" % "3.4" classifier "models",
-      "edu.stanford.nlp" % "stanford-parser" % "3.4",
+      // We exclude `xom`, which has a critical vulnerability,
+      // as we do not use the parts of corenlp that depend on it.
+      "edu.stanford.nlp" % "stanford-corenlp" % "3.9.2" exclude("com.io7m.xom", "xom"),
+      "edu.stanford.nlp" % "stanford-corenlp" % "3.9.2" classifier "models" exclude("com.io7m.xom", "xom"),
+      "edu.stanford.nlp" % "stanford-parser" % "3.9.2",
     ),
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core",

--- a/script/js/package.json
+++ b/script/js/package.json
@@ -4,6 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "libxmljs": "^0.19.7"
+    "libxmljs": "^0.19.10"
   }
 }

--- a/script/js/yarn.lock
+++ b/script/js/yarn.lock
@@ -2,492 +2,396 @@
 # yarn lockfile v1
 
 
-"abbrev@1":
-  "integrity" "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-  "resolved" "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz"
-  "version" "1.1.1"
-
-"ansi-regex@^2.0.0":
-  "integrity" "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-  "resolved" "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz"
-  "version" "2.1.1"
-
-"ansi-regex@^3.0.0":
-  "integrity" "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-  "resolved" "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz"
-  "version" "3.0.0"
-
-"aproba@^1.0.3":
-  "integrity" "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-  "resolved" "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz"
-  "version" "1.2.0"
-
-"are-we-there-yet@~1.1.2":
-  "integrity" "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w=="
-  "resolved" "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz"
-  "version" "1.1.5"
+"@mapbox/node-pre-gyp@^1.0.9":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz#8e6735ccebbb1581e5a7e652244cadc8a844d03c"
+  integrity sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==
   dependencies:
-    "delegates" "^1.0.0"
-    "readable-stream" "^2.0.6"
+    detect-libc "^2.0.0"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.1.0"
+    node-fetch "^2.6.7"
+    nopt "^5.0.0"
+    npmlog "^5.0.1"
+    rimraf "^3.0.2"
+    semver "^7.3.5"
+    tar "^6.1.11"
 
-"balanced-match@^1.0.0":
-  "integrity" "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-  "resolved" "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz"
-  "version" "1.0.2"
+abbrev@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz"
+  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-"bindings@~1.3.0":
-  "integrity" "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
-  "resolved" "https://registry.yarnpkg.com/bindings/-/bindings-1.3.1.tgz"
-  "version" "1.3.1"
-
-"brace-expansion@^1.1.7":
-  "integrity" "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="
-  "resolved" "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz"
-  "version" "1.1.11"
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
-    "balanced-match" "^1.0.0"
-    "concat-map" "0.0.1"
+    debug "4"
 
-"chownr@^1.1.1":
-  "integrity" "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-  "resolved" "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz"
-  "version" "1.1.4"
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-"code-point-at@^1.0.0":
-  "integrity" "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-  "resolved" "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz"
-  "version" "1.1.0"
+"aproba@^1.0.3 || ^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
+  integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
 
-"concat-map@0.0.1":
-  "integrity" "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-  "resolved" "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz"
-  "version" "0.0.1"
-
-"console-control-strings@^1.0.0", "console-control-strings@~1.1.0":
-  "integrity" "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-  "resolved" "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz"
-  "version" "1.1.0"
-
-"core-util-is@~1.0.0":
-  "integrity" "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-  "resolved" "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz"
-  "version" "1.0.2"
-
-"debug@^3.2.6":
-  "integrity" "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="
-  "resolved" "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz"
-  "version" "3.2.7"
+are-we-there-yet@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz#372e0e7bd279d8e94c653aaa1f67200884bf3e1c"
+  integrity sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==
   dependencies:
-    "ms" "^2.1.1"
+    delegates "^1.0.0"
+    readable-stream "^3.6.0"
 
-"deep-extend@^0.6.0":
-  "integrity" "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-  "resolved" "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz"
-  "version" "0.6.0"
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-"delegates@^1.0.0":
-  "integrity" "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-  "resolved" "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz"
-  "version" "1.0.0"
+bindings@~1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.1.tgz"
+  integrity sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==
 
-"detect-libc@^1.0.2":
-  "integrity" "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
-  "resolved" "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz"
-  "version" "1.0.3"
-
-"fs-minipass@^1.2.5":
-  "integrity" "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA=="
-  "resolved" "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz"
-  "version" "1.2.7"
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
-    "minipass" "^2.6.0"
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
 
-"fs.realpath@^1.0.0":
-  "integrity" "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-  "resolved" "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz"
-  "version" "1.0.0"
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-"gauge@~2.7.3":
-  "integrity" "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c="
-  "resolved" "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz"
-  "version" "2.7.4"
+color-support@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
+  integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+console-control-strings@^1.0.0, console-control-strings@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz"
+  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
+
+debug@4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
-    "aproba" "^1.0.3"
-    "console-control-strings" "^1.0.0"
-    "has-unicode" "^2.0.0"
-    "object-assign" "^4.1.0"
-    "signal-exit" "^3.0.0"
-    "string-width" "^1.0.1"
-    "strip-ansi" "^3.0.1"
-    "wide-align" "^1.1.0"
+    ms "2.1.2"
 
-"glob@^7.1.3":
-  "integrity" "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA=="
-  "resolved" "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz"
-  "version" "7.1.6"
+delegates@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz"
+  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+detect-libc@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.1.tgz#e1897aa88fa6ad197862937fbc0441ef352ee0cd"
+  integrity sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
   dependencies:
-    "fs.realpath" "^1.0.0"
-    "inflight" "^1.0.4"
-    "inherits" "2"
-    "minimatch" "^3.0.4"
-    "once" "^1.3.0"
-    "path-is-absolute" "^1.0.0"
+    minipass "^3.0.0"
 
-"has-unicode@^2.0.0":
-  "integrity" "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-  "resolved" "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz"
-  "version" "2.0.1"
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-"iconv-lite@^0.4.4":
-  "integrity" "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="
-  "resolved" "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz"
-  "version" "0.4.24"
+gauge@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-3.0.2.tgz#03bf4441c044383908bcfa0656ad91803259b395"
+  integrity sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==
   dependencies:
-    "safer-buffer" ">= 2.1.2 < 3"
+    aproba "^1.0.3 || ^2.0.0"
+    color-support "^1.1.2"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.1"
+    object-assign "^4.1.1"
+    signal-exit "^3.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    wide-align "^1.1.2"
 
-"ignore-walk@^3.0.1":
-  "integrity" "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw=="
-  "resolved" "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz"
-  "version" "3.0.3"
+glob@^7.1.3:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
-    "minimatch" "^3.0.4"
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
-"inflight@^1.0.4":
-  "integrity" "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
-  "resolved" "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz"
-  "version" "1.0.6"
+has-unicode@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+  integrity sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==
+
+https-proxy-agent@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
-    "once" "^1.3.0"
-    "wrappy" "1"
+    agent-base "6"
+    debug "4"
 
-"inherits@~2.0.3", "inherits@2":
-  "integrity" "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-  "resolved" "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz"
-  "version" "2.0.4"
-
-"ini@~1.3.0":
-  "integrity" "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-  "resolved" "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz"
-  "version" "1.3.8"
-
-"is-fullwidth-code-point@^1.0.0":
-  "integrity" "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
-  "resolved" "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
-  "version" "1.0.0"
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
   dependencies:
-    "number-is-nan" "^1.0.0"
+    once "^1.3.0"
+    wrappy "1"
 
-"is-fullwidth-code-point@^2.0.0":
-  "integrity" "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-  "resolved" "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
-  "version" "2.0.0"
+inherits@2, inherits@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-"isarray@~1.0.0":
-  "integrity" "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-  "resolved" "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz"
-  "version" "1.0.0"
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
-"libxmljs@^0.19.7":
-  "integrity" "sha512-lFJyG9T1mVwTzNTw6ZkvIt0O+NsIR+FTE+RcC2QDFGU8YMnQrnyEOGrj6HWSe1AdwQK7s37BOp4NL+pcAqfK2g=="
-  "resolved" "https://registry.yarnpkg.com/libxmljs/-/libxmljs-0.19.7.tgz"
-  "version" "0.19.7"
+libxmljs@^0.19.10:
+  version "0.19.10"
+  resolved "https://registry.yarnpkg.com/libxmljs/-/libxmljs-0.19.10.tgz#aa169b937a3c93940c07f802a73844df30f5c4d4"
+  integrity sha512-RY5/MD8Po8sGVocbODbYcdrbP6pJyA171LjFyd7Bp9wwxhmA8C5bm/VmXfpdED07fdW0FeC3lopxhG7UbwGx+g==
   dependencies:
-    "bindings" "~1.3.0"
-    "nan" "~2.14.0"
-    "node-pre-gyp" "~0.11.0"
+    "@mapbox/node-pre-gyp" "^1.0.9"
+    bindings "~1.3.0"
+    nan "~2.14.0"
 
-"minimatch@^3.0.4":
-  "integrity" "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
-  "resolved" "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz"
-  "version" "3.0.4"
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
-    "brace-expansion" "^1.1.7"
+    yallist "^4.0.0"
 
-"minimist@^1.2.0", "minimist@^1.2.5":
-  "integrity" "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-  "resolved" "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz"
-  "version" "1.2.5"
-
-"minipass@^2.6.0", "minipass@^2.8.6", "minipass@^2.9.0":
-  "integrity" "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg=="
-  "resolved" "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz"
-  "version" "2.9.0"
+make-dir@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
+  integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
-    "safe-buffer" "^5.1.2"
-    "yallist" "^3.0.0"
+    semver "^6.0.0"
 
-"minizlib@^1.2.1":
-  "integrity" "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q=="
-  "resolved" "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz"
-  "version" "1.3.3"
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
-    "minipass" "^2.9.0"
+    brace-expansion "^1.1.7"
 
-"mkdirp@^0.5.0", "mkdirp@^0.5.1":
-  "integrity" "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ=="
-  "resolved" "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz"
-  "version" "0.5.5"
+minipass@^3.0.0:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.3.6.tgz#7bba384db3a1520d18c9c0e5251c3444e95dd94a"
+  integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
   dependencies:
-    "minimist" "^1.2.5"
+    yallist "^4.0.0"
 
-"ms@^2.1.1":
-  "integrity" "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-  "resolved" "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz"
-  "version" "2.1.3"
-
-"nan@~2.14.0":
-  "integrity" "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
-  "resolved" "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz"
-  "version" "2.14.2"
-
-"needle@^2.2.1":
-  "integrity" "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg=="
-  "resolved" "https://registry.yarnpkg.com/needle/-/needle-2.6.0.tgz"
-  "version" "2.6.0"
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
   dependencies:
-    "debug" "^3.2.6"
-    "iconv-lite" "^0.4.4"
-    "sax" "^1.2.4"
+    minipass "^3.0.0"
+    yallist "^4.0.0"
 
-"node-pre-gyp@~0.11.0":
-  "integrity" "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q=="
-  "resolved" "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz"
-  "version" "0.11.0"
+mkdirp@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+nan@~2.14.0:
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz"
+  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
-    "detect-libc" "^1.0.2"
-    "mkdirp" "^0.5.1"
-    "needle" "^2.2.1"
-    "nopt" "^4.0.1"
-    "npm-packlist" "^1.1.6"
-    "npmlog" "^4.0.2"
-    "rc" "^1.2.7"
-    "rimraf" "^2.6.1"
-    "semver" "^5.3.0"
-    "tar" "^4"
+    whatwg-url "^5.0.0"
 
-"nopt@^4.0.1":
-  "integrity" "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg=="
-  "resolved" "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz"
-  "version" "4.0.3"
+nopt@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
+  integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
   dependencies:
-    "abbrev" "1"
-    "osenv" "^0.1.4"
+    abbrev "1"
 
-"npm-bundled@^1.0.1":
-  "integrity" "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ=="
-  "resolved" "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.2.tgz"
-  "version" "1.1.2"
+npmlog@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-5.0.1.tgz#f06678e80e29419ad67ab964e0fa69959c1eb8b0"
+  integrity sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==
   dependencies:
-    "npm-normalize-package-bin" "^1.0.1"
+    are-we-there-yet "^2.0.0"
+    console-control-strings "^1.1.0"
+    gauge "^3.0.0"
+    set-blocking "^2.0.0"
 
-"npm-normalize-package-bin@^1.0.1":
-  "integrity" "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
-  "resolved" "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz"
-  "version" "1.0.1"
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
-"npm-packlist@^1.1.6":
-  "integrity" "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A=="
-  "resolved" "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz"
-  "version" "1.4.8"
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
-    "ignore-walk" "^3.0.1"
-    "npm-bundled" "^1.0.1"
-    "npm-normalize-package-bin" "^1.0.1"
+    wrappy "1"
 
-"npmlog@^4.0.2":
-  "integrity" "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg=="
-  "resolved" "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz"
-  "version" "4.1.2"
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+
+readable-stream@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
   dependencies:
-    "are-we-there-yet" "~1.1.2"
-    "console-control-strings" "~1.1.0"
-    "gauge" "~2.7.3"
-    "set-blocking" "~2.0.0"
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
-"number-is-nan@^1.0.0":
-  "integrity" "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-  "resolved" "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz"
-  "version" "1.0.1"
-
-"object-assign@^4.1.0":
-  "integrity" "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-  "resolved" "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz"
-  "version" "4.1.1"
-
-"once@^1.3.0":
-  "integrity" "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
-  "resolved" "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz"
-  "version" "1.4.0"
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
-    "wrappy" "1"
+    glob "^7.1.3"
 
-"os-homedir@^1.0.0":
-  "integrity" "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-  "resolved" "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz"
-  "version" "1.0.2"
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-"os-tmpdir@^1.0.0":
-  "integrity" "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-  "resolved" "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-  "version" "1.0.2"
+semver@^6.0.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-"osenv@^0.1.4":
-  "integrity" "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g=="
-  "resolved" "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz"
-  "version" "0.1.5"
+semver@^7.3.5:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
-    "os-homedir" "^1.0.0"
-    "os-tmpdir" "^1.0.0"
+    lru-cache "^6.0.0"
 
-"path-is-absolute@^1.0.0":
-  "integrity" "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-  "resolved" "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-  "version" "1.0.1"
+set-blocking@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+  integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
-"process-nextick-args@~2.0.0":
-  "integrity" "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-  "resolved" "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
-  "version" "2.0.1"
+signal-exit@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz"
+  integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
-"rc@^1.2.7":
-  "integrity" "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="
-  "resolved" "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz"
-  "version" "1.2.8"
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
-    "deep-extend" "^0.6.0"
-    "ini" "~1.3.0"
-    "minimist" "^1.2.0"
-    "strip-json-comments" "~2.0.1"
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
-"readable-stream@^2.0.6":
-  "integrity" "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw=="
-  "resolved" "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz"
-  "version" "2.3.7"
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
-    "core-util-is" "~1.0.0"
-    "inherits" "~2.0.3"
-    "isarray" "~1.0.0"
-    "process-nextick-args" "~2.0.0"
-    "safe-buffer" "~5.1.1"
-    "string_decoder" "~1.1.1"
-    "util-deprecate" "~1.0.1"
+    safe-buffer "~5.2.0"
 
-"rimraf@^2.6.1":
-  "integrity" "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w=="
-  "resolved" "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz"
-  "version" "2.7.1"
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
-    "glob" "^7.1.3"
+    ansi-regex "^5.0.1"
 
-"safe-buffer@^5.1.2":
-  "integrity" "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-  "resolved" "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz"
-  "version" "5.2.1"
-
-"safe-buffer@~5.1.0", "safe-buffer@~5.1.1":
-  "integrity" "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-  "resolved" "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz"
-  "version" "5.1.2"
-
-"safer-buffer@>= 2.1.2 < 3":
-  "integrity" "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-  "resolved" "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz"
-  "version" "2.1.2"
-
-"sax@^1.2.4":
-  "integrity" "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-  "resolved" "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz"
-  "version" "1.2.4"
-
-"semver@^5.3.0":
-  "integrity" "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-  "resolved" "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz"
-  "version" "5.7.1"
-
-"set-blocking@~2.0.0":
-  "integrity" "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-  "resolved" "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz"
-  "version" "2.0.0"
-
-"signal-exit@^3.0.0":
-  "integrity" "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
-  "resolved" "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz"
-  "version" "3.0.3"
-
-"string_decoder@~1.1.1":
-  "integrity" "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="
-  "resolved" "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz"
-  "version" "1.1.1"
+tar@^6.1.11:
+  version "6.1.12"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.12.tgz#3b742fb05669b55671fb769ab67a7791ea1a62e6"
+  integrity sha512-jU4TdemS31uABHd+Lt5WEYJuzn+TJTCBLljvIAHZOz6M9Os5pJ4dD+vRFLxPa/n3T0iEFzpi+0x1UfuDZYbRMw==
   dependencies:
-    "safe-buffer" "~5.1.0"
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
-"string-width@^1.0.1":
-  "integrity" "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
-  "resolved" "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz"
-  "version" "1.0.2"
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
   dependencies:
-    "code-point-at" "^1.0.0"
-    "is-fullwidth-code-point" "^1.0.0"
-    "strip-ansi" "^3.0.0"
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
-"string-width@^1.0.2 || 2":
-  "integrity" "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw=="
-  "resolved" "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz"
-  "version" "2.1.1"
+wide-align@^1.1.2:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
+  integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
   dependencies:
-    "is-fullwidth-code-point" "^2.0.0"
-    "strip-ansi" "^4.0.0"
+    string-width "^1.0.2 || 2 || 3 || 4"
 
-"strip-ansi@^3.0.0", "strip-ansi@^3.0.1":
-  "integrity" "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
-  "resolved" "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz"
-  "version" "3.0.1"
-  dependencies:
-    "ansi-regex" "^2.0.0"
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-"strip-ansi@^4.0.0":
-  "integrity" "sha1-qEeQIusaw2iocTibY1JixQXuNo8="
-  "resolved" "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz"
-  "version" "4.0.0"
-  dependencies:
-    "ansi-regex" "^3.0.0"
-
-"strip-json-comments@~2.0.1":
-  "integrity" "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-  "resolved" "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
-  "version" "2.0.1"
-
-"tar@^4":
-  "integrity" "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA=="
-  "resolved" "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz"
-  "version" "4.4.13"
-  dependencies:
-    "chownr" "^1.1.1"
-    "fs-minipass" "^1.2.5"
-    "minipass" "^2.8.6"
-    "minizlib" "^1.2.1"
-    "mkdirp" "^0.5.0"
-    "safe-buffer" "^5.1.2"
-    "yallist" "^3.0.3"
-
-"util-deprecate@~1.0.1":
-  "integrity" "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-  "resolved" "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz"
-  "version" "1.0.2"
-
-"wide-align@^1.1.0":
-  "integrity" "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA=="
-  "resolved" "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz"
-  "version" "1.1.3"
-  dependencies:
-    "string-width" "^1.0.2 || 2"
-
-"wrappy@1":
-  "integrity" "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-  "resolved" "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz"
-  "version" "1.0.2"
-
-"yallist@^3.0.0", "yallist@^3.0.3":
-  "integrity" "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-  "resolved" "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz"
-  "version" "3.1.1"
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==


### PR DESCRIPTION
## What does this change?

Bumps a few dependencies across the board to improve our [Snyk scores](https://app.snyk.io/org/guardian/project/8ecf100e-b5f7-43e5-bbaa-c28fcd28eb7a) for this project.

## Dev notes

I've consolidated our application setup across the checker and manager apps. Seems fairly straightforward, but perhaps there's a more idiomatic way to do this?

The bump to LanguageTool has been tested with `./script/js/compare-rule-xml.js`, to ensure we aren't changing checker behaviour. All of the currently active rules (`COMMA_PARENTHESIS_WHITESPACE, DOUBLE_PUNCTUATION, UPPERCASE_SENTENCE_START, WHITESPACE_RULE, SENTENCE_WHITESPACE, PUNCTUATION_PARAGRAPH_END`) are not defined in XML, and are fairly self explanatory – I've tested them all in sandbox locally and they appear to work as expected.

## How to test

It should compile and run as usual. Snyk should be happy(er).

Tested in CODE. One rule needed to be amended (it had an invalid "skip" property that wasn't being respected anyhow) – I've amended the PROD spreadsheet, so there should be no problem deploying to PROD.