### PR TITLE
Add additional properties to the rule model

### DIFF
--- a/apps/rule-manager/app/AppComponents.scala
+++ b/apps/rule-manager/app/AppComponents.scala
@@ -15,11 +15,12 @@ import com.gu.pandomainauth.{PanDomainAuthSettingsRefresher, PublicSettings}
 import com.gu.AwsIdentity
 import com.gu.AppIdentity
 import com.gu.DevIdentity
-import com.gu.typerighter.rules.{BucketRuleManager, SheetsRuleManager}
+import com.gu.typerighter.rules.BucketRuleManager
 import router.Routes
 import db.DB
 import play.api.db.evolutions.EvolutionsComponents
 import play.api.db.{DBComponents, HikariCPComponents}
+import service.SheetsRuleManager
 import utils.RuleManagerConfig
 
 class AppComponents(

--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -247,7 +247,9 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
         Symbol("forceRedRule") -> entity.forceRedRule,
         Symbol("advisoryRule") -> entity.advisoryRule,
         Symbol("createdBy") -> entity.createdBy,
-        Symbol("updatedBy") -> entity.updatedBy
+        Symbol("createdAt") -> entity.createdAt,
+        Symbol("updatedBy") -> entity.updatedBy,
+        Symbol("updatedAt") -> entity.updatedAt
       )
     )
     SQL("""insert into rules(
@@ -263,7 +265,9 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
       force_red_rule,
       advisory_rule,
       created_by,
-      updated_by
+      created_at,
+      updated_by,
+      updated_at
     ) values (
       {ruleType},
       {pattern},
@@ -277,7 +281,9 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
       {forceRedRule},
       {advisoryRule},
       {createdBy},
-      {updatedBy}
+      {createdAt},
+      {updatedBy},
+      {updatedAt}
     )""").batchByName(params.toSeq: _*).apply[List]()
   }
 

