### PR TITLE
Fix for ScalaTest 3.1.x

### DIFF
--- a/apps/rule-manager/test/db/HealthyDBSpec.scala
+++ b/apps/rule-manager/test/db/HealthyDBSpec.scala
@@ -1,10 +1,10 @@
 package db
 
 import scalikejdbc.scalatest.AutoRollback
-import org.scalatest.fixture.FlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.FixtureAnyFlatSpec
 
-class HealthyDBSpec extends FlatSpec with Matchers with AutoRollback with DBTest {
+class HealthyDBSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with DBTest {
 
   behavior of "Database connection"
 


### PR DESCRIPTION
## What does this change?

My IDE refuses to build unless this deprecation is fixed. 

See https://github.com/scalatest/autofix/tree/master/3.1.x for more details.

## How to test

Can you build, test, compile, run the app? If so, we're good!