### PR TITLE
Check for rules in healthcheck

### DIFF
--- a/apps/checker/app/AppComponents.scala
+++ b/apps/checker/app/AppComponents.scala
@@ -135,7 +135,7 @@ class AppComponents(
     publicSettings,
     ruleManagerUrl
   )
-  val homeController = new HomeController(controllerComponents, publicSettings)
+  val homeController = new HomeController(controllerComponents, matcherPool, publicSettings)
   val auditController = new AuditController(controllerComponents, publicSettings)
   val capiProxyController =
     new CapiProxyController(controllerComponents, contentClient, publicSettings)

--- a/apps/checker/app/controllers/HomeController.scala
+++ b/apps/checker/app/controllers/HomeController.scala
@@ -3,12 +3,18 @@ package controllers
 import play.api.mvc._
 import com.gu.pandomainauth.PublicSettings
 import com.gu.typerighter.lib.PandaAuthentication
+import play.api.libs.json.Json
+import services._
 
 import scala.concurrent.ExecutionContext
 
 /** The controller for the index pages.
   */
-class HomeController(cc: ControllerComponents, val publicSettings: PublicSettings)(implicit
+class HomeController(
+    cc: ControllerComponents,
+    matcherPool: MatcherPool,
+    val publicSettings: PublicSettings
+)(implicit
     ec: ExecutionContext
 ) extends AbstractController(cc)
     with PandaAuthentication {
@@ -17,6 +23,21 @@ class HomeController(cc: ControllerComponents, val publicSettings: PublicSetting
   }
 
   def healthcheck() = Action { implicit request: Request[AnyContent] =>
-    Ok("""{ "healthy" : "true" }""")
+    {
+      val rules = matcherPool.getCurrentRules
+
+      if (rules.isEmpty) {
+        val errorMsg = "No rules found in S3"
+        log.error(errorMsg)
+        InternalServerError(
+          Json.obj(
+            "healthy" -> false,
+            "error" -> errorMsg
+          )
+        )
+      } else {
+        Ok(Json.obj("healthy" -> true))
+      }
+    }
   }
 }


### PR DESCRIPTION
## What does this change?

Our Checker service can launch and be marked as healthy, even though it hasn't been able to pick up rules 😢. Let's fix this.

## How to test

To test locally, start both the Manager and Checker services. Visit the healthcheck endpoint for the Checker service (on https://checker.typerighter.local.dev-gutools.co.uk/healthcheck). It should fail, unless you already have rules set up locally.

Refresh the rules in the Manager service (to persist to local S3), and wait a minute for the Checker service to pick up the rules (using its scheduled `RuleProvisionerService`). The healthcheck endpoint should now pass.

You can also deploy to CODE, where the Checker service should pick up the rules from S3 on startup (and so pass the healthcheck).

## How can we measure success?

We no longer run instances of the Checker services when there are no rules.
