### PR TITLE
Increase timeout for GHA

### DIFF
--- a/apps/checker/test/scala/services/MatcherPoolTest.scala
+++ b/apps/checker/test/scala/services/MatcherPoolTest.scala
@@ -103,7 +103,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     maxCurrentJobs: Int = 4,
     maxQueuedJobs: Int = 100,
     strategy: MatcherPool.CheckStrategy = MatcherPool.documentPerCategoryCheckStrategy,
-    checkTimeoutDuration: FiniteDuration = 100 milliseconds
+    checkTimeoutDuration: FiniteDuration = 500 milliseconds
   ): MatcherPool = {
     val futures = new DefaultFutures(system)
     val pool = new MatcherPool(maxCurrentJobs, maxQueuedJobs, strategy, futures, checkTimeoutDuration = checkTimeoutDuration)


### PR DESCRIPTION
## What does this change?

We've some flaky tests, possibly as a result of GHA running our tests in a slower environment. The tests relate to matcher timeouts, so let's increase the default and see if things improve.

## How to test

The tests should pass in GHA.