### PR TITLE
Bump google sheets API packages

### DIFF
--- a/apps/common-lib/src/main/scala/com/gu/typerighter/rules/SheetsRuleManager.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/rules/SheetsRuleManager.scala
@@ -7,11 +7,11 @@ import java.io._
 import java.util.Collections
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
-import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.sheets.v4.{Sheets, SheetsScopes}
 
 import scala.jdk.CollectionConverters._
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
 
 object PatternRuleCols {
@@ -33,7 +33,7 @@ object PatternRuleCols {
   */
 class SheetsRuleManager(credentialsJson: String, spreadsheetId: String) extends Logging {
   private val APPLICATION_NAME = "Typerighter"
-  private val JSON_FACTORY = JacksonFactory.getDefaultInstance
+  private val JSON_FACTORY = GsonFactory.getDefaultInstance()
 
   private val HTTP_TRANSPORT = GoogleNetHttpTransport.newTrustedTransport
   private val credentials = getCredentials(credentialsJson)

--- a/build.sbt
+++ b/build.sbt
@@ -48,9 +48,8 @@ val commonSettings = Seq(
     "com.gu" % "kinesis-logback-appender" % "2.1.0",
     "com.gu" %% "simple-configuration-ssm" % "1.5.7",
     "com.gu" %% "pan-domain-auth-verification" % "1.2.0",
-    "com.google.api-client" % "google-api-client" % "1.23.0",
-    "com.google.oauth-client" % "google-oauth-client-jetty" % "1.23.0",
-    "com.google.apis" % "google-api-services-sheets" % "v4-rev516-1.23.0",
+    "com.google.api-client" % "google-api-client" % "2.0.1",
+    "com.google.apis" % "google-api-services-sheets" % "v4-rev20221216-2.0.0",
     "org.languagetool" % "languagetool-core" % languageToolVersion,
     "org.languagetool" % "language-en" % languageToolVersion,
   ),
@@ -92,7 +91,7 @@ val checker = (project in file(s"$appsFolder/checker"))
       "com.gu" %% "content-api-models-json" % capiModelsVersion,
       "com.gu" %% "content-api-client-aws" % "0.7",
       "com.gu" %% "content-api-client-default" % capiClientVersion,
-      "org.apache.opennlp" % "opennlp" % "2.1.0",
+      "org.apache.opennlp" % "opennlp" % "2.1.0"
     ),
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core",
@@ -101,10 +100,6 @@ val checker = (project in file(s"$appsFolder/checker"))
     ).map(_ % circeVersion),
     libraryDependencies += "io.gatling.highcharts" % "gatling-charts-highcharts" % "3.7.2" % "test,it",
     libraryDependencies += "io.gatling"            % "gatling-test-framework"    % "3.7.2" % "test,it",
-    dependencyOverrides ++= Seq(
-      // Necessary to ensure that LanguageTool gets the correct version of Guava.
-      "com.google.guava" % "guava" % "30.1-jre"
-    )
   )
 
 val ruleManager = (project in file(s"$appsFolder/rule-manager"))


### PR DESCRIPTION
## What does this change?

Bumps google sheets API packages, and removed now-unnecessary dependencyOverride, to fix issue with a missing class.

This was causing `Uncaught error from thread [application-matcher-pool-dispatcher-24]: Class com.google.common.base.Suppliers$SupplierOfInstance does not implement the requested interface java.util.function.Supplier` in #229. 

## How to test

Run the application locally, or in CODE, and check a document against the `checkStream` interface. Does the check complete successfully?

## Have we considered potential risks?

We currently have no way of defending against problems of this sort. Adding an E2E smoke test that tests a document against a large list of rules may help to prevent errors of this sort reaching production.