### PR TITLE
Create rules table in the postgres database

### DIFF
--- a/apps/rule-manager/app/AppComponents.scala
+++ b/apps/rule-manager/app/AppComponents.scala
@@ -16,15 +16,22 @@ import com.gu.DevIdentity
 import com.gu.typerighter.rules.{BucketRuleManager, SheetsRuleManager}
 import router.Routes
 import db.RuleManagerDB
+import play.api.db.evolutions.EvolutionsComponents
+import play.api.db.{DBComponents, HikariCPComponents}
 import utils.RuleManagerConfig
 
 class AppComponents(context: Context, region: String, identity: AppIdentity, creds: AWSCredentialsProvider)
   extends BuiltInComponentsFromContext(context)
   with HttpFiltersComponents
   with AssetsComponents
+  with DBComponents
+  with HikariCPComponents
+  with EvolutionsComponents
   with AhcWSComponents {
   val config = new RuleManagerConfig(configuration, region, identity, creds)
   val db = new RuleManagerDB(config.dbUrl, config.dbUsername, config.dbPassword)
+
+  applicationEvolutions
 
   private val s3Client = AmazonS3ClientBuilder
     .standard()

--- a/apps/rule-manager/app/db/Rules.scala
+++ b/apps/rule-manager/app/db/Rules.scala
@@ -1,0 +1,179 @@
+package db
+
+import scalikejdbc._
+
+case class Rules(
+  id: Int,
+  ruleType: Option[String] = None,
+  pattern: String,
+  replacement: Option[String] = None,
+  category: Option[String] = None,
+  tags: Option[String] = None,
+  description: Option[String] = None,
+  ignore: Boolean,
+  notes: Option[String] = None,
+  googleSheetId: Option[String] = None,
+  forceRedRule: Option[Boolean] = None,
+  advisoryRule: Option[Boolean] = None) {
+
+  def save()(implicit session: DBSession = Rules.autoSession): Rules = Rules.save(this)(session)
+
+  def destroy()(implicit session: DBSession = Rules.autoSession): Int = Rules.destroy(this)(session)
+
+}
+
+
+object Rules extends SQLSyntaxSupport[Rules] {
+
+  override val tableName = "rules"
+
+  override val columns = Seq("id", "rule_type", "pattern", "replacement", "category", "tags", "description", "ignore", "notes", "google_sheet_id", "force_red_rule", "advisory_rule")
+
+  def apply(r: SyntaxProvider[Rules])(rs: WrappedResultSet): Rules = autoConstruct(rs, r)
+  def apply(r: ResultName[Rules])(rs: WrappedResultSet): Rules = autoConstruct(rs, r)
+
+  val r = Rules.syntax("r")
+
+  override val autoSession = AutoSession
+
+  def find(id: Int)(implicit session: DBSession = autoSession): Option[Rules] = {
+    withSQL {
+      select.from(Rules as r).where.eq(r.id, id)
+    }.map(Rules(r.resultName)).single.apply()
+  }
+
+  def findAll()(implicit session: DBSession = autoSession): List[Rules] = {
+    withSQL(select.from(Rules as r)).map(Rules(r.resultName)).list.apply()
+  }
+
+  def countAll()(implicit session: DBSession = autoSession): Long = {
+    withSQL(select(sqls.count).from(Rules as r)).map(rs => rs.long(1)).single.apply().get
+  }
+
+  def findBy(where: SQLSyntax)(implicit session: DBSession = autoSession): Option[Rules] = {
+    withSQL {
+      select.from(Rules as r).where.append(where)
+    }.map(Rules(r.resultName)).single.apply()
+  }
+
+  def findAllBy(where: SQLSyntax)(implicit session: DBSession = autoSession): List[Rules] = {
+    withSQL {
+      select.from(Rules as r).where.append(where)
+    }.map(Rules(r.resultName)).list.apply()
+  }
+
+  def countBy(where: SQLSyntax)(implicit session: DBSession = autoSession): Long = {
+    withSQL {
+      select(sqls.count).from(Rules as r).where.append(where)
+    }.map(_.long(1)).single.apply().get
+  }
+
+  def create(
+    ruleType: Option[String] = None,
+    pattern: String,
+    replacement: Option[String] = None,
+    category: Option[String] = None,
+    tags: Option[String] = None,
+    description: Option[String] = None,
+    ignore: Boolean,
+    notes: Option[String] = None,
+    googleSheetId: Option[String] = None,
+    forceRedRule: Option[Boolean] = None,
+    advisoryRule: Option[Boolean] = None)(implicit session: DBSession = autoSession): Rules = {
+    val generatedKey = withSQL {
+      insert.into(Rules).namedValues(
+        column.ruleType -> ruleType,
+        column.pattern -> pattern,
+        column.replacement -> replacement,
+        column.category -> category,
+        column.tags -> tags,
+        column.description -> description,
+        column.ignore -> ignore,
+        column.notes -> notes,
+        column.googleSheetId -> googleSheetId,
+        column.forceRedRule -> forceRedRule,
+        column.advisoryRule -> advisoryRule
+      )
+    }.updateAndReturnGeneratedKey.apply()
+
+    Rules(
+      id = generatedKey.toInt,
+      ruleType = ruleType,
+      pattern = pattern,
+      replacement = replacement,
+      category = category,
+      tags = tags,
+      description = description,
+      ignore = ignore,
+      notes = notes,
+      googleSheetId = googleSheetId,
+      forceRedRule = forceRedRule,
+      advisoryRule = advisoryRule)
+  }
+
+  def batchInsert(entities: collection.Seq[Rules])(implicit session: DBSession = autoSession): List[Int] = {
+    val params: collection.Seq[Seq[(Symbol, Any)]] = entities.map(entity =>
+      Seq(
+        Symbol("ruleType") -> entity.ruleType,
+        Symbol("pattern") -> entity.pattern,
+        Symbol("replacement") -> entity.replacement,
+        Symbol("category") -> entity.category,
+        Symbol("tags") -> entity.tags,
+        Symbol("description") -> entity.description,
+        Symbol("ignore") -> entity.ignore,
+        Symbol("notes") -> entity.notes,
+        Symbol("googleSheetId") -> entity.googleSheetId,
+        Symbol("forceRedRule") -> entity.forceRedRule,
+        Symbol("advisoryRule") -> entity.advisoryRule))
+    SQL("""insert into rules(
+      rule_type,
+      pattern,
+      replacement,
+      category,
+      tags,
+      description,
+      ignore,
+      notes,
+      google_sheet_id,
+      force_red_rule,
+      advisory_rule
+    ) values (
+      {ruleType},
+      {pattern},
+      {replacement},
+      {category},
+      {tags},
+      {description},
+      {ignore},
+      {notes},
+      {googleSheetId},
+      {forceRedRule},
+      {advisoryRule}
+    )""").batchByName(params.toSeq: _*).apply[List]()
+  }
+
+  def save(entity: Rules)(implicit session: DBSession = autoSession): Rules = {
+    withSQL {
+      update(Rules).set(
+        column.id -> entity.id,
+        column.ruleType -> entity.ruleType,
+        column.pattern -> entity.pattern,
+        column.replacement -> entity.replacement,
+        column.category -> entity.category,
+        column.tags -> entity.tags,
+        column.description -> entity.description,
+        column.ignore -> entity.ignore,
+        column.notes -> entity.notes,
+        column.googleSheetId -> entity.googleSheetId,
+        column.forceRedRule -> entity.forceRedRule,
+        column.advisoryRule -> entity.advisoryRule
+      ).where.eq(column.id, entity.id)
+    }.update.apply()
+    entity
+  }
+
+  def destroy(entity: Rules)(implicit session: DBSession = autoSession): Int = {
+    withSQL { delete.from(Rules).where.eq(column.id, entity.id) }.update.apply()
+  }
+
+}

--- a/apps/rule-manager/app/db/Rules.scala
+++ b/apps/rule-manager/app/db/Rules.scala
@@ -4,7 +4,7 @@ import scalikejdbc._
 
 case class Rules(
   id: Int,
-  ruleType: Option[String] = None,
+  ruleType: String,
   pattern: String,
   replacement: Option[String] = None,
   category: Option[String] = None,
@@ -69,7 +69,7 @@ object Rules extends SQLSyntaxSupport[Rules] {
   }
 
   def create(
-    ruleType: Option[String] = None,
+    ruleType: String,
     pattern: String,
     replacement: Option[String] = None,
     category: Option[String] = None,

--- a/apps/rule-manager/conf/application.conf
+++ b/apps/rule-manager/conf/application.conf
@@ -18,5 +18,8 @@ scalikejdbc.global.loggingSQLAndTime.warningEnabled=true
 scalikejdbc.global.loggingSQLAndTime.warningThresholdMillis=5
 scalikejdbc.global.loggingSQLAndTime.warningLogLevel=warn
 
+play.evolutions.autoApply=true
+play.evolutions.autoApplyDowns=true
+
 play.modules.enabled += "scalikejdbc.PlayModule"
 play.modules.disabled += "play.api.db.DBModule"

--- a/apps/rule-manager/conf/evolutions/default/1.sql
+++ b/apps/rule-manager/conf/evolutions/default/1.sql
@@ -1,0 +1,25 @@
+-- Rules Schema
+
+-- !Ups
+
+CREATE TYPE ruleType AS ENUM ('regex', 'languageTool');
+
+CREATE TABLE Rules (
+      id SERIAL PRIMARY KEY,
+      ruleType ruleType,
+      pattern text NOT NULL,
+      replacement text,
+      category text,
+      tags text,
+      description text,
+      ignore boolean NOT NULL,
+      notes text,
+      googleSheetId text,
+      forceRedRule boolean,
+      advisoryRule boolean
+);
+
+-- !Downs
+
+DROP TABLE Rules;
+DROP TYPE IF EXISTS ruleType;

--- a/apps/rule-manager/conf/evolutions/default/1.sql
+++ b/apps/rule-manager/conf/evolutions/default/1.sql
@@ -6,7 +6,7 @@ CREATE TYPE ruleType AS ENUM ('regex', 'languageTool');
 
 CREATE TABLE Rules (
       id SERIAL PRIMARY KEY,
-      ruleType ruleType,
+      rule_type ruleType,
       pattern text NOT NULL,
       replacement text,
       category text,
@@ -14,9 +14,9 @@ CREATE TABLE Rules (
       description text,
       ignore boolean NOT NULL,
       notes text,
-      googleSheetId text,
-      forceRedRule boolean,
-      advisoryRule boolean
+      google_sheet_id text,
+      force_red_rule boolean,
+      advisory_rule boolean
 );
 
 -- !Downs

--- a/apps/rule-manager/conf/evolutions/default/1.sql
+++ b/apps/rule-manager/conf/evolutions/default/1.sql
@@ -2,11 +2,9 @@
 
 -- !Ups
 
-CREATE TYPE ruleType AS ENUM ('regex', 'languageTool');
-
 CREATE TABLE Rules (
       id SERIAL PRIMARY KEY,
-      rule_type ruleType,
+      rule_type text NOT NULL,
       pattern text NOT NULL,
       replacement text,
       category text,

--- a/apps/rule-manager/test/db/RuleManagerDBSpec.scala
+++ b/apps/rule-manager/test/db/RuleManagerDBSpec.scala
@@ -1,0 +1,18 @@
+package db
+
+import scalikejdbc.scalatest.AutoRollback
+import org.scalatest.fixture.FlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RuleManagerDBSpec
+  extends FlatSpec
+  with Matchers
+  with AutoRollback
+  with RuleManagerDBTest {
+
+  behavior of "Database connection"
+
+  it should "provide a way of testing the DB connection" in { implicit session =>
+    scalikejdbcDb.connectionHealthy() shouldBe true
+  }
+}

--- a/apps/rule-manager/test/db/RuleManagerDBTest.scala
+++ b/apps/rule-manager/test/db/RuleManagerDBTest.scala
@@ -1,18 +1,24 @@
 package db
 
 import org.scalatest.{BeforeAndAfter, Suite}
+import play.api.{ApplicationLoader, ConfigLoader, Configuration, Environment}
 import play.api.db.Databases
 import play.api.db.evolutions.{Evolutions, InconsistentDatabase}
+import utils.RuleManagerConfig
 
 trait RuleManagerDBTest extends BeforeAndAfter { self: Suite =>
-  val url = "jdbc:postgresql://localhost:5432/tr-rule-manager-local"
-  val user = "tr-rule-manager-local"
-  val password = "tr-rule-manager-local"
-  val scalikejdbcDb = new RuleManagerDB(url, user, password)
-  var playDb = Databases("org.postgresql.Driver", url, config = Map(
+  private implicit val loader = ConfigLoader.stringLoader
+  private val config = Configuration.load(Environment.simple(), Map.empty)
+
+  private val url = config.get("db.default.url")
+  private val user = config.get("db.default.username")
+  private val password = config.get("db.default.password")
+  private val playDb = Databases("org.postgresql.Driver", url, config = Map(
     "username" -> user,
     "password" -> password
   ))
+
+  val scalikejdbcDb = new RuleManagerDB(url, user, password)
 
   before {
     try {

--- a/apps/rule-manager/test/db/RuleManagerDBTest.scala
+++ b/apps/rule-manager/test/db/RuleManagerDBTest.scala
@@ -1,10 +1,9 @@
 package db
 
 import org.scalatest.{BeforeAndAfter, Suite}
-import play.api.{ApplicationLoader, ConfigLoader, Configuration, Environment}
+import play.api.{ConfigLoader, Configuration, Environment}
 import play.api.db.Databases
 import play.api.db.evolutions.{Evolutions, InconsistentDatabase}
-import utils.RuleManagerConfig
 
 trait RuleManagerDBTest extends BeforeAndAfter { self: Suite =>
   private implicit val loader = ConfigLoader.stringLoader

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -10,9 +10,9 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback {
   val ruleDb = new RuleManagerDB(url= "jdbc:postgresql://localhost:5432/tr-rule-manager-local", user="tr-rule-manager-local",  password= "tr-rule-manager-local")
   val r = Rules.syntax("r")
 
-
   override def fixture(implicit session: DBSession) {
-    sql"insert into rules values (1, 'regex', ${"pattern"}, ${"replacement"}, ${"category"}, ${"someTags"}, ${"description"}, false, ${"notes"}, ${"googleSheetId"}, false, false)".update.apply()
+    sql"ALTER SEQUENCE rules_id_seq RESTART WITH 1".update.apply()
+    sql"insert into rules (rule_type, pattern, replacement, category, tags, description, ignore, notes, google_sheet_id, force_red_rule, advisory_rule) values (${"regex"}, ${"pattern"}, ${"replacement"}, ${"category"}, ${"someTags"}, ${"description"}, false, ${"notes"}, ${"googleSheetId"}, false, false)".update.apply()
   }
 
   behavior of "Rules"
@@ -22,7 +22,7 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback {
     maybeFound.isDefined should be(true)
   }
   it should "find by where clauses" in { implicit session =>
-    val maybeFound = Rules.findBy(sqls.eq(r.id, 123))
+    val maybeFound = Rules.findBy(sqls.eq(r.id, 1))
     maybeFound.isDefined should be(true)
   }
   it should "find all records" in { implicit session =>
@@ -34,15 +34,16 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback {
     count should be >(0L)
   }
   it should "find all by where clauses" in { implicit session =>
-    val results = Rules.findAllBy(sqls.eq(r.id, 123))
+    val results = Rules.findAllBy(sqls.eq(r.id, 1))
     results.size should be >(0)
   }
   it should "count by where clauses" in { implicit session =>
-    val count = Rules.countBy(sqls.eq(r.id, 123))
+    val count = Rules.countBy(sqls.eq(r.id, 1))
     count should be >(0L)
   }
   it should "create new record" in { implicit session =>
-    val created = Rules.create(pattern = "MyString", ignore = false)
+    val created = Rules.create(ruleType=Some("regex"), pattern = "MyString", ignore = false)
+    println(created)
     created should not be(null)
   }
   it should "save a record" in { implicit session =>

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -49,9 +49,9 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback {
   it should "save a record" in { implicit session =>
     val entity = Rules.findAll().head
     // TODO modify something
-    val modified = entity
+    val modified = entity.copy(pattern="NotMyString")
     val updated = Rules.save(modified)
-    updated should not equal(entity)
+    updated should equal(entity)
   }
   it should "destroy a record" in { implicit session =>
     val entity = Rules.findAll().head

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -5,9 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import scalikejdbc.scalatest.AutoRollback
 import scalikejdbc._
 
-
-class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback {
-  val ruleDb = new RuleManagerDB(url= "jdbc:postgresql://localhost:5432/tr-rule-manager-local", user="tr-rule-manager-local",  password= "tr-rule-manager-local")
+class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with RuleManagerDBTest {
   val r = Rules.syntax("r")
 
   override def fixture(implicit session: DBSession) {
@@ -43,7 +41,6 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback {
   }
   it should "create new record" in { implicit session =>
     val created = Rules.create(ruleType=Some("regex"), pattern = "MyString", ignore = false)
-    println(created)
     created should not be(null)
   }
   it should "save a record" in { implicit session =>

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -4,6 +4,7 @@ import org.scalatest.flatspec.FixtureAnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import scalikejdbc.scalatest.AutoRollback
 import scalikejdbc._
+import scala.util.Success
 
 class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with RuleManagerDBTest {
   val r = Rules.syntax("r")
@@ -45,10 +46,9 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
   }
   it should "save a record" in { implicit session =>
     val entity = Rules.findAll().head
-    // TODO modify something
     val modified = entity.copy(pattern="NotMyString")
     val updated = Rules.save(modified)
-    updated should equal(modified)
+    updated should equal(Success(modified))
   }
   it should "destroy a record" in { implicit session =>
     val entity = Rules.findAll().head

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -10,10 +10,15 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback {
   val ruleDb = new RuleManagerDB(url= "jdbc:postgresql://localhost:5432/tr-rule-manager-local", user="tr-rule-manager-local",  password= "tr-rule-manager-local")
   val r = Rules.syntax("r")
 
+
+  override def fixture(implicit session: DBSession) {
+    sql"insert into rules values (1, 'regex', ${"pattern"}, ${"replacement"}, ${"category"}, ${"someTags"}, ${"description"}, false, ${"notes"}, ${"googleSheetId"}, false, false)".update.apply()
+  }
+
   behavior of "Rules"
 
   it should "find by primary keys" in { implicit session =>
-    val maybeFound = Rules.find(123)
+    val maybeFound = Rules.find(1)
     maybeFound.isDefined should be(true)
   }
   it should "find by where clauses" in { implicit session =>

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -1,0 +1,63 @@
+package db
+
+import org.scalatest.flatspec.FixtureAnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scalikejdbc.scalatest.AutoRollback
+import scalikejdbc._
+
+
+class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback {
+  val ruleDb = new RuleManagerDB(url= "jdbc:postgresql://localhost:5432/tr-rule-manager-local", user="tr-rule-manager-local",  password= "tr-rule-manager-local")
+  val r = Rules.syntax("r")
+
+  behavior of "Rules"
+
+  it should "find by primary keys" in { implicit session =>
+    val maybeFound = Rules.find(123)
+    maybeFound.isDefined should be(true)
+  }
+  it should "find by where clauses" in { implicit session =>
+    val maybeFound = Rules.findBy(sqls.eq(r.id, 123))
+    maybeFound.isDefined should be(true)
+  }
+  it should "find all records" in { implicit session =>
+    val allResults = Rules.findAll()
+    allResults.size should be >(0)
+  }
+  it should "count all records" in { implicit session =>
+    val count = Rules.countAll()
+    count should be >(0L)
+  }
+  it should "find all by where clauses" in { implicit session =>
+    val results = Rules.findAllBy(sqls.eq(r.id, 123))
+    results.size should be >(0)
+  }
+  it should "count by where clauses" in { implicit session =>
+    val count = Rules.countBy(sqls.eq(r.id, 123))
+    count should be >(0L)
+  }
+  it should "create new record" in { implicit session =>
+    val created = Rules.create(pattern = "MyString", ignore = false)
+    created should not be(null)
+  }
+  it should "save a record" in { implicit session =>
+    val entity = Rules.findAll().head
+    // TODO modify something
+    val modified = entity
+    val updated = Rules.save(modified)
+    updated should not equal(entity)
+  }
+  it should "destroy a record" in { implicit session =>
+    val entity = Rules.findAll().head
+    val deleted = Rules.destroy(entity)
+    deleted should be(1)
+    val shouldBeNone = Rules.find(123)
+    shouldBeNone.isDefined should be(false)
+  }
+  it should "perform batch insert" in { implicit session =>
+    val entities = Rules.findAll()
+    entities.foreach(e => Rules.destroy(e))
+    val batchInserted = Rules.batchInsert(entities)
+    batchInserted.size should be >(0)
+  }
+}

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -51,7 +51,7 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback {
     // TODO modify something
     val modified = entity.copy(pattern="NotMyString")
     val updated = Rules.save(modified)
-    updated should equal(entity)
+    updated should equal(modified)
   }
   it should "destroy a record" in { implicit session =>
     val entity = Rules.findAll().head

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -40,7 +40,7 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     count should be >(0L)
   }
   it should "create new record" in { implicit session =>
-    val created = Rules.create(ruleType=Some("regex"), pattern = "MyString", ignore = false)
+    val created = Rules.create(ruleType = "regex", pattern = "MyString", ignore = false)
     created should not be(null)
   }
   it should "save a record" in { implicit session =>

--- a/build.sbt
+++ b/build.sbt
@@ -118,9 +118,10 @@ val ruleManager = (project in file(s"$appsFolder/rule-manager"))
       "org.scalikejdbc" %% "scalikejdbc" % scalikejdbcVersion,
       "org.scalikejdbc" %% "scalikejdbc-config" % scalikejdbcVersion,
       "org.scalikejdbc" %% "scalikejdbc-play-initializer" % scalikejdbcPlayVersion,
-      "org.scalikejdbc" %% "scalikejdbc-test" % "3.5.0" % Test,
+      "org.scalikejdbc" %% "scalikejdbc-test" % scalikejdbcVersion % Test,
+      "org.scalikejdbc" %% "scalikejdbc-syntax-support-macro" % scalikejdbcVersion,
       "com.gu" %% "pan-domain-auth-play_2-8" % "1.2.1",
-      "com.gu" %% "editorial-permissions-client" % "2.14"
+      "com.gu" %% "editorial-permissions-client" % "2.14",
     )
   )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,9 @@ services:
             - POSTGRES_DB=tr-rule-manager-local
         volumes:
             - postgres-data:/var/lib/postgresql/data
+        command: [ "postgres", "-c", "log_statement=all" ]
         healthcheck:
-          test: ["CMD-SHELL", "pg_isready -U postgres"]
+          test: ["CMD-SHELL", "pg_isready -U tr-rule-manager-local"]
           interval: 10s
           timeout: 5s
           retries: 5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0") // "2.4.0" is just sbt plugin version
 addSbtPlugin("org.scalikejdbc" %% "scalikejdbc-mapper-generator" % "3.5.0")
 
-libraryDependencies += "org.vafer" % "jdeb" % "1.7" artifacts Artifact("jdeb", "jar", "jar")
+libraryDependencies ++= Seq("org.vafer" % "jdeb" % "1.7" artifacts Artifact("jdeb", "jar", "jar"), "org.postgresql" % "postgresql" % "42.5.1")

--- a/project/scalikejdbc.properties
+++ b/project/scalikejdbc.properties
@@ -1,0 +1,28 @@
+# ---
+# jdbc settings
+
+jdbc.driver=org.postgresql.Driver
+jdbc.url=jdbc:postgresql://localhost:5432/tr-rule-manager-local
+jdbc.username=tr-rule-manager-local
+jdbc.password=tr-rule-manager-local
+jdbc.schema=
+
+# ---
+# source code generator settings
+
+generator.packageName=db
+# generator.lineBreak: LF/CRLF
+generator.lineBreak=LF
+# generator.template: interpolation/queryDsl
+generator.template=queryDsl
+#generator.testTemplate: specs2unit/specs2acceptance/ScalaTestFlatSpec
+generator.testTemplate=ScalaTestFlatSpec
+generator.encoding=UTF-8
+# When you're using Scala 2.11 or higher, you can use case classes for 22+ columns tables
+#generator.caseClassOnly=true
+# Set AutoSession for implicit DBSession parameter's default value
+generator.defaultAutoSession=true
+# Use autoConstruct macro (default: false)
+generator.autoConstruct=true
+# joda-time (org.joda.time.DateTime) or JSR-310 (java.time.ZonedDateTime java.time.OffsetDateTime java.time.LocalDateTime)
+generator.dateTimeClass=java.time.ZonedDateTime

--- a/project/scalikejdbc.properties
+++ b/project/scalikejdbc.properties
@@ -1,3 +1,5 @@
+# The settings in this file is used when generating ScalikeJDBC models from database tables.
+
 # ---
 # jdbc settings
 

--- a/project/scalikejdbc.properties
+++ b/project/scalikejdbc.properties
@@ -11,18 +11,10 @@ jdbc.schema=
 # source code generator settings
 
 generator.packageName=db
-# generator.lineBreak: LF/CRLF
 generator.lineBreak=LF
-# generator.template: interpolation/queryDsl
 generator.template=queryDsl
-#generator.testTemplate: specs2unit/specs2acceptance/ScalaTestFlatSpec
 generator.testTemplate=ScalaTestFlatSpec
 generator.encoding=UTF-8
-# When you're using Scala 2.11 or higher, you can use case classes for 22+ columns tables
-#generator.caseClassOnly=true
-# Set AutoSession for implicit DBSession parameter's default value
 generator.defaultAutoSession=true
-# Use autoConstruct macro (default: false)
 generator.autoConstruct=true
-# joda-time (org.joda.time.DateTime) or JSR-310 (java.time.ZonedDateTime java.time.OffsetDateTime java.time.LocalDateTime)
 generator.dateTimeClass=java.time.ZonedDateTime


### PR DESCRIPTION
_co-authored-by: @ParisaTork, @jonathonherbert, @phillipbarron, @rhystmills_   
## What does this change?

An initial pass at a table to contain our rules. It's intended to model the rules pretty match exactly as they're represented in the Google sheet.

We anticipate this model changing as we work on the rule manager, but this gets us off the ground.

This PR does not include code to add user-facing interaction with the DB, but the tests should prove that we're able to connect and read/write models.

## How to test

- Run the tests locally, ensuring that the database is present with `docker compose up`. Do they pass?