### PR TITLE
Increase polling to every 5 seconds

### DIFF
--- a/apps/checker/app/services/RuleProvisionerService.scala
+++ b/apps/checker/app/services/RuleProvisionerService.scala
@@ -86,7 +86,7 @@ class RuleProvisionerService(
   override def run(): Unit = maybeUpdateRulesFromBucket()
 
   def scheduleUpdateRules(scheduler: Scheduler): Unit = {
-    scheduler.scheduleWithFixedDelay(0.seconds, 1.minute)(this)
+    scheduler.scheduleWithFixedDelay(0.seconds, 5.seconds)(this)
   }
 
   private def addLTMatcherToPool(


### PR DESCRIPTION
## What does this change?

We currently ask S3 each minute whether or not the rules have been updated, so users of the checker service have to wait up to a minute to find out if their rule changes are live.

This PR makes the polling take place every 5 seconds rather than each minute. AWS cost explorer indicates that this will still be very cheap (less than 40p per month).

## How to test

1. Deploy this branch to CODE
2. Make a change to the CODE rule sheet
3. Hit 'refresh rules' in the CODE [rule manager](https://manager.typerighter.code.dev-gutools.co.uk/) service
4. Check the CODE [checker](https://checker.typerighter.code.dev-gutools.co.uk/rules) service. Do the rules update within 5 seconds to include your change?