### PR TITLE
Add scalafmtCheckAll step to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
           docker-compose up -d
       - name: Run tests
         run: |
-          sbt -v test
+          sbt -v test scalafmtCheckAll
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/apps/checker/test/scala/matchers/LanguageToolMatcherTest.scala
+++ b/apps/checker/test/scala/matchers/LanguageToolMatcherTest.scala
@@ -132,7 +132,12 @@ class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
   "getInstance" should "return an error if a defaultRule we provide is not available" in {
     val ltFactory = new LanguageToolFactory(None)
     val coreRules = List("NOT_A_THING")
-    val errors = ltFactory.createInstance(Nil, coreRules).left.getOrElse(fail("Expected a list of errors from unavailable default rules, not a valid instance"))
+    val errors = ltFactory
+      .createInstance(Nil, coreRules)
+      .left
+      .getOrElse(
+        fail("Expected a list of errors from unavailable default rules, not a valid instance")
+      )
     val messages = errors.map(_.getMessage())
     messages.filter(_.contains("rule was not available")).size shouldBe 1
   }
@@ -148,7 +153,12 @@ class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
     val ltFactory = new LanguageToolFactory(None)
     val exampleRulegroups = List(exampleRulegroup)
     val instance = ltFactory.createInstance(exampleRulegroups).getOrElse(fail)
