### PR TITLE
Add LanguageTool default rules to persisted rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you'd like to provide your own integration, this service will function as a s
 
 ## Upgrading LanguageTool
 
-LanguageTool has default rules that we use, and as we upgrade LT, these could change underneath us.
+LanguageTool has core rules that we use, and as we upgrade LT, these could change underneath us.
 
 There's a script to see if rules have changed as a result of an upgrade in ./script/js/compare-rule-xml.js.
 

--- a/apps/checker/app/matchers/LanguageToolMatcher.scala
+++ b/apps/checker/app/matchers/LanguageToolMatcher.scala
@@ -26,8 +26,8 @@ class LanguageToolFactory(
     useLanguageModelRules: Boolean = false
 ) extends Logging {
 
-  def createInstance(ruleXMLs: List[LTRuleXML], defaultRuleIds: List[String] = Nil)(implicit
-      ec: ExecutionContext
+  def createInstance(ruleXMLs: List[LTRuleXML], coreRuleIds: List[String] = Nil)(implicit
+                                                                                 ec: ExecutionContext
   ): Either[List[Throwable], Matcher] = {
     val language: Language = Languages.getLanguageForShortCode("en")
     val cache: ResultCache = new ResultCache(10000)
@@ -44,13 +44,13 @@ class LanguageToolFactory(
     val allRuleIds = instance.getAllRules.asScala.map(_.getId())
     allRuleIds.foreach(ruleId => instance.disableRule(ruleId))
     // ... apart from those we'd explicitly like
-    val errors = defaultRuleIds.foldLeft(List.empty[Throwable])((acc, ruleId) =>
+    val errors = coreRuleIds.foldLeft(List.empty[Throwable])((acc, ruleId) =>
       if (allRuleIds.contains(ruleId)) {
         instance.enableRule(ruleId)
         acc
       } else
         new Exception(
-          s"Attempted to enable a default rule with id ${ruleId}, but the rule was not available on the instance"
+          s"Attempted to enable a core rule with id ${ruleId}, but the rule was not available on the instance"
         ) :: acc
     )
 
@@ -60,7 +60,7 @@ class LanguageToolFactory(
         applyXMLRules(instance, ruleXMLs) map { _ =>
           val matcher = new LanguageToolMatcher(instance)
           logger.info(
-            s"Added ${ruleXMLs.size} rules and enabled ${defaultRuleIds.size} default rules for matcher instance with id: ${matcher.getId()}"
+            s"Added ${ruleXMLs.size} rules and enabled ${coreRuleIds.size} core rules for matcher instance with id: ${matcher.getId()}"
           )
           matcher
         }

--- a/apps/checker/app/matchers/LanguageToolMatcher.scala
+++ b/apps/checker/app/matchers/LanguageToolMatcher.scala
@@ -27,7 +27,7 @@ class LanguageToolFactory(
 ) extends Logging {
 
   def createInstance(ruleXMLs: List[LTRuleXML], coreRuleIds: List[String] = Nil)(implicit
-                                                                                 ec: ExecutionContext
+      ec: ExecutionContext
   ): Either[List[Throwable], Matcher] = {
     val language: Language = Languages.getLanguageForShortCode("en")
     val cache: ResultCache = new ResultCache(10000)

--- a/apps/checker/app/services/RuleProvisionerService.scala
+++ b/apps/checker/app/services/RuleProvisionerService.scala
@@ -90,9 +90,9 @@ class RuleProvisionerService(
   }
 
   private def addLTMatcherToPool(
-                                  matcherPool: MatcherPool,
-                                  xmlRules: List[LTRuleXML],
-                                  coreRules: List[LTRuleCore] = List.empty
+      matcherPool: MatcherPool,
+      xmlRules: List[LTRuleXML],
+      coreRules: List[LTRuleCore] = List.empty
   ): List[Throwable] = {
     languageToolFactory.createInstance(xmlRules, coreRules.map(_.languageToolRuleId)) match {
       case Right(matcher) =>

--- a/apps/checker/app/views/rules.scala.html
+++ b/apps/checker/app/views/rules.scala.html
@@ -3,9 +3,10 @@
 
 @import com.gu.typerighter.model.BaseRule
 @import com.gu.typerighter.model.RegexRule
-@import com.gu.typerighter.model.RegexRule
 @import com.gu.typerighter.model.LTRule
+@import com.gu.typerighter.model.PatternRule
 @import utils.Matcher
+
 @(sheetId: String, rules: scala.List[BaseRule], matchers: scala.List[Matcher], rulesRefreshed: Option[Boolean] = None,
         rulesIngested: Option[Int] = None, errors: List[String] = List.empty)(implicit req: RequestHeader)
 @main(title = "Typerighter", breadcrumbsList = List("Rules")) {
@@ -79,17 +80,21 @@
                           @rule.id
                         </td>
                         <td>
-                          @rule.category.name
+                          @rule match {
+                            case p: PatternRule => { @p.category.name }
+                            case _ => { N/A }
+                          }
                         </td>
                         <td>@rule match {
-                          case r: RegexRule => {
-                            @r.regex.toString.slice(0, 30)
-                          }
+                          case r: RegexRule => { @r.regex.toString.slice(0, 30) }
                           case _ => { N/A }
                         }</td>
-                        <td>@if(rule.description.nonEmpty) {
-                            @rule.description
-                        } else { None }</td>
+                        <td>
+                          @rule match {
+                            case p: PatternRule if p.description.nonEmpty => { @p.description }
+                            case _ => { N/A }
+                          }
+                        </td>
                     </tr>
                 }
                 </tbody>

--- a/apps/checker/app/views/rules.scala.html
+++ b/apps/checker/app/views/rules.scala.html
@@ -4,9 +4,9 @@
 @import com.gu.typerighter.model.BaseRule
 @import com.gu.typerighter.model.RegexRule
 @import com.gu.typerighter.model.LTRule
-@import com.gu.typerighter.model.PatternRule
 @import utils.Matcher
 
+@import com.gu.typerighter.model.LTRuleXML
 @(sheetId: String, rules: scala.List[BaseRule], matchers: scala.List[Matcher], rulesRefreshed: Option[Boolean] = None,
         rulesIngested: Option[Int] = None, errors: List[String] = List.empty)(implicit req: RequestHeader)
 @main(title = "Typerighter", breadcrumbsList = List("Rules")) {
@@ -80,10 +80,7 @@
                           @rule.id
                         </td>
                         <td>
-                          @rule match {
-                            case p: PatternRule => { @p.category.name }
-                            case _ => { N/A }
-                          }
+                          @rule.category.name
                         </td>
                         <td>@rule match {
                           case r: RegexRule => { @r.regex.toString.slice(0, 30) }
@@ -91,7 +88,8 @@
                         }</td>
                         <td>
                           @rule match {
-                            case p: PatternRule if p.description.nonEmpty => { @p.description }
+                            case p: RegexRule if p.description.nonEmpty => { @p.description }
+                            case p: LTRuleXML if p.description.nonEmpty => { @p.description }
                             case _ => { N/A }
                           }
                         </td>

--- a/apps/checker/test/scala/matchers/LanguageToolMatcherTest.scala
+++ b/apps/checker/test/scala/matchers/LanguageToolMatcherTest.scala
@@ -119,10 +119,10 @@ class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
     instance.getRules() shouldBe Nil
   }
 
-  "getInstance" should "include the rules we provide by id via `defaultRules`" in {
+  "getInstance" should "include the rules we provide by id via `coreRules`" in {
     val ltFactory = new LanguageToolFactory(None)
-    val defaultRules = List("FEWER_LESS", "DOES_YOU")
-    val instance = ltFactory.createInstance(Nil, defaultRules).getOrElse(fail)
+    val coreRules = List("FEWER_LESS", "DOES_YOU")
+    val instance = ltFactory.createInstance(Nil, coreRules).getOrElse(fail)
     // These rule ids map to rule groups, which contain two rules each.
     // This is weird, as we'd assume ids to be unique. We may want to alter
     // this to reflect rule groupings to ensure id uniqueness, for example.
@@ -131,8 +131,8 @@ class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
 
   "getInstance" should "return an error if a defaultRule we provide is not available" in {
     val ltFactory = new LanguageToolFactory(None)
-    val defaultRules = List("NOT_A_THING")
-    val errors = ltFactory.createInstance(Nil, defaultRules).left.getOrElse(fail("Expected a list of errors from unavailable default rules, not a valid instance"))
+    val coreRules = List("NOT_A_THING")
+    val errors = ltFactory.createInstance(Nil, coreRules).left.getOrElse(fail("Expected a list of errors from unavailable default rules, not a valid instance"))
     val messages = errors.map(_.getMessage())
     messages.filter(_.contains("rule was not available")).size shouldBe 1
   }
@@ -153,9 +153,9 @@ class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
 
   "getInstance" should "report categories both sorts of rules" in {
     val ltFactory = new LanguageToolFactory(None)
-    val defaultRules = List("FEWER_LESS", "DOES_YOU")
+    val coreRules = List("FEWER_LESS", "DOES_YOU")
     val exampleRules = List(exampleRule)
-    val instance = ltFactory.createInstance(exampleRules, defaultRules).getOrElse(fail)
+    val instance = ltFactory.createInstance(exampleRules, coreRules).getOrElse(fail)
     instance.getCategories().map(_.id) shouldBe Set("GRAMMAR", "EXAMPLE_CAT")
   }
 
@@ -187,9 +187,8 @@ class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
 
   "check" should "apply LanguageTool default rules" in {
     val ltFactory = new LanguageToolFactory(None)
-    val defaultRules = List("FEWER_LESS")
-    val instance = ltFactory.createInstance(Nil, defaultRules).getOrElse(fail)
-    val rules = instance.getRules()
+    val coreRules = List("FEWER_LESS")
+    val instance = ltFactory.createInstance(Nil, coreRules).getOrElse(fail)
     val request = MatcherRequest(List(TextBlock("id-1", "Three or less tests passed!", 0, 29)))
 
     val eventuallyMatches = instance.check(request)
@@ -204,7 +203,6 @@ class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
 
   "check" should "apply LanguageTool custom rules" in {
     val ltFactory = new LanguageToolFactory(None)
-    val exampleRules = List(exampleRule)
     val instance = ltFactory.createInstance(List(exampleRule)).getOrElse(fail)
     val request = MatcherRequest(List(TextBlock("id-1", "Three mistakes or less", 0, 29)))
 

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/model/BaseRule.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/model/BaseRule.scala
@@ -38,17 +38,6 @@ object LTRuleCore {
   implicit val reads: Reads[LTRuleCore] = Json.reads[LTRuleCore]
 }
 
-sealed trait PatternRule extends BaseRule {
-  val description: String
-  val suggestions: List[Suggestion]
-  val replacement: Option[TextSuggestion]
-}
-
-object PatternRule {
-  implicit val writes: Writes[PatternRule] = Json.writes[PatternRule]
-  implicit val reads: Reads[PatternRule] = Json.reads[PatternRule]
-}
-
 object RegexRule {
   implicit val regexWrites: Writes[ComparableRegex] = (regex: ComparableRegex) =>
     JsString(regex.toString())
@@ -77,7 +66,7 @@ case class RegexRule(
     suggestions: List[TextSuggestion] = List.empty,
     replacement: Option[TextSuggestion] = None,
     regex: ComparableRegex
-) extends PatternRule {
+) extends BaseRule {
 
   def toMatch(
       start: Int,
@@ -119,7 +108,7 @@ case class LTRuleXML(
     xml: String,
     category: Category,
     description: String
-) extends PatternRule {
+) extends BaseRule {
   val suggestions = List.empty
   val replacement: Option[TextSuggestion] = None
 }
@@ -142,7 +131,7 @@ case class LTRule(
     message: String,
     url: Option[String] = None,
     suggestions: List[TextSuggestion]
-) extends PatternRule {
+) extends BaseRule {
   val replacement: Option[TextSuggestion] = None
 }
 

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/model/BaseRule.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/model/BaseRule.scala
@@ -26,16 +26,16 @@ object BaseRule {
   implicit val reads: Reads[BaseRule] = Json.reads[BaseRule]
 }
 
-case class LTDefaultRule(
+case class LTRuleCore(
     id: String,
     languageToolRuleId: String
 ) extends BaseRule {
-  override val category: Category = Category("lt_default", "LanguageTool Default Rule")
+  override val category: Category = Category("lt_core", "LanguageTool Core Rule")
 }
 
-object LTDefaultRule {
-  implicit val writes: Writes[LTDefaultRule] = Json.writes[LTDefaultRule]
-  implicit val reads: Reads[LTDefaultRule] = Json.reads[LTDefaultRule]
+object LTRuleCore {
+  implicit val writes: Writes[LTRuleCore] = Json.writes[LTRuleCore]
+  implicit val reads: Reads[LTRuleCore] = Json.reads[LTRuleCore]
 }
 
 sealed trait PatternRule extends BaseRule {

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/model/BaseRule.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/model/BaseRule.scala
@@ -19,14 +19,34 @@ import scala.jdk.CollectionConverters._
 sealed trait BaseRule {
   val id: String
   val category: Category
-  val description: String
-  val suggestions: List[Suggestion]
-  val replacement: Option[TextSuggestion]
 }
 
 object BaseRule {
   implicit val writes: Writes[BaseRule] = Json.writes[BaseRule]
   implicit val reads: Reads[BaseRule] = Json.reads[BaseRule]
+}
+
+case class LTDefaultRule(
+    id: String,
+    languageToolRuleId: String
+) extends BaseRule {
+  override val category: Category = Category("lt_default", "LanguageTool Default Rule")
+}
+
+object LTDefaultRule {
+  implicit val writes: Writes[LTDefaultRule] = Json.writes[LTDefaultRule]
+  implicit val reads: Reads[LTDefaultRule] = Json.reads[LTDefaultRule]
+}
+
+sealed trait PatternRule extends BaseRule {
+  val description: String
+  val suggestions: List[Suggestion]
+  val replacement: Option[TextSuggestion]
+}
+
+object PatternRule {
+  implicit val writes: Writes[PatternRule] = Json.writes[PatternRule]
+  implicit val reads: Reads[PatternRule] = Json.reads[PatternRule]
 }
 
 object RegexRule {
@@ -57,7 +77,7 @@ case class RegexRule(
     suggestions: List[TextSuggestion] = List.empty,
     replacement: Option[TextSuggestion] = None,
     regex: ComparableRegex
-) extends BaseRule {
+) extends PatternRule {
 
   def toMatch(
       start: Int,
@@ -99,7 +119,7 @@ case class LTRuleXML(
     xml: String,
     category: Category,
     description: String
-) extends BaseRule {
+) extends PatternRule {
   val suggestions = List.empty
   val replacement: Option[TextSuggestion] = None
 }
@@ -122,7 +142,7 @@ case class LTRule(
     message: String,
     url: Option[String] = None,
     suggestions: List[TextSuggestion]
-) extends BaseRule {
+) extends PatternRule {
   val replacement: Option[TextSuggestion] = None
 }
 

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/model/RuleResource.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/model/RuleResource.scala
@@ -2,7 +2,7 @@ package com.gu.typerighter.model
 
 import play.api.libs.json.{Json, Reads, Writes}
 
-case class RuleResource(rules: List[BaseRule], ltDefaultRuleIds: List[String])
+case class RuleResource(rules: List[BaseRule])
 
 object RuleResource {
   implicit val writes: Writes[RuleResource] = Json.writes[RuleResource]

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/rules/BucketRuleManager.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/rules/BucketRuleManager.scala
@@ -15,7 +15,9 @@ class BucketRuleManager(s3: AmazonS3, bucketName: String, stage: String) extends
     val ruleJson = Json.toJson(ruleResource)
     val bytes = ruleJson.toString.getBytes(java.nio.charset.StandardCharsets.UTF_8.name)
 
-    logOnError(s"writing rules to S3 at $bucketName/$RULES_KEY with JSON hash ${ruleJson.hashCode}") {
+    logOnError(
+      s"writing rules to S3 at $bucketName/$RULES_KEY with JSON hash ${ruleJson.hashCode}"
+    ) {
       val stream: java.io.InputStream = new java.io.ByteArrayInputStream(bytes)
       val metaData = new ObjectMetadata()
       metaData.setContentLength(bytes.length)

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/rules/SheetsRuleManager.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/rules/SheetsRuleManager.scala
@@ -1,6 +1,15 @@
 package com.gu.typerighter.rules
 
-import com.gu.typerighter.model.{BaseRule, Category, ComparableRegex, LTDefaultRule, LTRuleXML, RegexRule, RuleResource, TextSuggestion}
+import com.gu.typerighter.model.{
+  BaseRule,
+  Category,
+  ComparableRegex,
+  LTRuleCore,
+  LTRuleXML,
+  RegexRule,
+  RuleResource,
+  TextSuggestion
+}
 import play.api.Logging
 
 import java.io._
@@ -124,11 +133,12 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String) extends 
               )
             )
           )
-        case (Some(id), _, "lt_default") => Success(
-          Some(
-            LTDefaultRule(id, id)
+        case (Some(id), _, "lt_core") =>
+          Success(
+            Some(
+              LTRuleCore(id, id)
+            )
           )
-        )
         case (Some(id), _, ruleType) =>
           Failure(new Exception(s"Rule type ${ruleType} for rule with id ${id} not supported"))
       }

--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -7,7 +7,7 @@ import scala.util.Try
 case class DbRule(
     id: Option[Int],
     ruleType: String,
-    pattern: String,
+    pattern: Option[String] = None,
     replacement: Option[String] = None,
     category: Option[String] = None,
     tags: Option[String] = None,
@@ -87,7 +87,7 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
 
   def create(
       ruleType: String,
-      pattern: String,
+      pattern: Option[String] = None,
       replacement: Option[String] = None,
       category: Option[String] = None,
       tags: Option[String] = None,

--- a/apps/rule-manager/app/service/DbRuleManager.scala
+++ b/apps/rule-manager/app/service/DbRuleManager.scala
@@ -1,7 +1,16 @@
 package service
 
 import com.gu.typerighter.lib.Loggable
-import com.gu.typerighter.model.{BaseRule, Category, ComparableRegex, LTRuleCore, LTRuleXML, RegexRule, RuleResource, TextSuggestion}
+import com.gu.typerighter.model.{
+  BaseRule,
+  Category,
+  ComparableRegex,
+  LTRuleCore,
+  LTRuleXML,
+  RegexRule,
+  RuleResource,
+  TextSuggestion
+}
 import db.DbRule
 
 object DbRuleManager extends Loggable {
@@ -35,7 +44,7 @@ object DbRuleManager extends Loggable {
           ignore = false,
           googleSheetId = Some(id)
         )
-      case LTRuleCore(id, languageToolRuleId) =>
+      case LTRuleCore(_, languageToolRuleId) =>
         DbRule(
           id = None,
           ruleType = RuleType.languageToolCore,
@@ -123,14 +132,17 @@ object DbRuleManager extends Loggable {
           Right(persistedRules)
         } else {
           val allRules = persistedRules.rules.zip(rules.rules)
-
-          allRules
+          log.error(s"Persisted rules differ.")
+          val diffRules = allRules
             .filter { case (persistedRule, expectedRule) => persistedRule != expectedRule }
-            .take(10)
-            .foreach { case (persistedRule, expectedRule) =>
-              log.error(s"Persisted rule: $persistedRule")
-              log.error(s"Expected rule: $expectedRule")
-            }
+
+          allRules.take(10).foreach { case (persistedRule, expectedRule) =>
+            log.error(s"Persisted rule: $persistedRule")
+            log.error(s"Expected rule: $expectedRule")
+          }
+
+          log.info((persistedRules.rules == rules.rules).toString)
+          log.info((persistedRules == rules).toString)
 
           Left(
             List(

--- a/apps/rule-manager/app/service/DbRuleManager.scala
+++ b/apps/rule-manager/app/service/DbRuleManager.scala
@@ -110,7 +110,7 @@ object DbRuleManager extends Loggable {
     failedDbRules match {
       case Nil =>
         val persistedRules =
-          RuleResource(rules = successfulDbRules, ltDefaultRuleIds = rules.ltDefaultRuleIds)
+          RuleResource(rules = successfulDbRules)
 
         if (persistedRules.rules == rules.rules) {
           Right(persistedRules)

--- a/apps/rule-manager/app/service/DbRuleManager.scala
+++ b/apps/rule-manager/app/service/DbRuleManager.scala
@@ -1,25 +1,23 @@
 package service
 
 import com.gu.typerighter.lib.Loggable
-import com.gu.typerighter.model.{
-  BaseRule,
-  Category,
-  ComparableRegex,
-  LTRuleXML,
-  RegexRule,
-  RuleResource,
-  TextSuggestion
-}
+import com.gu.typerighter.model.{BaseRule, Category, ComparableRegex, LTRuleCore, LTRuleXML, RegexRule, RuleResource, TextSuggestion}
 import db.DbRule
 
 object DbRuleManager extends Loggable {
+  object RuleType {
+    val regex = "regex"
+    val languageToolXML = "languageToolXML"
+    val languageToolCore = "languageToolCore"
+  }
+
   def baseRuleToDbRule(rule: BaseRule): DbRule = {
     rule match {
       case RegexRule(id, category, description, _, replacement, regex) =>
         DbRule(
           id = None,
-          ruleType = "regex",
-          pattern = regex.toString(),
+          ruleType = RuleType.regex,
+          pattern = Some(regex.toString()),
           category = Some(category.name),
           description = Some(description),
           replacement = replacement.map(_.text),
@@ -29,13 +27,20 @@ object DbRuleManager extends Loggable {
       case LTRuleXML(id, xml, category, description) =>
         DbRule(
           id = None,
-          ruleType = "languageTool",
-          pattern = xml,
+          ruleType = RuleType.languageToolXML,
+          pattern = Some(xml),
           category = Some(category.name),
           description = Some(description),
           replacement = None,
           ignore = false,
           googleSheetId = Some(id)
+        )
+      case LTRuleCore(id, languageToolRuleId) =>
+        DbRule(
+          id = None,
+          ruleType = RuleType.languageToolCore,
+          googleSheetId = Some(languageToolRuleId),
+          ignore = false
         )
     }
   }
@@ -44,8 +49,8 @@ object DbRuleManager extends Loggable {
     rule match {
       case DbRule(
             _,
-            "regex",
-            pattern,
+            RuleType.regex,
+            Some(pattern),
             replacement,
             Some(category),
             _,
@@ -68,8 +73,8 @@ object DbRuleManager extends Loggable {
         )
       case DbRule(
             _,
-            "languageTool",
-            pattern,
+            RuleType.languageToolXML,
+            Some(pattern),
             _,
             Some(category),
             _,
@@ -88,6 +93,8 @@ object DbRuleManager extends Loggable {
             xml = pattern
           )
         )
+      case DbRule(_, RuleType.languageToolCore, _, _, _, _, _, _, _, Some(googleSheetId), _, _) =>
+        Right(LTRuleCore(googleSheetId, googleSheetId))
       case other => Left(s"Could not derive BaseRule from DbRule for: $other")
     }
   }

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -55,7 +55,7 @@ const columns: Array<EuiBasicTableColumn<Rule>> = [
         field: 'category',
         name: 'Category',
         render: (category: Rule['category']) => {
-            return <>{category.name}</>
+            return <>{category?.name}</>
         }
     },
     {

--- a/apps/rule-manager/conf/evolutions/default/1.sql
+++ b/apps/rule-manager/conf/evolutions/default/1.sql
@@ -2,7 +2,7 @@
 
 -- !Ups
 
-CREATE TABLE Rules (
+CREATE TABLE rules (
       id SERIAL PRIMARY KEY,
       rule_type text NOT NULL,
       pattern text NOT NULL,
@@ -19,5 +19,4 @@ CREATE TABLE Rules (
 
 -- !Downs
 
-DROP TABLE Rules;
-DROP TYPE IF EXISTS ruleType;
+DROP TABLE rules;

--- a/apps/rule-manager/conf/evolutions/default/2.sql
+++ b/apps/rule-manager/conf/evolutions/default/2.sql
@@ -5,5 +5,5 @@ ALTER COLUMN pattern drop NOT NULL;
 
 -- !Downs
 
-ALTER TABLE rules
-ALTER COLUMN pattern add NOT NULL;
+UPDATE rules SET pattern = '' WHERE pattern IS NULL;
+ALTER TABLE rules ALTER COLUMN pattern SET NOT NULL;

--- a/apps/rule-manager/conf/evolutions/default/2.sql
+++ b/apps/rule-manager/conf/evolutions/default/2.sql
@@ -1,0 +1,9 @@
+-- !Ups
+
+ALTER TABLE rules
+ALTER COLUMN pattern drop NOT NULL;
+
+-- !Downs
+
+ALTER TABLE rules
+ALTER COLUMN pattern add NOT NULL;

--- a/apps/rule-manager/test/db/DbRuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/DbRuleManagerSpec.scala
@@ -1,6 +1,10 @@
 package db
 
+<<<<<<< HEAD
 import com.gu.typerighter.model.{Category, ComparableRegex, RegexRule, RuleResource}
+=======
+import com.gu.typerighter.model.{BaseRule, Category, ComparableRegex, LTRuleCore, LTRuleXML, RegexRule, RuleResource}
+>>>>>>> 6b9d7de2 (Update tests)
 import org.scalatest.flatspec.FixtureAnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import scalikejdbc.scalatest.AutoRollback
@@ -28,7 +32,7 @@ class DbRuleManagerSpec
 
   behavior of "DbRuleManager"
 
-  "destructivelyDumpRuleResourceToDB" should "add a single rule in a ruleResource, and read it back as an identical resource" in { implicit session =>
+  "destructivelyDumpRuleResourceToDB" should "add rules of each type in a ruleResource, and read it back as an identical resource" in { implicit session =>
     val rulesFromSheet = List(
       RegexRule(
         "faef1f8a-4ee2-4b97-8783-0566e27851da",
@@ -37,10 +41,20 @@ class DbRuleManagerSpec
         List(),
         None,
         new ComparableRegex("\b(children|sons?|daughters?) by")
+      ),
+      LTRuleXML(
+        "DATEFORMAT",
+        "<rulegroup></rulegroup>",
+        Category("Check this", "Check this"),
+        "An example description"
+      ),
+      LTRuleCore(
+        "DOUBLE_PUNCTUATION",
+        "DOUBLE_PUNCTUATION"
       )
     )
 
-    val rules = RuleResource(rules = rulesFromSheet, ltDefaultRuleIds = List.empty)
+    val rules = RuleResource(rules = rulesFromSheet)
     val rulesFromDb = DbRuleManager.destructivelyDumpRuleResourceToDB(rules)
 
     rulesFromDb.shouldEqual(Right(rules))
@@ -49,7 +63,7 @@ class DbRuleManagerSpec
   "destructivelyDumpRuleResourceToDB" should "add 1000 randomly generated rules in a ruleResource, and read them back from the DB as an identical resource" in { implicit session =>
     val rulesFromSheet = createRandomRules(1000)
 
-    val rules = RuleResource(rules = rulesFromSheet, ltDefaultRuleIds = List.empty)
+    val rules = RuleResource(rules = rulesFromSheet)
     val rulesFromDb = DbRuleManager.destructivelyDumpRuleResourceToDB(rules)
 
     rulesFromDb.shouldEqual(Right(rules))
@@ -57,11 +71,11 @@ class DbRuleManagerSpec
 
   "destructivelyDumpRuleResourceToDB" should "remove old rules before adding new ones" in { implicit session =>
     val firstRules = createRandomRules(10)
-    DbRuleManager.destructivelyDumpRuleResourceToDB(RuleResource(firstRules, List.empty))
+    DbRuleManager.destructivelyDumpRuleResourceToDB(RuleResource(firstRules))
 
     val secondRules = createRandomRules(10)
-    val secondRulesFromDb = DbRuleManager.destructivelyDumpRuleResourceToDB(RuleResource(secondRules, List.empty))
+    val secondRulesFromDb = DbRuleManager.destructivelyDumpRuleResourceToDB(RuleResource(secondRules))
 
-    secondRulesFromDb.shouldEqual(Right(RuleResource(secondRules, List.empty)))
+    secondRulesFromDb.shouldEqual(Right(RuleResource(secondRules)))
   }
 }

--- a/apps/rule-manager/test/db/DbRuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/DbRuleManagerSpec.scala
@@ -1,10 +1,6 @@
 package db
 
-<<<<<<< HEAD
-import com.gu.typerighter.model.{Category, ComparableRegex, RegexRule, RuleResource}
-=======
-import com.gu.typerighter.model.{BaseRule, Category, ComparableRegex, LTRuleCore, LTRuleXML, RegexRule, RuleResource}
->>>>>>> 6b9d7de2 (Update tests)
+import com.gu.typerighter.model.{Category, ComparableRegex, LTRuleCore, LTRuleXML, RegexRule, RuleResource}
 import org.scalatest.flatspec.FixtureAnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import scalikejdbc.scalatest.AutoRollback

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -41,12 +41,12 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     count should be >(0L)
   }
   it should "create new record" in { implicit session =>
-    val created = DbRule.create(ruleType = "regex", pattern = "MyString", ignore = false)
+    val created = DbRule.create(ruleType = "regex", pattern = Some("MyString"), ignore = false)
     created should not be(null)
   }
   it should "save a record" in { implicit session =>
     val entity = DbRule.findAll().head
-    val modified = entity.copy(pattern="NotMyString")
+    val modified = entity.copy(pattern = Some("NotMyString"))
     val updated = DbRule.save(modified)
     updated should equal(Success(modified))
   }

--- a/localstack/init-aws.sh
+++ b/localstack/init-aws.sh
@@ -2,6 +2,6 @@
 
 awslocal s3 mb s3://typerighter-app-local
 
-json='{"rules": [], "ltDefaultRuleIds":[]}'
+json='{"rules": []}'
 echo "$json" > typerighter-rules.json
 awslocal s3 cp typerighter-rules.json s3://typerighter-app-local/local/rules/typerighter-rules.json


### PR DESCRIPTION
**A reminder before merging:** we need to ensure these rules are added to the PROD sheet as this PR is merged – but not before, as the new rules will cause parsing errors for older builds.

## What does this change?

Add LanguageTool default rules to persisted rules. They can be added to the Google sheet as with other rules. The only two cells needed are 'Rule type', which should be `lt_core`, and ID.

## Dev notes

There are a couple of decisions in this PR:

- I've used `core` rather than `default` to describe the internally defined LanguageTool rules, as I think it better describes what these rules are. Looking back, maybe this isn't such a big deal!
- These rules are modelled in the database (rather than, for example, hardcoded in VCS). My reasoning here is that editorial should be able to search for these rules, see them described, and turn them on and off at will – as with any other rule.
- They're modelled as the other two rule types we currently support are modelled – using the 'one table per inheritance hierarchy' method. There's a good introduction to the alternatives [here.](https://vertabelo.com/blog/inheritance-in-database/) These rules only need to be described by a `ruleType` and a `googleSheetId` at present, so they leave behind a sparse record. I'm keen to avoid the complexity of the other two modelling approaches if possible, as I don't think the additional safety is worth the implementation cost, but this is something other devs might reasonably disagree with – let me know if you think another approach might be better.

## How to test

- The tests should pass. They include a new instance of this rule, and an additional check that we're removing existing rules from the DB (this was not previously the case – 2615773eee33cca83a9c413b527db378d90a3e78)
- Running locally or in CODE, add the following data to the sheet, and reingest the rules. The following copy should trigger each rule, with the exception of the paragraph end rule, which I think we can probably safely remove (the LanguageTool matcher cannot reason across paragraphs just yet.)

<details>
<summary>Rules</summary>

|Rule type| ID |
|--|--|
| lt_core | COMMA_PARENTHESIS_WHITESPACE |
| lt_core | DOUBLE_PUNCTUATION |
| lt_core | UPPERCASE_SENTENCE_START |
| lt_core | WHITESPACE_RULE |
| lt_core | SENTENCE_WHITESPACE |
| lt_core | PUNCTUATION_PARAGRAPH_END |
| lt_core | NO_SPACE_CLOSING_QUOTE |
| lt_core | PUBIC_X |
| lt_core | IN_PRINCIPAL |
| lt_core | CURRENCY_SPACE |
</details>

<details>
<summary>Copy</summary>

COMMA_PARENTHESIS_WHITESPACE

Use of whitespace before comma and before/after parentheses ,

DOUBLE_PUNCTUATION

Use of two consecutive dots or commas .. ,,

UPPERCASE_SENTENCE_START

checks that a sentence starts with an uppercase letter

WHITESPACE_RULE

Whitespace repetition  (bad formatting)

SENTENCE_WHITESPACE

Missing space.Between sentences.

PUNCTUATION_PARAGRAPH_END

No punctuation mark at the end of paragraph. It seems that another para is fine.

NO_SPACE_CLOSING_QUOTE

“An example of this”and another thing

PUBIC_X

Commonly Confused Words. Pubic education etc.

IN_PRINCIPAL

In principal, the principle was in his office.

CURRENCY_SPACE

Whitespace after currency symbols: ‘$ 100’ ($100)

</details>

[Test article in CODE.](https://composer.code.dev-gutools.co.uk/content/641c57a18f08e22b6b740a21)

The result should look something like:

<img width="1266" alt="Screenshot 2023-03-28 at 13 38 45" src="https://user-images.githubusercontent.com/7767575/228238657-6813fe9f-99d5-4bb7-bd67-9a65e1fc2944.png">

- [x] Tested locally.
- [x] Tested in CODE.