--- a/apps/rule-manager/app/service/DbRuleManager.scala
+++ b/apps/rule-manager/app/service/DbRuleManager.scala
@@ -167,10 +167,12 @@ object DbRuleManager extends Loggable {
         val persistedRules =
           CheckerRuleResource(rules = successfulDbRules)
 
-        if (persistedRules.rules == rules) {
+        val incomingRules = rules.map(dbRuleToCheckerRule).flatMap(_.toOption)
+
+        if (persistedRules.rules == incomingRules) {
           Right(persistedRules)
         } else {
-          val allRules = persistedRules.rules.zip(rules)
+          val allRules = persistedRules.rules.zip(incomingRules)
           log.error(s"Persisted rules differ.")
 
           allRules.take(10).foreach { case (persistedRule, expectedRule) =>

--- a/apps/rule-manager/app/service/DbRuleManager.scala
+++ b/apps/rule-manager/app/service/DbRuleManager.scala
@@ -148,19 +148,23 @@ object DbRuleManager extends Loggable {
 
   def getRules()(implicit session: DBSession = autoSession): List[DbRule] = DbRule.findAll()
 
-  def createCheckerRuleResourceFromDbRules(dbRules: List[DbRule]): Either[List[String], CheckerRuleResource] = {
+  def createCheckerRuleResourceFromDbRules(
+      dbRules: List[DbRule]
+  ): Either[List[String], CheckerRuleResource] = {
     val (failedDbRules, successfulDbRules) = dbRules
       .filter(_.ignore == false)
       .map(dbRuleToCheckerRule)
       .partitionMap(identity)
 
     failedDbRules match {
-      case Nil => Right(CheckerRuleResource(successfulDbRules))
+      case Nil      => Right(CheckerRuleResource(successfulDbRules))
       case failures => Left(failures)
     }
   }
 
-  def destructivelyDumpRulesToDB(incomingRules: List[DbRule]): Either[List[String], List[DbRule]] = {
+  def destructivelyDumpRulesToDB(
+      incomingRules: List[DbRule]
+  ): Either[List[String], List[DbRule]] = {
     DbRule.destroyAll()
 
     incomingRules

--- a/apps/rule-manager/app/service/SheetsRuleManager.scala
+++ b/apps/rule-manager/app/service/SheetsRuleManager.scala
@@ -103,7 +103,7 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String) extends 
         case (Some(id), _, _) if id.isEmpty =>
           Failure(new Exception(s"empty id for rule (row: ${rowNumber})"))
         case (Some(id), _, None) =>
-        Failure(new Exception(s"Rule type ${ruleType} for rule with id ${id} not supported"))
+          Failure(new Exception(s"Rule type ${ruleType} for rule with id ${id} not supported"))
         case (Some(_), None, _) =>
           Failure(new Exception(s"no Ignore column for rule (row: ${rowNumber})"))
         case (Some(id), Some(ignore), Some(ruleType)) =>

--- a/apps/rule-manager/app/service/SheetsRuleManager.scala
+++ b/apps/rule-manager/app/service/SheetsRuleManager.scala
@@ -78,7 +78,7 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String) extends 
             }
           }
 
-      if (errors.size != 0) {
+      if (errors.nonEmpty) {
         Left(errors)
       } else {
         Right(rules)
@@ -94,7 +94,6 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String) extends 
       val rowNumber = index + 1
 
       (maybeId, maybeIgnore, ruleType) match {
-        case (_, Some("TRUE"), _) => Success(None)
         case (None, _, _)         => Failure(new Exception(s"no id for rule (row: ${rowNumber})"))
         case (Some(id), _, _) if id.isEmpty =>
           Failure(new Exception(s"empty id for rule (row: ${rowNumber})"))

--- a/apps/rule-manager/app/service/SheetsRuleManager.scala
+++ b/apps/rule-manager/app/service/SheetsRuleManager.scala
@@ -1,36 +1,29 @@
-package com.gu.typerighter.rules
+package service
 
-import com.gu.typerighter.model.{
-  CheckerRule,
-  Category,
-  ComparableRegex,
-  LTRuleCore,
-  LTRuleXML,
-  RegexRule,
-  CheckerRuleResource,
-  TextSuggestion
-}
 import play.api.Logging
-
 import java.io._
 import java.util.Collections
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.sheets.v4.{Sheets, SheetsScopes}
-
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
+import db.DbRule
 
 object PatternRuleCols {
   val Type = 0
   val Pattern = 1
-  val Suggestion = 2
+  val Replacement = 2
   val Colour = 3
   val Category = 4
   val Description = 6
+  val Tags = 7
   val ShouldIgnore = 8
+  val Notes = 9
   val Id = 10
+  val ForceRed = 11
+  val Advisory = 13
 }
 
 /** A resource that gets rules from the given Google Sheet.
@@ -52,15 +45,13 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String) extends 
     credentials
   ).setApplicationName(APPLICATION_NAME).build
 
-  def getRules(): Either[List[String], CheckerRuleResource] = {
-    val maybeRules = getPatternRules()
-
-    maybeRules.map(CheckerRuleResource(_))
+  def getRules(): Either[List[String], List[DbRule]] = {
+    getPatternRules()
   }
 
   /** Get rules that match using patterns, e.g. `RegexRule`, `LTRule`.
     */
-  private def getPatternRules(): Either[List[String], List[CheckerRule]] = {
+  private def getPatternRules(): Either[List[String], List[DbRule]] = {
     getRulesFromSheet("regexRules", "A:N", getRuleFromRow)
   }
 
@@ -95,7 +86,7 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String) extends 
     }
   }
 
-  private def getRuleFromRow(row: List[Any], index: Int): Try[Option[CheckerRule]] = {
+  private def getRuleFromRow(row: List[Any], index: Int): Try[Option[DbRule]] = {
     try {
       val ruleType = row(PatternRuleCols.Type)
       val maybeIgnore = row.lift(PatternRuleCols.ShouldIgnore)
@@ -105,39 +96,25 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String) extends 
       (maybeId, maybeIgnore, ruleType) match {
         case (_, Some("TRUE"), _) => Success(None)
         case (None, _, _)         => Failure(new Exception(s"no id for rule (row: ${rowNumber})"))
-        case (Some(id), _, _) if id.length == 0 =>
+        case (Some(id), _, _) if id.isEmpty =>
           Failure(new Exception(s"empty id for rule (row: ${rowNumber})"))
-        case (Some(id), _, "regex") =>
-          Success(
-            Some(
-              getRegexRule(
-                id,
-                row(PatternRuleCols.Pattern).asInstanceOf[String],
-                row(PatternRuleCols.Suggestion).asInstanceOf[String],
-                row(PatternRuleCols.Category).asInstanceOf[String],
-                row.lift(PatternRuleCols.Description).asInstanceOf[Option[String]]
-              )
-            )
-          )
-        case (Some(id), _, "lt") =>
-          Success(
-            Some(
-              getLTRuleXML(
-                id,
-                row(PatternRuleCols.Pattern).asInstanceOf[String],
-                row(PatternRuleCols.Category).asInstanceOf[String],
-                row(PatternRuleCols.Description).asInstanceOf[String]
-              )
-            )
-          )
-        case (Some(id), _, "lt_core") =>
-          Success(
-            Some(
-              LTRuleCore(id, id)
-            )
-          )
-        case (Some(id), _, ruleType) =>
+        case (Some(id), _, ruleType) if !Set("regex", "lt", "lt_core").contains(ruleType.toString) =>
           Failure(new Exception(s"Rule type ${ruleType} for rule with id ${id} not supported"))
+        case (Some(id), Some(ignore), ruleType) => Success(Some(DbRule.withUser(
+          id = None,
+          ruleType = ruleType.asInstanceOf[String],
+          pattern = row.lift(PatternRuleCols.Pattern).asInstanceOf[Option[String]],
+          replacement = row.lift(PatternRuleCols.Replacement).asInstanceOf[Option[String]],
+          category = row.lift(PatternRuleCols.Category).asInstanceOf[Option[String]],
+          tags = row.lift(PatternRuleCols.Tags).asInstanceOf[Option[String]],
+          description = row.lift(PatternRuleCols.Description).asInstanceOf[Option[String]],
+          ignore = if (ignore.toString == "TRUE") true else false,
+          notes = row.lift(PatternRuleCols.Replacement).asInstanceOf[Option[String]],
+          googleSheetId = Some(id),
+          forceRedRule = Some(row.lift(PatternRuleCols.ForceRed).asInstanceOf[Option[String]].contains("y")),
+          advisoryRule = Some(row.lift(PatternRuleCols.Advisory).asInstanceOf[Option[String]].contains("y")),
+          user = "Google Sheet"
+        )))
       }
 
     } catch {
@@ -145,29 +122,6 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String) extends 
         Failure(new Exception(s"Error parsing rule at index ${index} – ${e.getMessage()}"))
       }
     }
-  }
-
-  private def getRegexRule(
-      id: String,
-      pattern: String,
-      suggestion: String,
-      category: String,
-      description: Option[String]
-  ) = RegexRule(
-    id = id,
-    category = Category(category, category),
-    description = description.getOrElse(""),
-    replacement = if (suggestion.isEmpty) None else Some(TextSuggestion(suggestion)),
-    regex = new ComparableRegex(pattern)
-  )
-
-  private def getLTRuleXML(
-      id: String,
-      pattern: String,
-      category: String,
-      description: String
-  ) = {
-    LTRuleXML(id, pattern, Category(category, category), description)
   }
 
   /** Creates an authorized Credential object.

--- a/apps/rule-manager/client/package-lock.json
+++ b/apps/rule-manager/client/package-lock.json
@@ -1610,6 +1610,18 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
@@ -3892,6 +3904,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "postcss": {

--- a/apps/rule-manager/test/db/DbRuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/DbRuleManagerSpec.scala
@@ -29,8 +29,8 @@ class DbRuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollba
         ignore = ignore,
         notes = Some(s"\b(${Random.shuffle(List("some", "random", "notes", "to", "test"))})"),
         googleSheetId = Some(s"rule-at-index-${ruleIndex}"),
-        forceRedRule = Some(math.random < 0.25),
-        advisoryRule = Some(math.random < 0.75),
+        forceRedRule = Some(true),
+        advisoryRule = Some(true),
         user = "Google Sheet",
         ruleType = "regex",
       )
@@ -40,7 +40,7 @@ class DbRuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollba
   behavior of "DbRuleManager"
 
   "destructivelyDumpRuleResourceToDB" should "add rules of each type in a ruleResource, and read it back as an identical resource" in {
-    implicit session =>
+    () =>
       val rulesFromSheet = List(
         RegexRule(
           "faef1f8a-4ee2-4b97-8783-0566e27851da",
@@ -69,7 +69,7 @@ class DbRuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollba
   }
 
   "destructivelyDumpRulesToDB" should "add 1000 randomly generated rules in a ruleResource, and read them back from the DB as an identical resource" in {
-    implicit session =>
+    () =>
       val rules = createRandomRules(1000)
       val rulesFromDb = DbRuleManager.destructivelyDumpRulesToDB(rules).map(_.map(_.copy(id = None)))
 
@@ -77,7 +77,7 @@ class DbRuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollba
   }
 
   "destructivelyDumpRulesToDB" should "remove old rules before adding new ones" in {
-    implicit session =>
+    () =>
       val firstRules = createRandomRules(10)
       DbRuleManager.destructivelyDumpRulesToDB(firstRules)
 

--- a/apps/rule-manager/test/db/DbRuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/DbRuleManagerSpec.scala
@@ -56,7 +56,7 @@ class DbRuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollba
         )
       )
 
-      val rules = CheckerRuleResource(rules = rulesFromSheet)
+      val rules = rulesFromSheet.map(DbRuleManager.checkerRuleToDbRule)
       val rulesFromDb = DbRuleManager.destructivelyDumpRuleResourceToDB(rules)
 
       rulesFromDb.shouldEqual(Right(rules))
@@ -66,7 +66,7 @@ class DbRuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollba
     implicit session =>
       val rulesFromSheet = createRandomRules(1000)
 
-      val rules = CheckerRuleResource(rules = rulesFromSheet)
+      val rules = rulesFromSheet.map(DbRuleManager.checkerRuleToDbRule)
       val rulesFromDb = DbRuleManager.destructivelyDumpRuleResourceToDB(rules)
 
       rulesFromDb.shouldEqual(Right(rules))
@@ -74,12 +74,12 @@ class DbRuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollba
 
   "destructivelyDumpRuleResourceToDB" should "remove old rules before adding new ones" in {
     implicit session =>
-      val firstRules = createRandomRules(10)
-      DbRuleManager.destructivelyDumpRuleResourceToDB(CheckerRuleResource(firstRules))
+      val firstRules = createRandomRules(10).map(DbRuleManager.checkerRuleToDbRule)
+      DbRuleManager.destructivelyDumpRuleResourceToDB(firstRules)
 
       val secondRules = createRandomRules(10)
       val secondRulesFromDb =
-        DbRuleManager.destructivelyDumpRuleResourceToDB(CheckerRuleResource(secondRules))
+        DbRuleManager.destructivelyDumpRuleResourceToDB(secondRules.map(DbRuleManager.checkerRuleToDbRule))
 
       secondRulesFromDb.shouldEqual(Right(CheckerRuleResource(secondRules)))
   }

--- a/apps/rule-manager/test/db/DbRuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/DbRuleManagerSpec.scala
@@ -89,10 +89,10 @@ class DbRuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollba
   }
 
   "createRuleResourceFromDbRules" should "not translate dbRules into RuleResource if ignore is true" in {
-    implicit session =>
+    () =>
       val rulesToIgnore = createRandomRules(10, ignore = true)
-      val ruleResourceWithIgnoredRules = DbRuleManager.createRuleResourceFromDbRules(rulesToIgnore)
+      val ruleResourceWithIgnoredRules = DbRuleManager.createCheckerRuleResourceFromDbRules(rulesToIgnore)
 
-      ruleResourceWithIgnoredRules.shouldEqual(Right(RuleResource(List())))
+      ruleResourceWithIgnoredRules.shouldEqual(Right(CheckerRuleResource(List())))
   }
 }

--- a/apps/rule-manager/test/db/DbRuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/DbRuleManagerSpec.scala
@@ -17,7 +17,7 @@ import scala.util.Random
 
 class DbRuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with DBTest {
 
-  def createRandomRules(ruleCount: Int) =
+  def createRandomRules(ruleCount: Int, ignore: Boolean = false) =
     (1 to ruleCount).map { ruleIndex =>
       DbRule.withUser(
         id = None,
@@ -26,15 +26,16 @@ class DbRuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollba
         replacement = None,
         pattern =
           Some(s"\b(${Random.shuffle(List("some", "random", "things", "to", "match", "on")).mkString("|")}) by"),
-        ignore = false,
-        notes = Some(""),
+        ignore = ignore,
+        notes = Some(s"\b(${Random.shuffle(List("some", "random", "notes", "to", "test"))})"),
         googleSheetId = Some(s"rule-at-index-${ruleIndex}"),
-        forceRedRule = Some(false),
-        advisoryRule = Some(false),
+        forceRedRule = Some(math.random < 0.25),
+        advisoryRule = Some(math.random < 0.75),
         user = "Google Sheet",
         ruleType = "regex",
       )
     }.toList
+
 
   behavior of "DbRuleManager"
 
@@ -85,5 +86,13 @@ class DbRuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollba
         DbRuleManager.destructivelyDumpRulesToDB(secondRules).map(_.map(_.copy(id = None)))
 
       secondRulesFromDb.shouldEqual(Right(secondRules))
+  }
+
+  "createRuleResourceFromDbRules" should "not translate dbRules into RuleResource if ignore is true" in {
+    implicit session =>
+      val rulesToIgnore = createRandomRules(10, ignore = true)
+      val ruleResourceWithIgnoredRules = DbRuleManager.createRuleResourceFromDbRules(rulesToIgnore)
+
+      ruleResourceWithIgnoredRules.shouldEqual(Right(RuleResource(List())))
   }
 }

--- a/apps/rule-manager/test/db/DbRuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/DbRuleManagerSpec.scala
@@ -24,18 +24,18 @@ class DbRuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollba
         category = Some("Check this"),
         description = Some("A random rule description. " * Random.between(0, 100)),
         replacement = None,
-        pattern =
-          Some(s"\b(${Random.shuffle(List("some", "random", "things", "to", "match", "on")).mkString("|")}) by"),
+        pattern = Some(
+          s"\b(${Random.shuffle(List("some", "random", "things", "to", "match", "on")).mkString("|")}) by"
+        ),
         ignore = ignore,
         notes = Some(s"\b(${Random.shuffle(List("some", "random", "notes", "to", "test"))})"),
         googleSheetId = Some(s"rule-at-index-${ruleIndex}"),
         forceRedRule = Some(true),
         advisoryRule = Some(true),
         user = "Google Sheet",
-        ruleType = "regex",
+        ruleType = "regex"
       )
     }.toList
-
 
   behavior of "DbRuleManager"
 
@@ -63,7 +63,8 @@ class DbRuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollba
       )
 
       val rules = rulesFromSheet.map(DbRuleManager.checkerRuleToDbRule)
-      val rulesFromDb = DbRuleManager.destructivelyDumpRulesToDB(rules).map(_.map(_.copy(id = None)))
+      val rulesFromDb =
+        DbRuleManager.destructivelyDumpRulesToDB(rules).map(_.map(_.copy(id = None)))
 
       rulesFromDb.shouldEqual(Right(rules))
   }
@@ -71,27 +72,28 @@ class DbRuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollba
   "destructivelyDumpRulesToDB" should "add 1000 randomly generated rules in a ruleResource, and read them back from the DB as an identical resource" in {
     () =>
       val rules = createRandomRules(1000)
-      val rulesFromDb = DbRuleManager.destructivelyDumpRulesToDB(rules).map(_.map(_.copy(id = None)))
+      val rulesFromDb =
+        DbRuleManager.destructivelyDumpRulesToDB(rules).map(_.map(_.copy(id = None)))
 
       rulesFromDb.shouldEqual(Right(rules))
   }
 
-  "destructivelyDumpRulesToDB" should "remove old rules before adding new ones" in {
-    () =>
-      val firstRules = createRandomRules(10)
-      DbRuleManager.destructivelyDumpRulesToDB(firstRules)
+  "destructivelyDumpRulesToDB" should "remove old rules before adding new ones" in { () =>
+    val firstRules = createRandomRules(10)
+    DbRuleManager.destructivelyDumpRulesToDB(firstRules)
 
-      val secondRules = createRandomRules(10)
-      val secondRulesFromDb =
-        DbRuleManager.destructivelyDumpRulesToDB(secondRules).map(_.map(_.copy(id = None)))
+    val secondRules = createRandomRules(10)
+    val secondRulesFromDb =
+      DbRuleManager.destructivelyDumpRulesToDB(secondRules).map(_.map(_.copy(id = None)))
 
-      secondRulesFromDb.shouldEqual(Right(secondRules))
+    secondRulesFromDb.shouldEqual(Right(secondRules))
   }
 
   "createRuleResourceFromDbRules" should "not translate dbRules into RuleResource if ignore is true" in {
     () =>
       val rulesToIgnore = createRandomRules(10, ignore = true)
-      val ruleResourceWithIgnoredRules = DbRuleManager.createCheckerRuleResourceFromDbRules(rulesToIgnore)
+      val ruleResourceWithIgnoredRules =
+        DbRuleManager.createCheckerRuleResourceFromDbRules(rulesToIgnore)
 
       ruleResourceWithIgnoredRules.shouldEqual(Right(CheckerRuleResource(List())))
   }

--- a/apps/rule-manager/test/db/HealthyDBSpec.scala
+++ b/apps/rule-manager/test/db/HealthyDBSpec.scala
@@ -1,6 +1,5 @@
 package db
 
-import org.scalatest.flatspec.FixtureAnyFlatSpec
 import scalikejdbc.scalatest.AutoRollback
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.FixtureAnyFlatSpec

--- a/apps/rule-manager/test/db/HealthyDBSpec.scala
+++ b/apps/rule-manager/test/db/HealthyDBSpec.scala
@@ -1,5 +1,6 @@
 package db
 
+import org.scalatest.flatspec.FixtureAnyFlatSpec
 import scalikejdbc.scalatest.AutoRollback
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.FixtureAnyFlatSpec


### PR DESCRIPTION
co-authored-by: @jonathonherbert 

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Further to #273, this PR adds the missing properties (_e.g. notes, googleSheetId, forceRedRule, advisoryRule_) to the rule model. SheetsRuleManager now creates dbRule instead of RuleResource. 

When translating rules in the database into the rule resource for the checker, the rule manager filters out any rules that should be ignored (`ignore = true`).


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
- The automated tests should pass.
- Using the steps mentioned in https://github.com/guardian/typerighter/pull/229, make a POST request to the /refresh endpoint and inspect the database. The rules should contain the new fields and the corresponding data from the Google Sheet.
![image](https://user-images.githubusercontent.com/47318984/234835598-b75f4683-c323-4dd3-9580-9b1496321634.png)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
We can refresh rules from the Google sheet with those additional properties, and read them from S3.
Additional work to add the UI is to come.
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
There is a new test to check that rules are filtered correctly depending on their 'ignore' flag.
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
