### PR TITLE
Add start scripts for checker and rule manager

### DIFF
--- a/apps/rule-manager/rule-manager-client/package-lock.json
+++ b/apps/rule-manager/rule-manager-client/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "rule-manager-client",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/docs/01-running-locally.md
+++ b/docs/01-running-locally.md
@@ -13,7 +13,7 @@ To launch the Checker, run `./script/run-checker` (`--debug` to run a debugger o
 
 To start the Rule Manager, run `./script/run-manager` (`--debug` to attach a debugger on port 5006) and visit `https://manager.typerighter.local.dev-gutools.co.uk/` to check it is running.
 
-To run everything, run `./script/start` (`--debug` will attach debuggers on both services in the respective ports above) and visit `localhost:9000` to confirm the service came up correctly.
+To run everything, run `./script/start` (`--debug` will attach debuggers on both services in the respective ports above) and visit [the locally running app](https://manager.typerighter.local.dev-gutools.co.uk/) to confirm the service came up correctly.
 
 If you're testing changes to the rule audit client, see [the additional steps in its README](https://github.com/guardian/typerighter/tree/main/rule-audit-client).
 

--- a/docs/01-running-locally.md
+++ b/docs/01-running-locally.md
@@ -7,9 +7,13 @@ Run `dev-nginx setup-app ./nginx/nginx-mapping.yml` from the root of the project
 
 # Basic developer run
 
-Get credentials for Composer profile then run `./script/start` and visit `localhost:9000` to confirm the service came up correctly.
+Get credentials for Composer profile.
 
-To attach an interactive debugger, run `./script/start --debug` to expose port 5005 for debugging.
+To launch the Checker, run `./script/run-checker` (`--debug` to run a debugger on port 5005).
+
+To start the Rule Manager, run `./script/run-manager` (`--debug` to attach a debugger on port 5006) and visit `https://manager.typerighter.local.dev-gutools.co.uk/` to check it is running.
+
+To run everything, run `./script/start` (`--debug` will attach debuggers on both services in the respective ports above) and visit `localhost:9000` to confirm the service came up correctly.
 
 If you're testing changes to the rule audit client, see [the additional steps in its README](https://github.com/guardian/typerighter/tree/main/rule-audit-client).
 

--- a/docs/01-running-locally.md
+++ b/docs/01-running-locally.md
@@ -9,7 +9,7 @@ Run `dev-nginx setup-app ./nginx/nginx-mapping.yml` from the root of the project
 
 Get credentials for Composer profile.
 
-To launch the Checker, run `./script/run-checker` (`--debug` to run a debugger on port 5005).
+To launch the Checker, run `./script/start-checker` (`--debug` to run a debugger on port 5005).
 
 To start the Rule Manager, run `./script/start-manager` (`--debug` to attach a debugger on port 5006) and visit `https://manager.typerighter.local.dev-gutools.co.uk/` to check it is running.
 

--- a/docs/01-running-locally.md
+++ b/docs/01-running-locally.md
@@ -11,7 +11,7 @@ Get credentials for Composer profile.
 
 To launch the Checker, run `./script/start-checker` (`--debug` to run a debugger on port 5005).
 
-To start the Rule Manager, run `./script/start-manager` (`--debug` to attach a debugger on port 5006) and visit `https://manager.typerighter.local.dev-gutools.co.uk/` to check it is running.
+To start the Rule Manager, run `./script/start-manager` (`--debug` to attach a debugger on port 5006) and visit [the locally running app](https://manager.typerighter.local.dev-gutools.co.uk) to check it is running.
 
 To run everything, run `./script/start` (`--debug` will attach debuggers on both services in the respective ports above) and visit [the locally running app](https://manager.typerighter.local.dev-gutools.co.uk/) to confirm the service came up correctly.
 

--- a/docs/01-running-locally.md
+++ b/docs/01-running-locally.md
@@ -11,7 +11,7 @@ Get credentials for Composer profile.
 
 To launch the Checker, run `./script/run-checker` (`--debug` to run a debugger on port 5005).
 
-To start the Rule Manager, run `./script/run-manager` (`--debug` to attach a debugger on port 5006) and visit `https://manager.typerighter.local.dev-gutools.co.uk/` to check it is running.
+To start the Rule Manager, run `./script/start-manager` (`--debug` to attach a debugger on port 5006) and visit `https://manager.typerighter.local.dev-gutools.co.uk/` to check it is running.
 
 To run everything, run `./script/start` (`--debug` will attach debuggers on both services in the respective ports above) and visit [the locally running app](https://manager.typerighter.local.dev-gutools.co.uk/) to confirm the service came up correctly.
 

--- a/script/lib/check-aws-credentials
+++ b/script/lib/check-aws-credentials
@@ -1,0 +1,12 @@
+#!/bin/bash
+red='\033[0;31m'
+plain='\x1B[0m'
+
+STATUS=$(aws sts get-caller-identity --profile composer 2>&1 || true)
+if [[ ${STATUS} =~ (ExpiredToken) ]]; then
+echo -e "${red}Credentials for the composer profile are expired. Please fetch new credentials and run this again.${plain}"
+exit 1
+elif [[ ${STATUS} =~ ("could not be found") ]]; then
+echo -e "${red}Credentials for the composer profile are missing. Please ensure you have the right credentials.${plain}"
+exit 1
+fi

--- a/script/lib/check-aws-credentials
+++ b/script/lib/check-aws-credentials
@@ -4,7 +4,7 @@ plain='\x1B[0m'
 
 STATUS=$(aws sts get-caller-identity --profile composer 2>&1 || true)
 if [[ ${STATUS} =~ (ExpiredToken) ]]; then
-echo -e "${red}Credentials for the composer profile are expired. Please fetch new credentials and run this again.${plain}"
+echo -e "❌Credentials for the composer profile are expired. Please fetch new credentials and run this again.❌"
 exit 1
 elif [[ ${STATUS} =~ ("could not be found") ]]; then
 echo -e "${red}Credentials for the composer profile are missing. Please ensure you have the right credentials.${plain}"

--- a/script/lib/check-aws-credentials
+++ b/script/lib/check-aws-credentials
@@ -7,6 +7,6 @@ if [[ ${STATUS} =~ (ExpiredToken) ]]; then
 echo -e "❌Credentials for the composer profile are expired. Please fetch new credentials and run this again.❌"
 exit 1
 elif [[ ${STATUS} =~ ("could not be found") ]]; then
-echo -e "${red}Credentials for the composer profile are missing. Please ensure you have the right credentials.${plain}"
+echo -e "❌Credentials for the composer profile are missing. Please ensure you have the right credentials.❌"
 exit 1
 fi

--- a/script/start
+++ b/script/start
@@ -1,6 +1,5 @@
 #!/bin/bash -e
-
-APP_FOLDER="apps"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 IS_DEBUG=false
 for arg in "$@"
@@ -11,35 +10,21 @@ do
   fi
 done
 
-checkCredentials() {
-  STATUS=$(aws sts get-caller-identity --profile composer 2>&1 || true)
-  if [[ ${STATUS} =~ (ExpiredToken) ]]; then
-    echo -e "${red}Credentials for the composer profile are expired. Please fetch new credentials and run this again.${plain}"
-    exit 1
-  elif [[ ${STATUS} =~ ("could not be found") ]]; then
-    echo -e "${red}Credentials for the composer profile are missing. Please ensure you have the right credentials.${plain}"
-    exit 1
-  fi
-}
-
-setupDependencies() {
-  docker-compose up -d
-  (cd $APP_FOLDER/rule-manager/rule-manager-client && npm i && npm run build)
-}
-
-teardownDependencies() {
-  docker-compose down
-}
-
-runApp() {
-  if [[ "$IS_DEBUG" = true ]] ; then
-    sbt -jvm-debug 5005 run
+runChecker() {
+  if [[ "$IS_DEBUG" = true ]]; then
+    bash "${DIR}"/start-checker --debug
   else
-    sbt "checker / run"
+    bash "${DIR}"/start-checker
   fi
 }
 
-trap teardownDependencies EXIT
+runRuleManager() {
+  if [[ "$IS_DEBUG" = true ]]; then
+    bash "${DIR}"/start-manager --debug
+  else
+    bash "${DIR}"/start-manager
+  fi
+}
 
-setupDependencies
-runApp
+runChecker &
+runRuleManager

--- a/script/start-checker
+++ b/script/start-checker
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+IS_DEBUG=false
+
+for arg in "$@"
+do
+  if [[ "$arg" == "--debug" ]]; then
+    IS_DEBUG=true
+    shift
+  fi
+done
+
+checkCredentials() {
+  bash "${DIR}"/lib/check-aws-credentials
+}
+
+runChecker() {
+  if [[ "$IS_DEBUG" = true ]]; then
+    sbt -jvm-debug 5005 "checker / run"
+  else
+    sbt "checker / run"
+  fi
+}
+
+checkCredentials
+runChecker

--- a/script/start-manager
+++ b/script/start-manager
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+APP_FOLDER="apps"
+
+IS_DEBUG=false
+
+for arg in "$@"
+do
+  if [[ "$arg" == "--debug" ]]; then
+    IS_DEBUG=true
+    shift
+  fi
+done
+
+checkCredentials() {
+  bash "${DIR}"/lib/check-aws-credentials
+}
+
+setupDependencies() {
+  docker-compose up -d
+  (cd $APP_FOLDER/rule-manager/rule-manager-client && npm i && npm run build)
+}
+
+teardownDependencies() {
+  docker-compose down
+}
+
+runRuleManager() {
+  if [[ "$IS_DEBUG" = true ]] ; then
+    sbt -jvm-debug 5006 "ruleManager / run"
+  else
+    sbt "ruleManager / run"
+  fi
+}
+
+trap teardownDependencies EXIT
+
+checkCredentials
+setupDependencies
+runRuleManager


### PR DESCRIPTION
## What does this change?
Add start scripts for:
- The rule manager (`script/start-manager`)
- The checker (`script/start-checker`)
- both together (`script/start`).
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Running each script from the project root should start the respective service, with  (`--debug` flag) or without the debugger.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
Devs can start the whole app or each service more easily.
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
Tested locally.
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->