### PR TITLE
update rule db instance type to db.t4g.micro

### DIFF
--- a/cdk/lib/__snapshots__/index.test.ts.snap
+++ b/cdk/lib/__snapshots__/index.test.ts.snap
@@ -1546,7 +1546,7 @@ dpkg -i /tmp/package.deb",
         "AutoMinorVersionUpgrade": true,
         "BackupRetentionPeriod": 10,
         "CopyTagsToSnapshot": true,
-        "DBInstanceClass": "db.t3.micro",
+        "DBInstanceClass": "db.t4g.micro",
         "DBInstanceIdentifier": Object {
           "Fn::Join": Array [
             "",

--- a/cdk/lib/index.ts
+++ b/cdk/lib/index.ts
@@ -299,7 +299,7 @@ dpkg -i /tmp/package.deb`,
       engine: DatabaseInstanceEngine.postgres({
         version: PostgresEngineVersion.VER_13,
       }),
-      instanceType: "t3.micro",
+      instanceType: "db.t4g.micro",
       instanceIdentifier: `typerighter-rule-manager-store-${this.stage}`,
       subnetGroup: new SubnetGroup(this, "DBSubnetGroup", {
         vpc: ruleManagerApp.vpc,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Changes the Rule DB instance type to `db.t4g.micro`

## How to test

Deploy to code and check that the db is up and running. 

