### PR TITLE
Add endpoint for creating and editing rules

### DIFF
--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -64,7 +64,7 @@ class RulesController(
       )
   }
 
-  def update = ApiAuthAction { implicit request: Request[AnyContent] =>
+  def update(id: Int) = ApiAuthAction { implicit request: Request[AnyContent] =>
     UpdateRuleForm.form
       .bindFromRequest()
       .fold(
@@ -73,7 +73,7 @@ class RulesController(
           BadRequest(Json.toJson(errors))
         },
         formRule => {
-          DbRule.updateFromFormRule(formRule) match {
+          DbRule.updateFromFormRule(formRule, id) match {
             case Left(result)  => result
             case Right(dbRule) => Ok(DbRule.toJson(dbRule))
           }

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -74,7 +74,7 @@ class RulesController(
         },
         formRule => {
           DbRule.updateFromFormRule(formRule) match {
-            case Left(result) => result
+            case Left(result)  => result
             case Right(dbRule) => Ok(DbRule.toJson(dbRule))
           }
         }

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -50,48 +50,17 @@ class RulesController(
   }
 
   def create = ApiAuthAction { implicit request: Request[AnyContent] =>
-//    val maybeJson = request.body.asJson.toRight("JSON parse failed");
-//    val maybeMap = maybeJson.flatMap(json => json match {
-//      case JsObject(fields) => Right(fields.toMap)
-//      case _ => Left("Expected JSON Object")
-//    })
-    CreateRuleForm.form.bindFromRequest.fold(
-      formWithErrors => {
+    CreateRuleForm.form
+      .bindFromRequest()
+      .fold(
+        formWithErrors => {
           val errors = formWithErrors.errors
           BadRequest(Json.toJson(errors))
         },
-      formRule => {
-        val dbRule = DbRule.create(
-          formRule.ruleType,
-          formRule.pattern,
-          formRule.replacement,
-          formRule.category,
-          formRule.tags,
-          formRule.description,
-          formRule.ignore,
-          formRule.notes,
-          formRule.googleSheetId,
-          formRule.forceRedRule,
-          formRule.advisoryRule,
-        )
-        val returnedRule = DbRule.find(dbRule.id.get).get
-        val baseReturnedRule = DbRuleManager.dbRuleToBaseRule(returnedRule)
-        baseReturnedRule match {
-          case Right(rule) => Ok(Json.toJson(rule))
-          case Left(error) => InternalServerError(error)
+        formRule => {
+          val dbRule = DbRule.createFromFormRule(formRule)
+          Ok(DbRule.toJson(dbRule))
         }
-      }
-    )
-
-    val maybeCreateRule = for {
-      sheetRules <- sheetsRuleManager.getRules()
-      dbRules <- DbRuleManager.destructivelyDumpRuleResourceToDB(sheetRules)
-      _ <- bucketRuleManager.putRules(dbRules).left.map { l => List(l.toString) }
-    } yield dbRules
-
-    maybeCreateRule match {
-      case Right(ruleResource) => Ok(Json.toJson(ruleResource))
-      case Left(errors)        => InternalServerError(Json.toJson(errors))
-    }
+      )
   }
 }

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -3,7 +3,10 @@ package controllers
 import com.gu.pandomainauth.PublicSettings
 import com.gu.typerighter.lib.PandaAuthentication
 import com.gu.typerighter.rules.{BucketRuleManager, SheetsRuleManager}
-import play.api.libs.json.Json
+import db.DbRule
+import model.{CreateRuleForm, UpdateRuleForm}
+import play.api.data.FormError
+import play.api.libs.json.{JsObject, JsValue, Json, Writes}
 import play.api.mvc._
 import service.DbRuleManager
 
@@ -36,6 +39,59 @@ class RulesController(
     bucketRuleManager.getRules() match {
       case Right((ruleResource, _)) => Ok(Json.toJson(ruleResource))
       case Left(error)              => InternalServerError(Json.toJson(error.getMessage))
+    }
+  }
+
+  implicit object FormErrorWrites extends Writes[FormError] {
+    override def writes(o: FormError): JsValue = Json.obj(
+      "key" -> Json.toJson(o.key),
+      "message" -> Json.toJson(o.message)
+    )
+  }
+
+  def create = ApiAuthAction { implicit request: Request[AnyContent] =>
+//    val maybeJson = request.body.asJson.toRight("JSON parse failed");
+//    val maybeMap = maybeJson.flatMap(json => json match {
+//      case JsObject(fields) => Right(fields.toMap)
+//      case _ => Left("Expected JSON Object")
+//    })
+    CreateRuleForm.form.bindFromRequest.fold(
+      formWithErrors => {
+          val errors = formWithErrors.errors
+          BadRequest(Json.toJson(errors))
+        },
+      formRule => {
+        val dbRule = DbRule.create(
+          formRule.ruleType,
+          formRule.pattern,
+          formRule.replacement,
+          formRule.category,
+          formRule.tags,
+          formRule.description,
+          formRule.ignore,
+          formRule.notes,
+          formRule.googleSheetId,
+          formRule.forceRedRule,
+          formRule.advisoryRule,
+        )
+        val returnedRule = DbRule.find(dbRule.id.get).get
+        val baseReturnedRule = DbRuleManager.dbRuleToBaseRule(returnedRule)
+        baseReturnedRule match {
+          case Right(rule) => Ok(Json.toJson(rule))
+          case Left(error) => InternalServerError(error)
+        }
+      }
+    )
+
+    val maybeCreateRule = for {
+      sheetRules <- sheetsRuleManager.getRules()
+      dbRules <- DbRuleManager.destructivelyDumpRuleResourceToDB(sheetRules)
+      _ <- bucketRuleManager.putRules(dbRules).left.map { l => List(l.toString) }
+    } yield dbRules
+
+    maybeCreateRule match {
+      case Right(ruleResource) => Ok(Json.toJson(ruleResource))
+      case Left(errors)        => InternalServerError(Json.toJson(errors))
     }
   }
 }

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -4,7 +4,7 @@ import com.gu.pandomainauth.PublicSettings
 import com.gu.typerighter.lib.PandaAuthentication
 import com.gu.typerighter.rules.{BucketRuleManager, SheetsRuleManager}
 import db.DbRule
-import model.{CreateRuleForm}
+import model.{CreateRuleForm, UpdateRuleForm}
 import play.api.data.FormError
 import play.api.libs.json.{JsValue, Json, Writes}
 import play.api.mvc._
@@ -60,6 +60,23 @@ class RulesController(
         formRule => {
           val dbRule = DbRule.createFromFormRule(formRule)
           Ok(DbRule.toJson(dbRule))
+        }
+      )
+  }
+
+  def update = ApiAuthAction { implicit request: Request[AnyContent] =>
+    UpdateRuleForm.form
+      .bindFromRequest()
+      .fold(
+        formWithErrors => {
+          val errors = formWithErrors.errors
+          BadRequest(Json.toJson(errors))
+        },
+        formRule => {
+          DbRule.updateFromFormRule(formRule) match {
+            case Left(result) => result
+            case Right(dbRule) => Ok(DbRule.toJson(dbRule))
+          }
         }
       )
   }

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -4,9 +4,9 @@ import com.gu.pandomainauth.PublicSettings
 import com.gu.typerighter.lib.PandaAuthentication
 import com.gu.typerighter.rules.{BucketRuleManager, SheetsRuleManager}
 import db.DbRule
-import model.{CreateRuleForm, UpdateRuleForm}
+import model.{CreateRuleForm}
 import play.api.data.FormError
-import play.api.libs.json.{JsObject, JsValue, Json, Writes}
+import play.api.libs.json.{JsValue, Json, Writes}
 import play.api.mvc._
 import service.DbRuleManager
 

--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -152,55 +152,57 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
   }
 
   def updateFromFormRule(formRule: UpdateRuleForm): Either[Result, DbRule] = {
-    val updatedRule = DbRule.find(formRule.id).toRight(NotFound("Rule not found matching ID"))
+    val updatedRule = DbRule
+      .find(formRule.id)
+      .toRight(NotFound("Rule not found matching ID"))
       .map(existingRule =>
-      new DbRule(
-        id = Some(formRule.id),
-        ruleType = formRule.ruleType.getOrElse(existingRule.ruleType),
-        pattern = formRule.pattern match {
-          case Some(string) => Some(string)
-          case None => existingRule.pattern
-        },
-        replacement = formRule.replacement match {
-          case Some(string) => Some(string)
-          case None => existingRule.replacement
-        },
-        category = formRule.category match {
-          case Some(string) => Some(string)
-          case None => existingRule.category
-        },
-        tags = formRule.tags match {
-          case Some(string) => Some(string)
-          case None => existingRule.tags
-        },
-        description = formRule.description match {
-          case Some(string) => Some(string)
-          case None => existingRule.description
-        },
-        ignore = formRule.ignore.getOrElse(existingRule.ignore),
-        notes = formRule.notes match {
-          case Some(string) => Some(string)
-          case None => existingRule.notes
-        },
-        googleSheetId = formRule.googleSheetId match {
-          case Some(bool) => Some(bool)
-          case None => existingRule.googleSheetId
-        },
-        forceRedRule = formRule.forceRedRule match {
-          case Some(bool) => Some(bool)
-          case None => existingRule.forceRedRule
-        },
-        advisoryRule = formRule.advisoryRule match {
-          case Some(bool) => Some(bool)
-          case None => existingRule.advisoryRule
-        },
+        new DbRule(
+          id = Some(formRule.id),
+          ruleType = formRule.ruleType.getOrElse(existingRule.ruleType),
+          pattern = formRule.pattern match {
+            case Some(string) => Some(string)
+            case None         => existingRule.pattern
+          },
+          replacement = formRule.replacement match {
+            case Some(string) => Some(string)
+            case None         => existingRule.replacement
+          },
+          category = formRule.category match {
+            case Some(string) => Some(string)
+            case None         => existingRule.category
+          },
+          tags = formRule.tags match {
+            case Some(string) => Some(string)
+            case None         => existingRule.tags
+          },
+          description = formRule.description match {
+            case Some(string) => Some(string)
+            case None         => existingRule.description
+          },
+          ignore = formRule.ignore.getOrElse(existingRule.ignore),
+          notes = formRule.notes match {
+            case Some(string) => Some(string)
+            case None         => existingRule.notes
+          },
+          googleSheetId = formRule.googleSheetId match {
+            case Some(bool) => Some(bool)
+            case None       => existingRule.googleSheetId
+          },
+          forceRedRule = formRule.forceRedRule match {
+            case Some(bool) => Some(bool)
+            case None       => existingRule.forceRedRule
+          },
+          advisoryRule = formRule.advisoryRule match {
+            case Some(bool) => Some(bool)
+            case None       => existingRule.advisoryRule
+          }
+        )
       )
-    )
     updatedRule match {
       case Right(dbRule) => {
         DbRule.save(dbRule).toEither match {
           case Left(e: Throwable) => Left(InternalServerError(e.getMessage()))
-          case Right(dbRule) => Right(dbRule)
+          case Right(dbRule)      => Right(dbRule)
         }
       }
       case Left(result) => Left(result)

--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -1,6 +1,6 @@
 package db
 
-import model.UpdateRuleForm
+import model.{CreateRuleForm, UpdateRuleForm}
 import scalikejdbc._
 
 import scala.util.Try
@@ -43,6 +43,21 @@ case class DbRule(
 
   def fromFormRule(id: Int, formRule: UpdateRuleForm): DbRule =
     fromFormRule(formRule).copy(id = Some(id))
+
+  def fromCreateFormRule(formRule: CreateRuleForm) = DbRule(
+    id = None,
+    ruleType = formRule.ruleType,
+    pattern = formRule.pattern.orElse(this.pattern),
+    replacement = formRule.replacement.orElse(this.replacement),
+    category = formRule.category.orElse(this.category),
+    tags = formRule.tags.orElse(this.tags),
+    description = formRule.description.orElse(this.description),
+    ignore = formRule.ignore,
+    notes = formRule.notes.orElse(this.notes),
+    googleSheetId = formRule.googleSheetId.orElse(this.googleSheetId),
+    forceRedRule = formRule.forceRedRule.orElse(this.forceRedRule),
+    advisoryRule = formRule.advisoryRule.orElse(this.advisoryRule)
+  )
 }
 
 object DbRule extends SQLSyntaxSupport[DbRule] {

--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -1,5 +1,6 @@
 package db
 
+import model.UpdateRuleForm
 import scalikejdbc._
 
 import scala.util.Try
@@ -25,6 +26,23 @@ case class DbRule(
   def destroy()(implicit session: DBSession = DbRule.autoSession): Int =
     DbRule.destroy(this)(session)
 
+  def fromFormRule(formRule: UpdateRuleForm) = DbRule(
+    id = None,
+    ruleType = formRule.ruleType.getOrElse(this.ruleType),
+    pattern = formRule.pattern.orElse(this.pattern),
+    replacement = formRule.replacement.orElse(this.replacement),
+    category = formRule.category.orElse(this.category),
+    tags = formRule.tags.orElse(this.tags),
+    description = formRule.description.orElse(this.description),
+    ignore = formRule.ignore.getOrElse(this.ignore),
+    notes = formRule.notes.orElse(this.notes),
+    googleSheetId = formRule.googleSheetId.orElse(this.googleSheetId),
+    forceRedRule = formRule.forceRedRule.orElse(this.forceRedRule),
+    advisoryRule = formRule.advisoryRule.orElse(this.advisoryRule)
+  )
+
+  def fromFormRule(id: Int, formRule: UpdateRuleForm): DbRule =
+    fromFormRule(formRule).copy(id = Some(id))
 }
 
 object DbRule extends SQLSyntaxSupport[DbRule] {

--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -162,43 +162,16 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
         new DbRule(
           id = Some(id),
           ruleType = formRule.ruleType.getOrElse(existingRule.ruleType),
-          pattern = formRule.pattern match {
-            case Some(string) => Some(string)
-            case None         => existingRule.pattern
-          },
-          replacement = formRule.replacement match {
-            case Some(string) => Some(string)
-            case None         => existingRule.replacement
-          },
-          category = formRule.category match {
-            case Some(string) => Some(string)
-            case None         => existingRule.category
-          },
-          tags = formRule.tags match {
-            case Some(string) => Some(string)
-            case None         => existingRule.tags
-          },
-          description = formRule.description match {
-            case Some(string) => Some(string)
-            case None         => existingRule.description
-          },
+          pattern = formRule.pattern.orElse(existingRule.pattern),
+          replacement = formRule.replacement.orElse(existingRule.replacement),
+          category = formRule.category.orElse(existingRule.category),
+          tags = formRule.tags.orElse(existingRule.tags),
+          description = formRule.description.orElse(existingRule.description),
           ignore = formRule.ignore.getOrElse(existingRule.ignore),
-          notes = formRule.notes match {
-            case Some(string) => Some(string)
-            case None         => existingRule.notes
-          },
-          googleSheetId = formRule.googleSheetId match {
-            case Some(bool) => Some(bool)
-            case None       => existingRule.googleSheetId
-          },
-          forceRedRule = formRule.forceRedRule match {
-            case Some(bool) => Some(bool)
-            case None       => existingRule.forceRedRule
-          },
-          advisoryRule = formRule.advisoryRule match {
-            case Some(bool) => Some(bool)
-            case None       => existingRule.advisoryRule
-          }
+          notes = formRule.notes.orElse(existingRule.notes),
+          googleSheetId = formRule.googleSheetId.orElse(existingRule.googleSheetId),
+          forceRedRule = formRule.forceRedRule.orElse(existingRule.forceRedRule),
+          advisoryRule = formRule.advisoryRule.orElse(existingRule.advisoryRule)
         )
       )
     updatedRule match {

--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -26,39 +26,6 @@ case class DbRule(
 
   def destroy()(implicit session: DBSession = DbRule.autoSession): Int =
     DbRule.destroy(this)(session)
-
-  def fromFormRule(formRule: UpdateRuleForm) = DbRule(
-    id = None,
-    ruleType = formRule.ruleType.getOrElse(this.ruleType),
-    pattern = formRule.pattern.orElse(this.pattern),
-    replacement = formRule.replacement.orElse(this.replacement),
-    category = formRule.category.orElse(this.category),
-    tags = formRule.tags.orElse(this.tags),
-    description = formRule.description.orElse(this.description),
-    ignore = formRule.ignore.getOrElse(this.ignore),
-    notes = formRule.notes.orElse(this.notes),
-    googleSheetId = formRule.googleSheetId.orElse(this.googleSheetId),
-    forceRedRule = formRule.forceRedRule.orElse(this.forceRedRule),
-    advisoryRule = formRule.advisoryRule.orElse(this.advisoryRule)
-  )
-
-  def fromFormRule(id: Int, formRule: UpdateRuleForm): DbRule =
-    fromFormRule(formRule).copy(id = Some(id))
-
-  def fromCreateFormRule(formRule: CreateRuleForm) = DbRule(
-    id = None,
-    ruleType = formRule.ruleType,
-    pattern = formRule.pattern.orElse(this.pattern),
-    replacement = formRule.replacement.orElse(this.replacement),
-    category = formRule.category.orElse(this.category),
-    tags = formRule.tags.orElse(this.tags),
-    description = formRule.description.orElse(this.description),
-    ignore = formRule.ignore,
-    notes = formRule.notes.orElse(this.notes),
-    googleSheetId = formRule.googleSheetId.orElse(this.googleSheetId),
-    forceRedRule = formRule.forceRedRule.orElse(this.forceRedRule),
-    advisoryRule = formRule.advisoryRule.orElse(this.advisoryRule)
-  )
 }
 
 object DbRule extends SQLSyntaxSupport[DbRule] {

--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -135,7 +135,7 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
     )
   }
 
-  def createFromFormRule(formRule: CreateRuleForm) = {
+  def createFromFormRule(formRule: CreateRuleForm)(implicit session: DBSession = autoSession) = {
     DbRule.create(
       formRule.ruleType,
       formRule.pattern,

--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -151,7 +151,9 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
     )
   }
 
-  def updateFromFormRule(formRule: UpdateRuleForm): Either[Result, DbRule] = {
+  def updateFromFormRule(
+      formRule: UpdateRuleForm
+  )(implicit session: DBSession = autoSession): Either[Result, DbRule] = {
     val updatedRule = DbRule
       .find(formRule.id)
       .toRight(NotFound("Rule not found matching ID"))

--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -149,25 +149,6 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
     )
   }
 
-  def toJson(dbRule: DbRule): JsValue = {
-    Json.toJson(
-      Map(
-        "id" -> Json.toJson(dbRule.id),
-        "ruleType" -> Json.toJson(dbRule.ruleType),
-        "pattern" -> Json.toJson(dbRule.pattern),
-        "replacement" -> Json.toJson(dbRule.replacement),
-        "category" -> Json.toJson(dbRule.category),
-        "tags" -> Json.toJson(dbRule.tags),
-        "description" -> Json.toJson(dbRule.description),
-        "ignore" -> Json.toJson(dbRule.ignore),
-        "notes" -> Json.toJson(dbRule.notes),
-        "googleSheetId" -> Json.toJson(dbRule.googleSheetId),
-        "forceRedRule" -> Json.toJson(dbRule.forceRedRule),
-        "advisoryRule" -> Json.toJson(dbRule.advisoryRule)
-      )
-    )
-  }
-
   def batchInsert(
       entities: collection.Seq[DbRule]
   )(implicit session: DBSession = autoSession): List[Int] = {
@@ -251,4 +232,22 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
     }.update.apply()
   }
 
+  def toJson(dbRule: DbRule): JsValue = {
+    Json.toJson(
+      Map(
+        "id" -> Json.toJson(dbRule.id),
+        "ruleType" -> Json.toJson(dbRule.ruleType),
+        "pattern" -> Json.toJson(dbRule.pattern),
+        "replacement" -> Json.toJson(dbRule.replacement),
+        "category" -> Json.toJson(dbRule.category),
+        "tags" -> Json.toJson(dbRule.tags),
+        "description" -> Json.toJson(dbRule.description),
+        "ignore" -> Json.toJson(dbRule.ignore),
+        "notes" -> Json.toJson(dbRule.notes),
+        "googleSheetId" -> Json.toJson(dbRule.googleSheetId),
+        "forceRedRule" -> Json.toJson(dbRule.forceRedRule),
+        "advisoryRule" -> Json.toJson(dbRule.advisoryRule)
+      )
+    )
+  }
 }

--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -1,6 +1,7 @@
 package db
 
 import model.{CreateRuleForm, UpdateRuleForm}
+import play.api.libs.json.{JsValue, Json}
 import scalikejdbc._
 
 import scala.util.Try
@@ -162,6 +163,41 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
       googleSheetId = googleSheetId,
       forceRedRule = forceRedRule,
       advisoryRule = advisoryRule
+    )
+  }
+
+  def createFromFormRule(formRule: CreateRuleForm) = {
+    DbRule.create(
+      formRule.ruleType,
+      formRule.pattern,
+      formRule.replacement,
+      formRule.category,
+      formRule.tags,
+      formRule.description,
+      formRule.ignore,
+      formRule.notes,
+      formRule.googleSheetId,
+      formRule.forceRedRule,
+      formRule.advisoryRule
+    )
+  }
+
+  def toJson(dbRule: DbRule): JsValue = {
+    Json.toJson(
+      Map(
+        "id" -> Json.toJson(dbRule.id),
+        "ruleType" -> Json.toJson(dbRule.ruleType),
+        "pattern" -> Json.toJson(dbRule.pattern),
+        "replacement" -> Json.toJson(dbRule.replacement),
+        "category" -> Json.toJson(dbRule.category),
+        "tags" -> Json.toJson(dbRule.tags),
+        "description" -> Json.toJson(dbRule.description),
+        "ignore" -> Json.toJson(dbRule.ignore),
+        "notes" -> Json.toJson(dbRule.notes),
+        "googleSheetId" -> Json.toJson(dbRule.googleSheetId),
+        "forceRedRule" -> Json.toJson(dbRule.forceRedRule),
+        "advisoryRule" -> Json.toJson(dbRule.advisoryRule)
+      )
     )
   }
 

--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -152,14 +152,15 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
   }
 
   def updateFromFormRule(
-      formRule: UpdateRuleForm
+      formRule: UpdateRuleForm,
+      id: Int
   )(implicit session: DBSession = autoSession): Either[Result, DbRule] = {
     val updatedRule = DbRule
-      .find(formRule.id)
+      .find(id)
       .toRight(NotFound("Rule not found matching ID"))
       .map(existingRule =>
         new DbRule(
-          id = Some(formRule.id),
+          id = Some(id),
           ruleType = formRule.ruleType.getOrElse(existingRule.ruleType),
           pattern = formRule.pattern match {
             case Some(string) => Some(string)

--- a/apps/rule-manager/app/model/CreateRuleForm.scala
+++ b/apps/rule-manager/app/model/CreateRuleForm.scala
@@ -1,12 +1,33 @@
 package model
 
 import play.api.data.Form
-import play.api.data.Forms.{boolean, mapping, optional, text}
+import play.api.data.Forms.{boolean, mapping, nonEmptyText, optional, text}
+import play.api.data.validation.{Constraint, ValidationError, Valid, Invalid}
+import service.DbRuleManager.RuleType
 
 object CreateRuleForm {
+  val ruleTypeConstraint: Constraint[String] = Constraint("constraints.ruleType")({ text =>
+    val errors = text match {
+      case RuleType.regex            => Nil
+      case RuleType.languageToolCore => Nil
+      case RuleType.languageToolXML  => Nil
+      case _ =>
+        Seq(
+          ValidationError(
+            s"RuleType must be one of \"${RuleType.regex}\", \"${RuleType.languageToolXML}\" or \"${RuleType.languageToolCore}\""
+          )
+        )
+    }
+    if (errors.isEmpty) {
+      Valid
+    } else {
+      Invalid(errors)
+    }
+  })
+
   val form = Form(
     mapping(
-      "ruleType" -> text(),
+      "ruleType" -> nonEmptyText().verifying(ruleTypeConstraint),
       "pattern" -> optional(text()),
       "replacement" -> optional(text()),
       "category" -> optional(text()),
@@ -22,15 +43,15 @@ object CreateRuleForm {
 }
 
 case class CreateRuleForm(
-  ruleType: String,
-  pattern: Option[String] = None,
-  replacement: Option[String] = None,
-  category: Option[String] = None,
-  tags: Option[String] = None,
-  description: Option[String] = None,
-  ignore: Boolean,
-  notes: Option[String] = None,
-  googleSheetId: Option[String] = None,
-  forceRedRule: Option[Boolean] = None,
-  advisoryRule: Option[Boolean] = None
+    ruleType: String,
+    pattern: Option[String] = None,
+    replacement: Option[String] = None,
+    category: Option[String] = None,
+    tags: Option[String] = None,
+    description: Option[String] = None,
+    ignore: Boolean,
+    notes: Option[String] = None,
+    googleSheetId: Option[String] = None,
+    forceRedRule: Option[Boolean] = None,
+    advisoryRule: Option[Boolean] = None
 )

--- a/apps/rule-manager/app/model/CreateRuleForm.scala
+++ b/apps/rule-manager/app/model/CreateRuleForm.scala
@@ -1,0 +1,36 @@
+package model
+
+import play.api.data.Form
+import play.api.data.Forms.{boolean, mapping, optional, text}
+
+object CreateRuleForm {
+  val form = Form(
+    mapping(
+      "ruleType" -> text(),
+      "pattern" -> optional(text()),
+      "replacement" -> optional(text()),
+      "category" -> optional(text()),
+      "tags" -> optional(text()),
+      "description" -> optional(text()),
+      "ignore" -> boolean,
+      "notes" -> optional(text()),
+      "googleSheetId" -> optional(text()),
+      "forceRedRule" -> optional(boolean),
+      "advisoryRule" -> optional(boolean)
+    )(CreateRuleForm.apply)(CreateRuleForm.unapply)
+  )
+}
+
+case class CreateRuleForm(
+  ruleType: String,
+  pattern: Option[String] = None,
+  replacement: Option[String] = None,
+  category: Option[String] = None,
+  tags: Option[String] = None,
+  description: Option[String] = None,
+  ignore: Boolean,
+  notes: Option[String] = None,
+  googleSheetId: Option[String] = None,
+  forceRedRule: Option[Boolean] = None,
+  advisoryRule: Option[Boolean] = None
+)

--- a/apps/rule-manager/app/model/UpdateRuleForm.scala
+++ b/apps/rule-manager/app/model/UpdateRuleForm.scala
@@ -2,11 +2,33 @@ package model
 
 import play.api.data.Form
 import play.api.data.Forms.{boolean, mapping, nonEmptyText, number, optional, text}
+import play.api.data.validation.{Constraint, Invalid, Valid, ValidationError}
+import service.DbRuleManager.RuleType
 
 object UpdateRuleForm {
+  val ruleTypeConstraint: Constraint[Option[String]] = Constraint("constraints.ruleType")({ text =>
+    val errors = text match {
+      case None                            => Nil
+      case Some(RuleType.regex)            => Nil
+      case Some(RuleType.languageToolCore) => Nil
+      case Some(RuleType.languageToolXML)  => Nil
+      case _ =>
+        Seq(
+          ValidationError(
+            s"RuleType must be one of \"${RuleType.regex}\", \"${RuleType.languageToolXML}\" or \"${RuleType.languageToolCore}\""
+          )
+        )
+    }
+    if (errors.isEmpty) {
+      Valid
+    } else {
+      Invalid(errors)
+    }
+  })
+
   val form = Form(
     mapping(
-      "ruleType" -> optional(text()),
+      "ruleType" -> optional(text()).verifying(ruleTypeConstraint),
       "pattern" -> optional(text()),
       "replacement" -> optional(text()),
       "category" -> optional(text()),

--- a/apps/rule-manager/app/model/UpdateRuleForm.scala
+++ b/apps/rule-manager/app/model/UpdateRuleForm.scala
@@ -1,0 +1,36 @@
+package model
+
+import play.api.data.Form
+import play.api.data.Forms.{boolean, mapping, optional, text}
+
+object UpdateRuleForm {
+  val form = Form(
+    mapping(
+      "ruleType" -> optional(text()),
+      "pattern" -> optional(text()),
+      "replacement" -> optional(text()),
+      "category" -> optional(text()),
+      "tags" -> optional(text()),
+      "description" -> optional(text()),
+      "ignore" -> optional(boolean),
+      "notes" -> optional(text()),
+      "googleSheetId" -> optional(text()),
+      "forceRedRule" -> optional(boolean),
+      "advisoryRule" -> optional(boolean)
+    )(UpdateRuleForm.apply)(UpdateRuleForm.unapply)
+  )
+}
+
+case class UpdateRuleForm(
+    ruleType: Option[String] = None,
+    pattern: Option[String] = None,
+    replacement: Option[String] = None,
+    category: Option[String] = None,
+    tags: Option[String] = None,
+    description: Option[String] = None,
+    ignore: Option[Boolean] = None,
+    notes: Option[String] = None,
+    googleSheetId: Option[String] = None,
+    forceRedRule: Option[Boolean] = None,
+    advisoryRule: Option[Boolean] = None
+)

--- a/apps/rule-manager/app/model/UpdateRuleForm.scala
+++ b/apps/rule-manager/app/model/UpdateRuleForm.scala
@@ -1,11 +1,12 @@
 package model
 
 import play.api.data.Form
-import play.api.data.Forms.{boolean, mapping, optional, text}
+import play.api.data.Forms.{boolean, mapping, nonEmptyText, number, optional, text}
 
 object UpdateRuleForm {
   val form = Form(
     mapping(
+      "id" -> number(),
       "ruleType" -> optional(text()),
       "pattern" -> optional(text()),
       "replacement" -> optional(text()),
@@ -22,6 +23,7 @@ object UpdateRuleForm {
 }
 
 case class UpdateRuleForm(
+    id: Int,
     ruleType: Option[String] = None,
     pattern: Option[String] = None,
     replacement: Option[String] = None,

--- a/apps/rule-manager/app/model/UpdateRuleForm.scala
+++ b/apps/rule-manager/app/model/UpdateRuleForm.scala
@@ -6,7 +6,6 @@ import play.api.data.Forms.{boolean, mapping, nonEmptyText, number, optional, te
 object UpdateRuleForm {
   val form = Form(
     mapping(
-      "id" -> number(),
       "ruleType" -> optional(text()),
       "pattern" -> optional(text()),
       "replacement" -> optional(text()),
@@ -23,7 +22,6 @@ object UpdateRuleForm {
 }
 
 case class UpdateRuleForm(
-    id: Int,
     ruleType: Option[String] = None,
     pattern: Option[String] = None,
     replacement: Option[String] = None,

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -16,9 +16,8 @@ GET     /healthcheck                controllers.HomeController.healthcheck()
 +nocsrf
 POST    /refresh                    controllers.RulesController.refresh()
 +nocsrf
-POST    /create                     controllers.RulesController.create()
-+nocsrf
-POST    /update                     controllers.RulesController.update()
-+nocsrf
 GET     /rules                      controllers.RulesController.rules()
-
++nocsrf
+POST    /rules               controllers.RulesController.create()
++nocsrf
+POST    /rules/:id            controllers.RulesController.update(id: Int)

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -16,7 +16,9 @@ GET     /healthcheck                controllers.HomeController.healthcheck()
 +nocsrf
 POST    /refresh                    controllers.RulesController.refresh()
 +nocsrf
-POST    /create                    controllers.RulesController.create()
+POST    /create                     controllers.RulesController.create()
++nocsrf
+POST    /update                     controllers.RulesController.update()
 +nocsrf
 GET     /rules                      controllers.RulesController.rules()
 

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -16,4 +16,7 @@ GET     /healthcheck                controllers.HomeController.healthcheck()
 +nocsrf
 POST    /refresh                    controllers.RulesController.refresh()
 +nocsrf
+POST    /create                    controllers.RulesController.create()
++nocsrf
 GET     /rules                      controllers.RulesController.rules()
+

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -70,11 +70,10 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     val existingRule = DbRule.create(ruleType = "regex", pattern = Some("MyString"), ignore = false)
     val existingId = existingRule.id.get
     val formRule = UpdateRuleForm(
-      id = existingId,
       ruleType = Some("regex"),
       pattern = Some("NewString")
     )
-    val dbRule = DbRule.updateFromFormRule(formRule)
+    val dbRule = DbRule.updateFromFormRule(formRule, existingId)
     val rule = dbRule.getOrElse(null)
     rule.id should be(Some(existingId))
     rule.pattern should be(Some("NewString"))

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -79,14 +79,15 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     rule.id should be(Some(existingId))
     rule.pattern should be(Some("NewString"))
   }
-  it should "return an error when attempting to update a record that doesn't exist" in { implicit session =>
-    val formRule = UpdateRuleForm(
-      ruleType = Some("regex"),
-      pattern = Some("NewString")
-    )
-    val nonExistentRuleId = 2000
-    val dbRule = DbRule.updateFromFormRule(formRule, nonExistentRuleId)
-    dbRule should be(Left(NotFound("Rule not found matching ID")))
+  it should "return an error when attempting to update a record that doesn't exist" in {
+    implicit session =>
+      val formRule = UpdateRuleForm(
+        ruleType = Some("regex"),
+        pattern = Some("NewString")
+      )
+      val nonExistentRuleId = 2000
+      val dbRule = DbRule.updateFromFormRule(formRule, nonExistentRuleId)
+      dbRule should be(Left(NotFound("Rule not found matching ID")))
   }
   it should "save a record" in { implicit session =>
     val entity = DbRule.findAll().head

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -1,9 +1,13 @@
 package db
 
+import model.CreateRuleForm
 import org.scalatest.flatspec.FixtureAnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import scalikejdbc.scalatest.AutoRollback
 import scalikejdbc._
+import play.api.libs.json.{JsValue, Json}
+
+
 import scala.util.Success
 
 class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with DBTest {
@@ -45,6 +49,24 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     val created = DbRule.create(ruleType = "regex", pattern = Some("MyString"), ignore = false)
     created should not be (null)
   }
+  // TODO: Figure out why this test won't run
+//  it should "create a new record from a form rule" in { implicit session =>
+//   val formRule = CreateRuleForm(
+//      ruleType = "regex",
+//      pattern = None,
+//      replacement = None,
+//      category = None,
+//      tags = None,
+//      description = None,
+//      ignore = false,
+//      notes = None,
+//      googleSheetId = None,
+//      forceRedRule = None,
+//      advisoryRule = None
+//    )
+//    val dbRule = DbRule.createFromFormRule(formRule)
+//    dbRule should not be (null)
+//  }
   it should "save a record" in { implicit session =>
     val entity = DbRule.findAll().head
     val modified = entity.copy(pattern = Some("NotMyString"))
@@ -63,5 +85,26 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     entities.foreach(e => DbRule.destroy(e))
     val batchInserted = DbRule.batchInsert(entities)
     batchInserted.size should be > (0)
+  }
+  it should "return a JSON representation of a rule" in { implicit session =>
+    val created = DbRule.create(ruleType = "regex", pattern = Some("MyString"), ignore = false)
+    val json = DbRule.toJson(created)
+    val expected = Json.parse(s"""
+    {
+      "ruleType" : "regex",
+      "forceRedRule": null,
+      "replacement": null,
+      "advisoryRule": null,
+      "id": ${created.id.get},
+      "category": null,
+      "notes": null,
+      "ignore": false,
+      "pattern": "MyString",
+      "googleSheetId": null,
+      "description": null,
+      "tags": null
+    }
+    """)
+    json should equal(expected)
   }
 }

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -7,7 +7,6 @@ import scalikejdbc.scalatest.AutoRollback
 import scalikejdbc._
 import play.api.libs.json.{JsValue, Json}
 
-
 import scala.util.Success
 
 class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with DBTest {
@@ -50,7 +49,7 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     created should not be (null)
   }
   it should "create a new record from a form rule" in { implicit session =>
-   val formRule = CreateRuleForm(
+    val formRule = CreateRuleForm(
       ruleType = "regex",
       pattern = None,
       replacement = None,

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -1,6 +1,7 @@
 package db
 
 import model.CreateRuleForm
+import model.UpdateRuleForm
 import org.scalatest.flatspec.FixtureAnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import scalikejdbc.scalatest.AutoRollback
@@ -64,6 +65,19 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     )
     val dbRule = DbRule.createFromFormRule(formRule)
     dbRule should not be (null)
+  }
+  it should "edit an existing record using a form rule" in { implicit session =>
+    val existingRule = DbRule.create(ruleType = "regex", pattern = Some("MyString"), ignore = false)
+    val existingId = existingRule.id.get
+    val formRule = UpdateRuleForm(
+      id = existingId,
+      ruleType = Some("regex"),
+      pattern = Some("NewString"),
+    )
+    val dbRule = DbRule.updateFromFormRule(formRule)
+    val rule = dbRule.getOrElse(null)
+    rule.id should be (Some(existingId))
+    rule.pattern should be (Some("NewString"))
   }
   it should "save a record" in { implicit session =>
     val entity = DbRule.findAll().head

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -49,24 +49,23 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     val created = DbRule.create(ruleType = "regex", pattern = Some("MyString"), ignore = false)
     created should not be (null)
   }
-  // TODO: Figure out why this test won't run
-//  it should "create a new record from a form rule" in { implicit session =>
-//   val formRule = CreateRuleForm(
-//      ruleType = "regex",
-//      pattern = None,
-//      replacement = None,
-//      category = None,
-//      tags = None,
-//      description = None,
-//      ignore = false,
-//      notes = None,
-//      googleSheetId = None,
-//      forceRedRule = None,
-//      advisoryRule = None
-//    )
-//    val dbRule = DbRule.createFromFormRule(formRule)
-//    dbRule should not be (null)
-//  }
+  it should "create a new record from a form rule" in { implicit session =>
+   val formRule = CreateRuleForm(
+      ruleType = "regex",
+      pattern = None,
+      replacement = None,
+      category = None,
+      tags = None,
+      description = None,
+      ignore = false,
+      notes = None,
+      googleSheetId = None,
+      forceRedRule = None,
+      advisoryRule = None
+    )
+    val dbRule = DbRule.createFromFormRule(formRule)
+    dbRule should not be (null)
+  }
   it should "save a record" in { implicit session =>
     val entity = DbRule.findAll().head
     val modified = entity.copy(pattern = Some("NotMyString"))

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -72,12 +72,12 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     val formRule = UpdateRuleForm(
       id = existingId,
       ruleType = Some("regex"),
-      pattern = Some("NewString"),
+      pattern = Some("NewString")
     )
     val dbRule = DbRule.updateFromFormRule(formRule)
     val rule = dbRule.getOrElse(null)
-    rule.id should be (Some(existingId))
-    rule.pattern should be (Some("NewString"))
+    rule.id should be(Some(existingId))
+    rule.pattern should be(Some("NewString"))
   }
   it should "save a record" in { implicit session =>
     val entity = DbRule.findAll().head


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds endpoints for creating and editing rules in the rule manager.

The endpoints are:
- `/create` e.g. https://manager.typerighter.local.dev-gutools.co.uk/create
- `/update` e.g. https://manager.typerighter.local.dev-gutools.co.uk/update

The `create` endpoint expects a POST request with a JSON body that contains at minimum a ruleType.

An example request body might look like:
```json
{
    "ruleType": "regex",
    "pattern": "/example/",
    "description": "A perfectly fine word"
}
```

The `update` endpoint expects a POST request with a JSON body that contains at minimum an `id`.

An example request body might look like:
```json
{
    "pattern": "/embiggens/",
    "id": 53
}
```

The validation rules are pretty sparse currently - for `create` the only custom validation is checking that the ruleType is one of "regex", "languageToolXML" or "languageToolCore".

#### N.b. The rules displayed in the rule-manager UI will not be updated currently as a result of your changes to the rules in the DB - they're only updated by re-ingesting the Google Sheet.


## How to test

Automated tests:

1. Run the application from the project root with `./script/start`
2. In another tab, run `sbt` from the project root
3. Use the `rule-manager` project with `project ruleManager` in the sbt shell
4. Run the tests with `test`
Do all the tests pass?

Manual testing:

You may want to do some testing of the endpoints using something like `Postman`. I found I needed to grab some cookies from the browser in order to be validated, specifically `PLAY_SESSION`, `guToolsAuth` and `gutoolsAuth-assym`.

I used `application/json` as the `Content-Type` header with the json listed at the top of this page as the request body.