-    instance.getRules().map(_.id) shouldBe List("EXAMPLE_RULEGROUP", "EXAMPLE_RULEGROUP", "EXAMPLE_RULEGROUP", "EXAMPLE_RULEGROUP")
+    instance.getRules().map(_.id) shouldBe List(
+      "EXAMPLE_RULEGROUP",
+      "EXAMPLE_RULEGROUP",
+      "EXAMPLE_RULEGROUP",
+      "EXAMPLE_RULEGROUP"
+    )
   }
 
   "getInstance" should "report categories both sorts of rules" in {
@@ -161,28 +171,42 @@ class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
 
   "getInstance" should "handle cases where no novel rules are available" in {
     val ltFactory = new LanguageToolFactory(None)
-    val instance = ltFactory.createInstance(List.empty).getOrElse(fail("Attempted to create an instance with no rules, but got a `Left` instead"))
+    val instance = ltFactory
+      .createInstance(List.empty)
+      .getOrElse(fail("Attempted to create an instance with no rules, but got a `Left` instead"))
     instance.getRules().map(_.id) shouldBe List.empty
   }
 
   "getInstance" should "handle cases where the XML is inconsistent, reporting the affect rule(s) correctly" in {
     val ltFactory = new LanguageToolFactory(None)
     val exampleRules = List(exampleBadRule1)
-    val errors = ltFactory.createInstance(exampleRules).left.getOrElse(fail("Expected a list of errors from bad rules, not a valid instance"))
+    val errors = ltFactory
+      .createInstance(exampleRules)
+      .left
+      .getOrElse(fail("Expected a list of errors from bad rules, not a valid instance"))
     val messages = errors.map(_.getMessage())
 
     errors.size shouldBe 1
-    messages.filter(_.contains("""The entity "months" was referenced, but not declared.""")).size shouldBe 1
+    messages
+      .filter(_.contains("""The entity "months" was referenced, but not declared."""))
+      .size shouldBe 1
   }
 
   "getInstance" should "handle cases where the XML is malformed, reporting the affect rule(s) correctly" in {
     val ltFactory = new LanguageToolFactory(None)
     val exampleRules = List(exampleBadRule2)
-    val errors = ltFactory.createInstance(exampleRules).left.getOrElse(fail("Expected a list of errors from bad rules, not a valid instance"))
+    val errors = ltFactory
+      .createInstance(exampleRules)
+      .left
+      .getOrElse(fail("Expected a list of errors from bad rules, not a valid instance"))
     val messages = errors.map(_.getMessage())
 
     errors.size shouldBe 1
-    messages.filter(_.contains("""The markup in the document following the root element must be well-formed.""")).size shouldBe 1
+    messages
+      .filter(
+        _.contains("""The markup in the document following the root element must be well-formed.""")
+      )
+      .size shouldBe 1
   }
 
   "check" should "apply LanguageTool default rules" in {
@@ -193,7 +217,8 @@ class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
 
     val eventuallyMatches = instance.check(request)
 
-    val expectedMatchMessages = List("Did you mean <suggestion>fewer</suggestion>? The noun tests is countable.")
+    val expectedMatchMessages =
+      List("Did you mean <suggestion>fewer</suggestion>? The noun tests is countable.")
     val expectedMatchCategoryIds = List("GRAMMAR")
     eventuallyMatches map { matches =>
       matches.map(_.message) shouldBe expectedMatchMessages
@@ -207,7 +232,8 @@ class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
     val request = MatcherRequest(List(TextBlock("id-1", "Three mistakes or less", 0, 29)))
 
     val eventuallyMatches = instance.check(request)
-    val expectedMatchMessages = List("Did you mean <suggestion>fewer</suggestion>? The noun mistakes is countable.")
+    val expectedMatchMessages =
+      List("Did you mean <suggestion>fewer</suggestion>? The noun mistakes is countable.")
     eventuallyMatches map { matches =>
       matches.map(_.message) shouldBe expectedMatchMessages
     }

--- a/apps/checker/test/scala/matchers/RegexMatcherTest.scala
+++ b/apps/checker/test/scala/matchers/RegexMatcherTest.scala
@@ -1,7 +1,15 @@
 package matchers
 
 import com.gu.typerighter
-import com.gu.typerighter.model.{Category, ComparableRegex, RegexRule, RuleMatch, Text, TextBlock, TextSuggestion}
+import com.gu.typerighter.model.{
+  Category,
+  ComparableRegex,
+  RegexRule,
+  RuleMatch,
+  Text,
+  TextBlock,
+  TextSuggestion
+}
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import com.softwaremill.diffx.scalatest.DiffShouldMatcher._
@@ -29,7 +37,16 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
 
   def getBlocks(text: String) = List(TextBlock("text-block-id", text, 0, text.length))
 
-  def getMatch(text: String, fromPos: Int, toPos: Int, before: String, after: String, rule: RegexRule = exampleRule, replacement: Option[String] = None, markAsCorrect: Boolean = false) = RuleMatch(
+  def getMatch(
+      text: String,
+      fromPos: Int,
+      toPos: Int,
+      before: String,
+      after: String,
+      rule: RegexRule = exampleRule,
+      replacement: Option[String] = None,
+      markAsCorrect: Boolean = false
+  ) = RuleMatch(
     rule = rule,
     fromPos = fromPos,
     toPos = toPos,
@@ -44,7 +61,11 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     markAsCorrect = markAsCorrect
   )
 
-  def checkTextWithRegex(regex: ComparableRegex, replacement: String, text: String): Future[List[RuleMatch]] = {
+  def checkTextWithRegex(
+      regex: ComparableRegex,
+      replacement: String,
+      text: String
+  ): Future[List[RuleMatch]] = {
     val rule = typerighter.model.RegexRule(
       id = "test-rule",
       description = "test-description",
@@ -65,7 +86,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
       MatcherRequest(getBlocks(sampleText))
     )
     eventuallyMatches.map { matches =>
-      matches shouldMatchTo(List(
+      matches shouldMatchTo (List(
         getMatch("text", 8, 12, "example ", " is here")
       ))
     }
@@ -101,7 +122,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
       MatcherRequest(getBlocks(sampleText))
     )
     eventuallyMatches.map { matches =>
-      matches shouldMatchTo(List(
+      matches shouldMatchTo (List(
         getMatch("text", 121, 125, before, after)
       ))
     }
@@ -112,7 +133,7 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
       MatcherRequest(getBlocks("text text text"))
     )
     eventuallyMatches.map { matches =>
-      matches shouldMatchTo(List(
+      matches shouldMatchTo (List(
         getMatch("text", 0, 4, "", " text text"),
         getMatch("text", 5, 9, "text ", " text"),
         getMatch("text", 10, 14, "text text ", "")
@@ -128,9 +149,9 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     )
     eventuallyMatches.map { matches =>
       matches.size shouldBe 3
-      matches(0) shouldMatchTo(getMatch("ton", 5, 8, "tone ", " goto", overlapRules(1)))
-      matches(1) shouldMatchTo(getMatch("one", 1, 4, "t", " ton goto", overlapRules(2)))
-      matches(2) shouldMatchTo(getMatch("got", 9, 12, "tone ton ", "o", overlapRules(3)))
+      matches(0) shouldMatchTo (getMatch("ton", 5, 8, "tone ", " goto", overlapRules(1)))
+      matches(1) shouldMatchTo (getMatch("one", 1, 4, "t", " ton goto", overlapRules(2)))
+      matches(2) shouldMatchTo (getMatch("got", 9, 12, "tone ton ", "o", overlapRules(3)))
     }
   }
 
@@ -151,8 +172,9 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     eventuallyMatches.map { matches =>
       matches.size shouldBe 1
       val expectedReplacement = Some("teapot")
-      val expectedMatch = getMatch("tea pot", 13, 20, "I'm a little ", "", rule, expectedReplacement)
-      matches(0) shouldMatchTo(expectedMatch)
+      val expectedMatch =
+        getMatch("tea pot", 13, 20, "I'm a little ", "", rule, expectedReplacement)
+      matches(0) shouldMatchTo (expectedMatch)
       matches(0).markAsCorrect shouldBe false
     }
   }
@@ -174,8 +196,17 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     eventuallyMatches.map { matches =>
       matches.size shouldBe 1
       val expectedReplacement = Some("teapot")
-      val expectedMatch = getMatch("teapot", 13, 19, "I'm a little ", "", rule, expectedReplacement, markAsCorrect = true)
-      matches(0) shouldMatchTo(expectedMatch)
+      val expectedMatch = getMatch(
+        "teapot",
+        13,
+        19,
+        "I'm a little ",
+        "",
+        rule,
+        expectedReplacement,
+        markAsCorrect = true
+      )
+      matches(0) shouldMatchTo (expectedMatch)
     }
   }
 
@@ -200,13 +231,15 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     }
   }
 
-   "check" should "handle multiple substitions" in {
+  "check" should "handle multiple substitions" in {
     val rule = typerighter.model.RegexRule(
       id = s"example-rule",
       category = Category("new-category", "New Category"),
       description = s"Example rule",
       replacement = Some(TextSuggestion("$1-$2-long")),
-      regex = new ComparableRegex("\\b(one|two|three|four|five|six|seven|eight|nine|\\d)-? (year|day|month|week|mile)-? long")
+      regex = new ComparableRegex(
+        "\\b(one|two|three|four|five|six|seven|eight|nine|\\d)-? (year|day|month|week|mile)-? long"
+      )
     )
 
     val validator = new RegexMatcher(List(rule))
@@ -217,8 +250,9 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
     eventuallyMatches.map { matches =>
       matches.size shouldBe 1
       val expectedReplacement = Some("nine-month-long")
-      val expectedMatch = getMatch("nine month long", 2, 17, "A ", " sabbatical", rule, expectedReplacement)
-      matches(0) shouldMatchTo(expectedMatch)
+      val expectedMatch =
+        getMatch("nine month long", 2, 17, "A ", " sabbatical", rule, expectedReplacement)
+      matches(0) shouldMatchTo (expectedMatch)
     }
   }
 

--- a/apps/checker/test/scala/model/RuleMatchTest.scala
+++ b/apps/checker/test/scala/model/RuleMatchTest.scala
@@ -1,6 +1,5 @@
 package scala.model
 
-
 import com.gu.typerighter.model.{Category, ComparableRegex, RegexRule, RuleMatch, Text, TextRange}
 import model._
 import org.scalatest.flatspec.AsyncFlatSpec
@@ -20,7 +19,7 @@ class RuleMatchTest extends AsyncFlatSpec with Matchers {
     subsequentText = "",
     matchedText = "placeholder text",
     message = "placeholder message",
-    matchContext = "[placeholder text]",
+    matchContext = "[placeholder text]"
   )
 
   behavior of "mapMatchThroughSkippedRanges"

--- a/apps/checker/test/scala/model/TextBlockTest.scala
+++ b/apps/checker/test/scala/model/TextBlockTest.scala
@@ -29,7 +29,8 @@ class TextBlockTest extends AsyncFlatSpec with Matchers {
 
   it should "remove multiple non-adjacent skipped ranges from the block text - 1" in {
     val skippedRanges = Some(List(TextRange(18, 25), TextRange(41, 48)))
-    val block = TextBlock("id", "Example [noted ]text with more [noted ]text", 10, 52, skippedRanges)
+    val block =
+      TextBlock("id", "Example [noted ]text with more [noted ]text", 10, 52, skippedRanges)
     val newBlock = block.removeSkippedRanges()
     newBlock.text shouldBe "Example text with more text"
     newBlock.from shouldBe 10

--- a/apps/checker/test/scala/services/SentenceHelperTest.scala
+++ b/apps/checker/test/scala/services/SentenceHelperTest.scala
@@ -20,49 +20,87 @@ class SentenceHelperTest extends AsyncFlatSpec with Matchers {
     "‘",
     "-",
     "–",
-    "—",
+    "—"
   )
 
   behavior of "getFirstWordsInSentences"
 
   it should "return sentence starts, including the word and range covered" in {
-    val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
-    firstWordsInSentences shouldMatchTo(List(
-      WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
-      WordInSentence("Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(102, 107)),
+    val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(
+      "Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit"
+    )
+    firstWordsInSentences shouldMatchTo (List(
+      WordInSentence(
+        "Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.",
+        "Allowed",
+        TextRange(0, 7)
+      ),
+      WordInSentence(
+        "Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit",
+        "Cafes",
+        TextRange(102, 107)
+      )
     ))
   }
 
   charactersThatProduceNonWordTokens.foreach { nonWordChar =>
     it should s"ignore non-word tokens when finding sentence starts: $nonWordChar" in {
-      val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. ${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
-      firstWordsInSentences shouldMatchTo(List(
-        WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
-        WordInSentence(s"${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(103, 108)),
+      val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(
+        s"Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. ${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit"
+      )
+      firstWordsInSentences shouldMatchTo (List(
+        WordInSentence(
+          "Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.",
+          "Allowed",
+          TextRange(0, 7)
+        ),
+        WordInSentence(
+          s"${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit",
+          "Cafes",
+          TextRange(103, 108)
+        )
       ))
     }
 
     it should s"not ignore words that contain non-word tokens when finding sentence starts: $nonWordChar" in {
-      val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Other${nonWordChar} cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
-      firstWordsInSentences shouldMatchTo(List(
-        WordInSentence("Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.", "Allowed", TextRange(0, 7)),
-        WordInSentence(s"Other${nonWordChar} cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Other", TextRange(102, 107)),
+      val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(
+        s"Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. Other${nonWordChar} cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit"
+      )
+      firstWordsInSentences shouldMatchTo (List(
+        WordInSentence(
+          "Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation.",
+          "Allowed",
+          TextRange(0, 7)
+        ),
+        WordInSentence(
+          s"Other${nonWordChar} cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit",
+          "Other",
+          TextRange(102, 107)
+        )
       ))
     }
   }
 
   charactersThatProduceNonWordTokens.foreach { nonWordChar =>
     it should s"ignore multiple non-word tokens when finding sentence starts: $nonWordChar" in {
-      val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"${nonWordChar}${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit")
-      firstWordsInSentences shouldMatchTo(List(
-        WordInSentence(s"${nonWordChar}${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit", "Cafes", TextRange(2, 7)),
+      val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(
+        s"${nonWordChar}${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit"
+      )
+      firstWordsInSentences shouldMatchTo (List(
+        WordInSentence(
+          s"${nonWordChar}${nonWordChar}Cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit",
+          "Cafes",
+          TextRange(2, 7)
+        )
       ))
     }
   }
 
   it should s"not give any results if the sentence consists entirely of non word tokens" in {
     val nonWordChar = charactersThatProduceNonWordTokens.head
-    val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(s"$nonWordChar$nonWordChar$nonWordChar$nonWordChar$nonWordChar$nonWordChar")
-    firstWordsInSentences shouldMatchTo(List.empty[WordInSentence])
+    val firstWordsInSentences = sentenceTokenizer.getFirstWordsInSentences(
+      s"$nonWordChar$nonWordChar$nonWordChar$nonWordChar$nonWordChar$nonWordChar"
+    )
+    firstWordsInSentences shouldMatchTo (List.empty[WordInSentence])
   }
 }

--- a/apps/checker/test/scala/simulation/CheckPermutationsSimulation.scala
+++ b/apps/checker/test/scala/simulation/CheckPermutationsSimulation.scala
@@ -6,22 +6,26 @@ import io.gatling.http.Predef._
 import scala.concurrent.duration._
 
 class CheckPermutationsSimulation extends Simulation {
-  val httpConf = http.baseUrl("http://localhost:9000")
+  val httpConf = http
+    .baseUrl("http://localhost:9000")
     .contentTypeHeader("application/json")
 
   val scn = scenario("CheckPermutationsSimulation")
-    .exec(http("checkRequest")
-    .post("/check").body(StringBody(_ =>
-      s"""{
+    .exec(
+      http("checkRequest")
+        .post("/check")
+        .body(StringBody(_ => s"""{
          |\"text\": \"$getRandomArticle\",
          |\"id\": \"${java.util.UUID.randomUUID.toString}\"
-         |}""".stripMargin)))
+         |}""".stripMargin))
+    )
 
   setUp(
     scn.inject(atOnceUsers(100))
   ).protocols(httpConf)
 
-  val articleFragments = List("Michel Barnier has warned that the move led by Labour MP Yvette Cooper to block the prime minister from delivering a no-deal Brexit is doomed to fail unless a majority for an alternative agreement is found",
+  val articleFragments = List(
+    "Michel Barnier has warned that the move led by Labour MP Yvette Cooper to block the prime minister from delivering a no-deal Brexit is doomed to fail unless a majority for an alternative agreement is found",
     "The EU’s chief negotiator, in a speech in Brussels, said the “default” for the UK was still crashing out if MPs could not coalesce around a new vision of its future outside the bloc",
     "“There appears to be a majority in the Commons to oppose a no-deal but opposing a no-deal will not stop a no-deal from happening at the end of March”, he said. “To stop ‘no deal’, a positive majority for another solution will need to emerge.” Labour appears set to whip its MPs to back Cooper’s amendment paving the way for legislation that would mandate ministers to extend article 50 if a no-deal Brexit looked imminent",
     "Advertisement Barnier said that extending the two years of the negotiating period beyond 29 March should not be the primary focus for the UK parliament",
@@ -33,10 +37,10 @@ class CheckPermutationsSimulation extends Simulation {
     "In an interview with Le Monde, Rzeczpospolita and Luxemburger Wort published earlier on Wednesday, Barnier made public his belief that May’s strategy of trying to secure a time-limit was doomed to fail",
     "In comments that appear to put a wrecking ball to the prime minister’s strategy, he said the withdrawal agreement in all its facets was the “the only possible option” for Britain as it leaves",
     "“The question of limiting the backstop in time has already been discussed twice by European leaders”, Barnier said. “This is the only possible option because an insurance is of no use if it is time limited",
-    "“We cannot tie the backstop to a time limit”, he added. “Imagine if your home’s insurance was limited to five years and you’d have a problem after six years … That’s difficult to justify. It’s similar with the backstop.” Under the backstop, the UK would stay in a customs union with the EU unless an alternative arrangement could avoid the imposition of a hard border on the island of Ireland")
+    "“We cannot tie the backstop to a time limit”, he added. “Imagine if your home’s insurance was limited to five years and you’d have a problem after six years … That’s difficult to justify. It’s similar with the backstop.” Under the backstop, the UK would stay in a customs union with the EU unless an alternative arrangement could avoid the imposition of a hard border on the island of Ireland"
+  )
 
   def getRandomArticle = {
     util.Random.shuffle(articleFragments).mkString
   }
 }
-

--- a/apps/checker/test/scala/utils/TimerTest.scala
+++ b/apps/checker/test/scala/utils/TimerTest.scala
@@ -1,7 +1,7 @@
 package utils
 
 import org.scalatest.flatspec.AnyFlatSpec
-import org.mockito.{ IdiomaticMockito }
+import org.mockito.{IdiomaticMockito}
 import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.Future
@@ -17,7 +17,7 @@ class TimerTest extends AnyFlatSpec with Matchers with IdiomaticMockito {
   it should "not call `onSlowLog` when a task does not exceed its slow log threshold" in {
     val mockFunction = spyLambda((d: Long) => ())
 
-    Timer.time(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction){}
+    Timer.time(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction) {}
 
     mockFunction wasNever called
   }
@@ -26,7 +26,7 @@ class TimerTest extends AnyFlatSpec with Matchers with IdiomaticMockito {
     var eventualDuration = 0L
     val mockFunction = spyLambda((duration: Long) => eventualDuration = duration)
 
-    Timer.time(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction){
+    Timer.time(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction) {
       Thread.sleep(200)
     }
 
@@ -38,7 +38,7 @@ class TimerTest extends AnyFlatSpec with Matchers with IdiomaticMockito {
   it should "not call `onSlowLog` when a task does not exceed its slow log threshold" in {
     val mockFunction = spyLambda((d: Long) => ())
 
-    Timer.timeAsync(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction){
+    Timer.timeAsync(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction) {
       Future.successful(())
     }
 
@@ -49,10 +49,11 @@ class TimerTest extends AnyFlatSpec with Matchers with IdiomaticMockito {
     var eventualDuration = 0L
     val mockFunction = (duration: Long) => eventualDuration = duration
 
-    val task = Timer.timeAsync(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction){
-      Thread.sleep(200)
-      Future.successful(())
-    }
+    val task =
+      Timer.timeAsync(taskName = "task", slowLogThresholdMs = 100, onSlowLog = mockFunction) {
+        Thread.sleep(200)
+        Future.successful(())
+      }
     Await.result(task, 1.second)
 
     eventualDuration.toInt should be >= 200

--- a/apps/rule-manager/test/db/DBTest.scala
+++ b/apps/rule-manager/test/db/DBTest.scala
@@ -12,10 +12,14 @@ trait DBTest extends BeforeAndAfter { self: Suite =>
   private val url = config.get("db.default.url")
   private val user = config.get("db.default.username")
   private val password = config.get("db.default.password")
-  private val playDb = Databases("org.postgresql.Driver", url, config = Map(
-    "username" -> user,
-    "password" -> password
-  ))
+  private val playDb = Databases(
+    "org.postgresql.Driver",
+    url,
+    config = Map(
+      "username" -> user,
+      "password" -> password
+    )
+  )
 
   val scalikejdbcDb = new DB(url, user, password)
 

--- a/apps/rule-manager/test/db/DbRuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/DbRuleManagerSpec.scala
@@ -1,6 +1,13 @@
 package db
 
-import com.gu.typerighter.model.{Category, ComparableRegex, LTRuleCore, LTRuleXML, RegexRule, RuleResource}
+import com.gu.typerighter.model.{
+  Category,
+  ComparableRegex,
+  LTRuleCore,
+  LTRuleXML,
+  RegexRule,
+  RuleResource
+}
 import org.scalatest.flatspec.FixtureAnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import scalikejdbc.scalatest.AutoRollback
@@ -8,11 +15,7 @@ import service.DbRuleManager
 
 import scala.util.Random
 
-class DbRuleManagerSpec
-    extends FixtureAnyFlatSpec
-    with Matchers
-    with AutoRollback
-    with DBTest {
+class DbRuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with DBTest {
 
   def createRandomRules(ruleCount: Int) =
     (1 to ruleCount).map { ruleIndex =>
@@ -22,56 +25,62 @@ class DbRuleManagerSpec
         "A random rule description. " * Random.between(0, 100),
         List(),
         None,
-        new ComparableRegex(s"\b(${Random.shuffle(List("some", "random", "things", "to", "match", "on")).mkString("|")}) by")
+        new ComparableRegex(
+          s"\b(${Random.shuffle(List("some", "random", "things", "to", "match", "on")).mkString("|")}) by"
+        )
       )
     }.toList
 
   behavior of "DbRuleManager"
 
-  "destructivelyDumpRuleResourceToDB" should "add rules of each type in a ruleResource, and read it back as an identical resource" in { implicit session =>
-    val rulesFromSheet = List(
-      RegexRule(
-        "faef1f8a-4ee2-4b97-8783-0566e27851da",
-        Category("Check this", "Check this"),
-        "**bearing children** Such phrases as “she bore him two sons” and “he had two children by” are outdated and sexist",
-        List(),
-        None,
-        new ComparableRegex("\b(children|sons?|daughters?) by")
-      ),
-      LTRuleXML(
-        "DATEFORMAT",
-        "<rulegroup></rulegroup>",
-        Category("Check this", "Check this"),
-        "An example description"
-      ),
-      LTRuleCore(
-        "DOUBLE_PUNCTUATION",
-        "DOUBLE_PUNCTUATION"
+  "destructivelyDumpRuleResourceToDB" should "add rules of each type in a ruleResource, and read it back as an identical resource" in {
+    implicit session =>
+      val rulesFromSheet = List(
+        RegexRule(
+          "faef1f8a-4ee2-4b97-8783-0566e27851da",
+          Category("Check this", "Check this"),
+          "**bearing children** Such phrases as “she bore him two sons” and “he had two children by” are outdated and sexist",
+          List(),
+          None,
+          new ComparableRegex("\b(children|sons?|daughters?) by")
+        ),
+        LTRuleXML(
+          "DATEFORMAT",
+          "<rulegroup></rulegroup>",
+          Category("Check this", "Check this"),
+          "An example description"
+        ),
+        LTRuleCore(
+          "DOUBLE_PUNCTUATION",
+          "DOUBLE_PUNCTUATION"
+        )
       )
-    )
 
-    val rules = RuleResource(rules = rulesFromSheet)
-    val rulesFromDb = DbRuleManager.destructivelyDumpRuleResourceToDB(rules)
+      val rules = RuleResource(rules = rulesFromSheet)
+      val rulesFromDb = DbRuleManager.destructivelyDumpRuleResourceToDB(rules)
 
-    rulesFromDb.shouldEqual(Right(rules))
+      rulesFromDb.shouldEqual(Right(rules))
   }
 
-  "destructivelyDumpRuleResourceToDB" should "add 1000 randomly generated rules in a ruleResource, and read them back from the DB as an identical resource" in { implicit session =>
-    val rulesFromSheet = createRandomRules(1000)
+  "destructivelyDumpRuleResourceToDB" should "add 1000 randomly generated rules in a ruleResource, and read them back from the DB as an identical resource" in {
+    implicit session =>
+      val rulesFromSheet = createRandomRules(1000)
 
-    val rules = RuleResource(rules = rulesFromSheet)
-    val rulesFromDb = DbRuleManager.destructivelyDumpRuleResourceToDB(rules)
+      val rules = RuleResource(rules = rulesFromSheet)
+      val rulesFromDb = DbRuleManager.destructivelyDumpRuleResourceToDB(rules)
 
-    rulesFromDb.shouldEqual(Right(rules))
+      rulesFromDb.shouldEqual(Right(rules))
   }
 
-  "destructivelyDumpRuleResourceToDB" should "remove old rules before adding new ones" in { implicit session =>
-    val firstRules = createRandomRules(10)
-    DbRuleManager.destructivelyDumpRuleResourceToDB(RuleResource(firstRules))
+  "destructivelyDumpRuleResourceToDB" should "remove old rules before adding new ones" in {
+    implicit session =>
+      val firstRules = createRandomRules(10)
+      DbRuleManager.destructivelyDumpRuleResourceToDB(RuleResource(firstRules))
 
-    val secondRules = createRandomRules(10)
-    val secondRulesFromDb = DbRuleManager.destructivelyDumpRuleResourceToDB(RuleResource(secondRules))
+      val secondRules = createRandomRules(10)
+      val secondRulesFromDb =
+        DbRuleManager.destructivelyDumpRuleResourceToDB(RuleResource(secondRules))
 
-    secondRulesFromDb.shouldEqual(Right(RuleResource(secondRules)))
+      secondRulesFromDb.shouldEqual(Right(RuleResource(secondRules)))
   }
 }

--- a/apps/rule-manager/test/db/HealthyDBSpec.scala
+++ b/apps/rule-manager/test/db/HealthyDBSpec.scala
@@ -4,11 +4,7 @@ import scalikejdbc.scalatest.AutoRollback
 import org.scalatest.fixture.FlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class HealthyDBSpec
-  extends FlatSpec
-  with Matchers
-  with AutoRollback
-  with DBTest {
+class HealthyDBSpec extends FlatSpec with Matchers with AutoRollback with DBTest {
 
   behavior of "Database connection"
 

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -11,7 +11,8 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
 
   override def fixture(implicit session: DBSession) {
     sql"ALTER SEQUENCE rules_id_seq RESTART WITH 1".update.apply()
-    sql"insert into rules (rule_type, pattern, replacement, category, tags, description, ignore, notes, google_sheet_id, force_red_rule, advisory_rule) values (${"regex"}, ${"pattern"}, ${"replacement"}, ${"category"}, ${"someTags"}, ${"description"}, false, ${"notes"}, ${"googleSheetId"}, false, false)".update.apply()
+    sql"insert into rules (rule_type, pattern, replacement, category, tags, description, ignore, notes, google_sheet_id, force_red_rule, advisory_rule) values (${"regex"}, ${"pattern"}, ${"replacement"}, ${"category"}, ${"someTags"}, ${"description"}, false, ${"notes"}, ${"googleSheetId"}, false, false)".update
+      .apply()
   }
 
   behavior of "Rules"
@@ -26,23 +27,23 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
   }
   it should "find all records" in { implicit session =>
     val allResults = DbRule.findAll()
-    allResults.size should be >(0)
+    allResults.size should be > (0)
   }
   it should "count all records" in { implicit session =>
     val count = DbRule.countAll()
-    count should be >(0L)
+    count should be > (0L)
   }
   it should "find all by where clauses" in { implicit session =>
     val results = DbRule.findAllBy(sqls.eq(r.id, 1))
-    results.size should be >(0)
+    results.size should be > (0)
   }
   it should "count by where clauses" in { implicit session =>
     val count = DbRule.countBy(sqls.eq(r.id, 1))
-    count should be >(0L)
+    count should be > (0L)
   }
   it should "create new record" in { implicit session =>
     val created = DbRule.create(ruleType = "regex", pattern = Some("MyString"), ignore = false)
-    created should not be(null)
+    created should not be (null)
   }
   it should "save a record" in { implicit session =>
     val entity = DbRule.findAll().head
@@ -61,6 +62,6 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     val entities = DbRule.findAll()
     entities.foreach(e => DbRule.destroy(e))
     val batchInserted = DbRule.batchInsert(entities)
-    batchInserted.size should be >(0)
+    batchInserted.size should be > (0)
   }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds a `scalafmtCheckAll` to our GitHub Actions-based CI.

It also formats the project to make sure all existing files are formatted in line with `scalaFmt`. (The **only** non-formatting change is to `.github/workflows/ci.yaml`)

## How to test

1. Run `sbt scalafmtCheckAll` locally (with the app running in another terminal via `./script/start`). Does the formatting check pass?
2. Look at a CI build for this PR in the Github Actions tab. Does the formatting check pass? Does the CI otherwise perform as expected?