### PR TITLE
Use `npm ci` in ci to fail early where there are packages in the package.json which are not referenced in the package-lock.json

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,12 +31,12 @@ jobs:
       - name: build rule-manager-client
         working-directory: ./apps/rule-manager/client
         run: |
-          npm i
+          npm ci
           npm run build
       - name: build rule-audit-client
         working-directory: ./apps/rule-audit-client
         run: |
-          npm i
+          npm ci
           npm run build
       - name: cdk synth
         working-directory: ./cdk


### PR DESCRIPTION
## What does this change?

Uses `npm ci` rather than `npm i` in ci to expose issues in package lock at the PR stage

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

If this PR builds, we're probably fine

## How can we measure success?

Everything still works

## Have we considered potential risks?

This presents a reduction in risk and should prevent merges to main where there are libraries in the `package,json` for which we have no corresponding version in the lock

