### PR TITLE
Support CI via Github Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,3 @@ jobs:
         with:
           java-version: "8"
           distribution: "corretto"
-      - name: test and check formatting
-        run: |
-          sbt -v test scalafmtCheckAll
-      - name: build uberjar
-        run: |
-          sbt -v assembly

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,3 +22,8 @@ jobs:
         with:
           java-version: "8"
           distribution: "corretto"
+      - name: Build the stack
+        run: docker-compose up
+      - name: test and check formatting
+        run: |
+          sbt -v test scalafmtCheckAll

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,4 +33,5 @@ jobs:
           node-version: 16
       - working-directory: ./cdk
         run: |
-          npm run synth
+          yarn
+          yarn synth

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
           aws-region: eu-west-1
       - uses: actions/setup-java@v3
         with:
-          java-version: "11"
+          java-version: "8"
           distribution: "corretto"
       - name: test and check formatting
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,6 @@ jobs:
       - name: Build the stack
         run: | 
           docker-compose up -d
-      - name: test and check formatting
+      - name: Run tests
         run: |
-          sbt -v test scalafmtCheckAll
+          sbt -v test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,7 @@
 name: Typerighter CI
 on:
-  pull_request:
   workflow_dispatch:
   push:
-    branches:
-      - main
 
 jobs:
   CI:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,5 +48,9 @@ jobs:
           yarn synth
       - name: build sbt
         run: |
+          set -e
+          # Ensure we don't overwrite existing (Teamcity) builds.
+          LAST_TEAMCITY_BUILD=1280
+          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
           sbt clean compile test riffRaffUpload
   

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,3 +28,9 @@ jobs:
       - name: Run tests
         run: |
           sbt -v test
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - working-directory: ./cdk
+        run: |
+          npm run synth

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,30 @@
+name: CI
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+      - uses: actions/setup-java@v3
+        with:
+          java-version: "11"
+          distribution: "corretto"
+      - name: test and check formatting
+        run: |
+          sbt -v test scalafmtCheckAll
+      - name: build uberjar
+        run: |
+          sbt -v assembly

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Typerighter CI
 on:
   pull_request:
   workflow_dispatch:
@@ -23,7 +23,8 @@ jobs:
           java-version: "8"
           distribution: "corretto"
       - name: Build the stack
-        run: docker-compose up
+        run: | 
+          docker-compose up -d
       - name: test and check formatting
         run: |
           sbt -v test scalafmtCheckAll

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,22 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - working-directory: ./cdk
+      - name: build rule-manager-client
+        working-directory: ./apps/rule-manager/client
+        run: |
+          npm i
+          npm run build
+      - name: build rule-audit-client
+        working-directory: ./apps/rule-audit-client
+        run: |
+          npm i
+          npm run build
+      - name: cdk synth
+        working-directory: ./cdk
         run: |
           yarn
           yarn synth
+      - name: build sbt
+        run: |
+          sbt clean compile test riffRaffUpload
+  

--- a/.tmp/data/startup_info.json
+++ b/.tmp/data/startup_info.json
@@ -1,1 +1,0 @@
-[{"timestamp": "2023-03-20T10:48:50.922472", "localstack_version": "0.14.0", "localstack_ext_version": "0.14.0", "pro_activated": false}]

--- a/.tmp/data/startup_info.json
+++ b/.tmp/data/startup_info.json
@@ -1,0 +1,1 @@
+[{"timestamp": "2023-03-20T10:48:50.922472", "localstack_version": "0.14.0", "localstack_ext_version": "0.14.0", "pro_activated": false}]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR build and deploys to RiffRaff via Github Actions.

Following the merge of this PR, we will want to:
1. include `scalaFmt` checks. We should add it as part of the Github action.
2. disable Teamcity's builds to stop duplicates occurring.

## How to test

We're not sure how to test this change until this PR has been merged. However, this branch has been deployed via an action, you can see it in [RiffRaff](https://riffraff.gutools.co.uk/deployment/request) by looking at the builds for `Editorial Tools::Typerighter` (it's build 1297).