### PR TITLE
Remove refresh logic from the Checker app

### DIFF
--- a/apps/checker/app/AppComponents.scala
+++ b/apps/checker/app/AppComponents.scala
@@ -101,6 +101,7 @@ class AppComponents(
     case identity: AwsIdentity => identity.stage.toLowerCase
     case _: DevIdentity        => "local"
   }
+
   val typerighterBucket = s"typerighter-app-${stage}"
 
   val cloudWatchClient = identity match {
@@ -123,12 +124,19 @@ class AppComponents(
     cloudWatchClient
   )
 
+  val rulesManagerUrl = identity match {
+    case identity: AwsIdentity if identity.stage == "PROD" => "https://manager.typerighter.gutools.co.uk"
+    case identity: AwsIdentity => s"https://manager.typerighter.${identity.stage.toLowerCase}.dev-gutools.co.uk"
+    case _: DevIdentity => "https://manager.typerighter.local.dev-gutools.co.uk"
+  }
+
   val apiController = new ApiController(controllerComponents, matcherPool, publicSettings)
   val rulesController = new RulesController(
     controllerComponents,
     matcherPool,
     config.spreadsheetId,
-    publicSettings
+    publicSettings,
+    rulesManagerUrl,
   )
   val homeController = new HomeController(controllerComponents, publicSettings)
   val auditController = new AuditController(controllerComponents, publicSettings)

--- a/apps/checker/app/AppComponents.scala
+++ b/apps/checker/app/AppComponents.scala
@@ -124,9 +124,11 @@ class AppComponents(
     cloudWatchClient
   )
 
-  val rulesManagerUrl = identity match {
-    case identity: AwsIdentity if identity.stage == "PROD" => "https://manager.typerighter.gutools.co.uk"
-    case identity: AwsIdentity => s"https://manager.typerighter.${identity.stage.toLowerCase}.dev-gutools.co.uk"
+  private val ruleManagerUrl = identity match {
+    case identity: AwsIdentity if identity.stage == "PROD" =>
+      "https://manager.typerighter.gutools.co.uk"
+    case identity: AwsIdentity =>
+      s"https://manager.typerighter.${identity.stage.toLowerCase}.dev-gutools.co.uk"
     case _: DevIdentity => "https://manager.typerighter.local.dev-gutools.co.uk"
   }
 
@@ -136,7 +138,7 @@ class AppComponents(
     matcherPool,
     config.spreadsheetId,
     publicSettings,
-    rulesManagerUrl,
+    ruleManagerUrl
   )
   val homeController = new HomeController(controllerComponents, publicSettings)
   val auditController = new AuditController(controllerComponents, publicSettings)

--- a/apps/checker/app/AppComponents.scala
+++ b/apps/checker/app/AppComponents.scala
@@ -123,16 +123,11 @@ class AppComponents(
     cloudWatchClient
   )
 
-  val sheetsRuleManager = new SheetsRuleManager(config.credentials, config.spreadsheetId)
-
   val apiController = new ApiController(controllerComponents, matcherPool, publicSettings)
   val rulesController = new RulesController(
     controllerComponents,
     matcherPool,
-    sheetsRuleManager,
-    bucketRuleManager,
     config.spreadsheetId,
-    ruleProvisioner,
     publicSettings
   )
   val homeController = new HomeController(controllerComponents, publicSettings)

--- a/apps/checker/app/controllers/RulesController.scala
+++ b/apps/checker/app/controllers/RulesController.scala
@@ -19,7 +19,6 @@ class RulesController(
     with PandaAuthentication {
 
   def rules = ApiAuthAction { implicit request: Request[AnyContent] =>
-
     Ok(
       views.html.rules(
         sheetId,

--- a/apps/checker/app/controllers/RulesController.scala
+++ b/apps/checker/app/controllers/RulesController.scala
@@ -12,17 +12,20 @@ class RulesController(
     cc: ControllerComponents,
     matcherPool: MatcherPool,
     sheetId: String,
-    val publicSettings: PublicSettings
+    val publicSettings: PublicSettings,
+    val ruleManagerUrl: String
 )(implicit ec: ExecutionContext)
     extends AbstractController(cc)
     with PandaAuthentication {
 
   def rules = ApiAuthAction { implicit request: Request[AnyContent] =>
+
     Ok(
       views.html.rules(
         sheetId,
         matcherPool.getCurrentRules,
-        matcherPool.getCurrentMatchers
+        matcherPool.getCurrentMatchers,
+        ruleManagerUrl
       )
     )
   }

--- a/apps/checker/app/controllers/RulesController.scala
+++ b/apps/checker/app/controllers/RulesController.scala
@@ -2,10 +2,8 @@ package controllers
 
 import com.gu.pandomainauth.PublicSettings
 import com.gu.typerighter.lib.PandaAuthentication
-import com.gu.typerighter.rules.{BucketRuleManager, SheetsRuleManager}
 import play.api.mvc._
 import services._
-
 import scala.concurrent.ExecutionContext
 
 /** The controller that handles the management of matcher rules.
@@ -13,52 +11,11 @@ import scala.concurrent.ExecutionContext
 class RulesController(
     cc: ControllerComponents,
     matcherPool: MatcherPool,
-    sheetsRuleManager: SheetsRuleManager,
-    bucketRuleManager: BucketRuleManager,
     sheetId: String,
-    ruleProvisioner: RuleProvisionerService,
     val publicSettings: PublicSettings
 )(implicit ec: ExecutionContext)
     extends AbstractController(cc)
     with PandaAuthentication {
-  def refresh = ApiAuthAction { implicit request: Request[AnyContent] =>
-    sheetsRuleManager.getRules().flatMap { ruleResource =>
-      val maybeRules = bucketRuleManager.putRules(ruleResource).flatMap { _ =>
-        bucketRuleManager.getRulesLastModified.map { lastModified =>
-          (ruleResource, lastModified)
-        }
-      }
-      maybeRules.left.map { error => List(error.getMessage) }
-    } match {
-      case Right((ruleResource, lastModified)) =>
-        val ruleErrors = ruleProvisioner.updateRules(ruleResource, lastModified) match {
-          case Right(())    => Nil
-          case Left(errors) => errors.map(_.getMessage)
-        }
-        val currentRules = matcherPool.getCurrentRules
-        Ok(
-          views.html.rules(
-            sheetId,
-            currentRules,
-            matcherPool.getCurrentMatchers,
-            Some(true),
-            Some(currentRules.size),
-            ruleErrors
-          )
-        )
-      case Left(errors) =>
-        Ok(
-          views.html.rules(
-            sheetId,
-            matcherPool.getCurrentRules,
-            matcherPool.getCurrentMatchers,
-            Some(false),
-            Some(0),
-            errors
-          )
-        )
-    }
-  }
 
   def rules = ApiAuthAction { implicit request: Request[AnyContent] =>
     Ok(

--- a/apps/checker/app/views/rules.scala.html
+++ b/apps/checker/app/views/rules.scala.html
@@ -1,13 +1,20 @@
-
 @import helper._
 
 @import com.gu.typerighter.model.BaseRule
 @import com.gu.typerighter.model.RegexRule
 @import com.gu.typerighter.model.LTRule
 @import utils.Matcher
-@(sheetId: String, rules: scala.List[BaseRule], matchers: scala.List[Matcher],
-        rulesIngested: Option[Int] = None, errors: List[String] = List.empty)(implicit req: RequestHeader)
+
+@import com.gu.typerighter.model.LTRuleXML
+@(sheetId: String, rules: scala.List[BaseRule], matchers: scala.List[Matcher], ruleManagerUrl: String,
+rulesIngested: Option[Int] = None, errors: List[String] = List.empty)(implicit req: RequestHeader)
 @main(title = "Typerighter", breadcrumbsList = List("Rules")) {
+    <h1 class="align-middle mb-4">
+        Current rules
+    </h1>
+  <div class="pb-3 align-content-end">
+      <aside >Looking for the refresh button? It's moved <a href="@ruleManagerUrl" target="_blank">here</a></aside>
+  </div>
     <div class="row">
         <div class="col-sm-5">
             <h5>Matchers (@matchers.size)</h5>
@@ -23,7 +30,7 @@
                 @for(matcher <- matchers) {
                     <tr>
                         <td>
-                          @matcher.getType()
+                        @matcher.getType()
                         </td>
                         <td>@matcher.getCategories().map(_.id).mkString(", ")</td>
                         <td>@matcher.getRules().size</td>
@@ -48,27 +55,27 @@
                 @for(rule <- rules) {
                     <tr>
                         <td>@rule match {
-                          case r: RegexRule => { regex }
-                          case r: LTRule => { languagetool }
-                          case _ => { unknown }
+                            case r: RegexRule => { regex }
+                            case r: LTRule => { languagetool }
+                            case _ => { unknown }
                         }
                         </td>
                         <td>
-                          @rule.id
+                        @rule.id
                         </td>
                         <td>
-                          @rule.category.name
+                        @rule.category.name
                         </td>
                         <td>@rule match {
-                          case r: RegexRule => { @r.regex.toString.slice(0, 30) }
-                          case _ => { N/A }
+                            case r: RegexRule => { @r.regex.toString.slice(0, 30) }
+                            case _ => { N/A }
                         }</td>
                         <td>
-                          @rule match {
+                        @rule match {
                             case p: RegexRule if p.description.nonEmpty => { @p.description }
                             case p: LTRuleXML if p.description.nonEmpty => { @p.description }
                             case _ => { N/A }
-                          }
+                        }
                         </td>
                     </tr>
                 }

--- a/apps/checker/app/views/rules.scala.html
+++ b/apps/checker/app/views/rules.scala.html
@@ -5,32 +5,9 @@
 @import com.gu.typerighter.model.RegexRule
 @import com.gu.typerighter.model.LTRule
 @import utils.Matcher
-
-@import com.gu.typerighter.model.LTRuleXML
-@(sheetId: String, rules: scala.List[BaseRule], matchers: scala.List[Matcher], rulesRefreshed: Option[Boolean] = None,
+@(sheetId: String, rules: scala.List[BaseRule], matchers: scala.List[Matcher],
         rulesIngested: Option[Int] = None, errors: List[String] = List.empty)(implicit req: RequestHeader)
 @main(title = "Typerighter", breadcrumbsList = List("Rules")) {
-    @form(CSRF(routes.RulesController.refresh())) {
-        @CSRF.formField
-        <h1 class="align-middle mb-4">
-            Current rules
-            <button class="btn btn-primary btn-sm ml-3">Refresh rules</button>
-        </h1>
-    }
-    @if(rulesRefreshed.isInstanceOf[Some[Boolean]] ) {
-        <div class="alert alert-@if(errors != Nil) {danger} else {success}" role="alert">
-            @if(rulesRefreshed == Some(true)){
-                Rules were refreshed, @rulesIngested.getOrElse("No") found. These rules will be available within a minute. @if(errors != Nil) {Errors found: @errors.size}
-            } else {
-                Rules were not refreshed due to errors. @if(errors != Nil) {Errors found: @errors.size}
-            }
-            <ul>
-                @for(error <- errors) {
-                    <li>@error</li>
-                }
-            </ul>
-        </div>
-    }
     <div class="row">
         <div class="col-sm-5">
             <h5>Matchers (@matchers.size)</h5>

--- a/apps/checker/app/views/rules.scala.html
+++ b/apps/checker/app/views/rules.scala.html
@@ -12,7 +12,7 @@ rulesIngested: Option[Int] = None, errors: List[String] = List.empty)(implicit r
     <h1 class="align-middle mb-4">
         Current rules
     </h1>
-  <div class="pb-3 align-content-end">
+  <div class="pb-3">
       <aside >Looking for the refresh button? It's moved <a href="@ruleManagerUrl" target="_blank">here</a></aside>
   </div>
     <div class="row">

--- a/apps/checker/conf/routes
+++ b/apps/checker/conf/routes
@@ -8,14 +8,13 @@ GET     /assets/*file               controllers.Assets.versioned(path="/public",
 GET     /                           controllers.HomeController.index()
 GET     /healthcheck                controllers.HomeController.healthcheck()
 
-POST    /refresh                    controllers.RulesController.refresh()
 GET     /rules                      controllers.RulesController.rules()
 
 GET     /audit                      controllers.AuditController.index()
 
-+ nocsrf
++nocsrf
 POST    /check                      controllers.ApiController.check()
-+ nocsrf
++nocsrf
 POST    /checkStream                controllers.ApiController.checkStream
 
 GET     /categories                 controllers.ApiController.getCurrentCategories()

--- a/docs/03-composer-integration.md
+++ b/docs/03-composer-integration.md
@@ -34,5 +34,5 @@ Correct this, and click "Check whole document" again.  Both names should now be 
 ## Developing new typerighter rules.
 
 If you wish to test new rules, you should visit the google doc (see [here](./02-google-sheet.md)) and edit appropriately
-Once you have added a rule to the doc, you must visit the [local typerighter rules page](http://localhost:9000/rules) 
+Once you have added a rule to the doc, you must visit the [local typerighter rules page](https://manager.typerighter.local.dev-gutools.co.uk/) 
 and click the "refresh rules" button.

--- a/script/start-manager
+++ b/script/start-manager
@@ -24,6 +24,7 @@ setupDependencies() {
 
 teardownDependencies() {
   docker-compose down
+  kill -9 $(lsof -ti:9100) # terminates the rule manager app
 }
 
 runRuleManager() {


### PR DESCRIPTION
plus a small update to start script in the rules manager app to automatically terminate the app on `ctrl+c`

- Removes Route
- Removes controller logic
- Removes UI elements of refresh from checker.

## What does this change?

After this change, users will no longer be able to trigger a refresh of the rules from the checker app. Instead, the rule manager UI should be used to pull in changes from the google sheet

## How to test

Test that rules are still displayed in the app

## Have we considered potential risks?

We should make sure that all rule maintainers know about the new UI available in the [rule manager app](https://manager.typerighter.gutools.co.uk/)


## Images

![Screenshot 2023-03-29 at 12 05 40](https://user-images.githubusercontent.com/3277259/228514775-dae6a08b-a213-4d5e-8def-b11829ede456.png)

Tested locally