### PR TITLE
Manager service reads DBRules, not BaseRules

### DIFF
--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -25,21 +25,20 @@ class RulesController(
   def refresh = ApiAuthAction { implicit request: Request[AnyContent] =>
     val maybeWrittenRules = for {
       sheetRules <- sheetsRuleManager.getRules()
-      dbRules <- DbRuleManager.destructivelyDumpRuleResourceToDB(sheetRules)
-      _ <- bucketRuleManager.putRules(dbRules).left.map { l => List(l.toString) }
-    } yield dbRules
+      ruleResource <- DbRuleManager.destructivelyDumpRuleResourceToDB(sheetRules)
+      _ <- bucketRuleManager.putRules(ruleResource).left.map { l => List(l.toString) }
+    } yield {
+      DbRuleManager.getRules()
+    }
 
     maybeWrittenRules match {
-      case Right(ruleResource) => Ok(Json.toJson(ruleResource))
-      case Left(errors)        => InternalServerError(Json.toJson(errors))
+      case Right(rules) => Ok(Json.toJson(rules))
+      case Left(errors) => InternalServerError(Json.toJson(errors))
     }
   }
 
   def rules = ApiAuthAction { implicit request: Request[AnyContent] =>
-    bucketRuleManager.getRules() match {
-      case Right((ruleResource, _)) => Ok(Json.toJson(ruleResource))
-      case Left(error)              => InternalServerError(Json.toJson(error.getMessage))
-    }
+    Ok(Json.toJson(DbRuleManager.getRules()))
   }
 
   implicit object FormErrorWrites extends Writes[FormError] {

--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -9,19 +9,19 @@ import scalikejdbc._
 import scala.util.{Failure, Try}
 
 case class DbRule(
-                   id: Option[Int],
-                   ruleType: String,
-                   pattern: Option[String] = None,
-                   replacement: Option[String] = None,
-                   category: Option[String] = None,
-                   tags: Option[String] = None,
-                   description: Option[String] = None,
-                   ignore: Boolean,
-                   notes: Option[String] = None,
-                   googleSheetId: Option[String] = None,
-                   forceRedRule: Option[Boolean] = None,
-                   advisoryRule: Option[Boolean] = None
-                 ) {
+    id: Option[Int],
+    ruleType: String,
+    pattern: Option[String] = None,
+    replacement: Option[String] = None,
+    category: Option[String] = None,
+    tags: Option[String] = None,
+    description: Option[String] = None,
+    ignore: Boolean,
+    notes: Option[String] = None,
+    googleSheetId: Option[String] = None,
+    forceRedRule: Option[Boolean] = None,
+    advisoryRule: Option[Boolean] = None
+) {
 
   def save()(implicit session: DBSession = DbRule.autoSession): Try[DbRule] =
     DbRule.save(this)(session)
@@ -51,7 +51,8 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
     "advisory_rule"
   )
 
-  def fromSyntaxProvider(r: SyntaxProvider[DbRule])(rs: WrappedResultSet): DbRule = autoConstruct(rs, r)
+  def fromSyntaxProvider(r: SyntaxProvider[DbRule])(rs: WrappedResultSet): DbRule =
+    autoConstruct(rs, r)
   def fromResultName(r: ResultName[DbRule])(rs: WrappedResultSet): DbRule = autoConstruct(rs, r)
 
   val r = DbRule.syntax("r")
@@ -65,7 +66,10 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
   }
 
   def findAll()(implicit session: DBSession = autoSession): List[DbRule] = {
-    withSQL(select.from(DbRule as r).orderBy(r.id)).map(DbRule.fromResultName(r.resultName)).list.apply()
+    withSQL(select.from(DbRule as r).orderBy(r.id))
+      .map(DbRule.fromResultName(r.resultName))
+      .list
+      .apply()
   }
 
   def countAll()(implicit session: DBSession = autoSession): Long = {

--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -1,7 +1,7 @@
 package db
 
 import model.{CreateRuleForm, UpdateRuleForm}
-import play.api.libs.json.{JsValue, Json, Reads, Writes}
+import play.api.libs.json.{Format, JsValue, Json}
 import play.api.mvc.Result
 import play.api.mvc.Results.{InternalServerError, NotFound}
 import scalikejdbc._
@@ -31,8 +31,7 @@ case class DbRule(
 }
 
 object DbRule extends SQLSyntaxSupport[DbRule] {
-  implicit val reads: Reads[DbRule] = Json.reads[DbRule]
-  implicit val writes: Writes[DbRule] = Json.writes[DbRule]
+  implicit val format: Format[DbRule] = Json.format[DbRule]
 
   override val tableName = "rules"
 

--- a/apps/rule-manager/app/service/DbRuleManager.scala
+++ b/apps/rule-manager/app/service/DbRuleManager.scala
@@ -113,10 +113,7 @@ object DbRuleManager extends Loggable {
   def getRulesAsRuleResource() = {
     val (failedDbRules, successfulDbRules) = getRules()
       .map(dbRuleToBaseRule)
-      .partitionMap {
-        case l @ Left(_)  => l
-        case r @ Right(_) => r
-      }
+      .partitionMap(identity)
 
     failedDbRules match {
       case Nil      => Right(RuleResource(successfulDbRules))

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -11,7 +11,7 @@ import {
     EuiButtonIcon,
     EuiFlexGrid,
 } from '@elastic/eui';
-import {useRules} from "./hooks/rules-hook";
+import {useRules} from "./hooks/useRules";
 import {css} from "@emotion/react";
 
 const sorting = {
@@ -41,33 +41,24 @@ export type Rule = {
 
 const columns: Array<EuiBasicTableColumn<Rule>> = [
     {
-        field: '_type',
+        field: 'ruleType',
         name: 'Type',
-        render: (_type: Rule['type']) => {
-            return <>{_type.split('.').pop()}</>
-        }
     },
     {
-        field: 'id',
+        field: 'googleSheetId',
         name: 'ID'
     },
     {
         field: 'category',
         name: 'Category',
-        render: (category: Rule['category']) => {
-            return <>{category?.name}</>
-        }
     },
     {
-        field: 'regex',
+        field: 'pattern',
         name: 'Match',
     },
     {
       field: 'replacement',
       name: 'Replacement',
-      render: (replacement: Rule['replacement']) => {
-        return <>{replacement?.text}</>
-      }
     },
     {
         field: 'description',

--- a/apps/rule-manager/client/src/ts/components/hooks/useRules.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRules.ts
@@ -1,5 +1,4 @@
-import React, {useEffect, useState} from 'react';
-import {Promise as PromiseType} from 'es6-promise'
+import {useEffect, useState} from 'react';
 
 export function useRules() {
     const { location } = window;
@@ -7,14 +6,14 @@ export function useRules() {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState(null);
     const [isRefreshing, setIsRefreshing] = useState(false);
-    const fetchRules = async (): PromiseType<void> => {
+    const fetchRules = async (): Promise<void> => {
         setIsLoading(true);
         try {
             const response = await fetch(`${location}rules`);
             if (!response.ok) {
                 throw new Error(`Failed to fetch rules: ${response.status} ${response.statusText}`);
             }
-            const { rules } = await response.json();
+            const rules = await response.json();
             setRules(rules);
         } catch (error) {
             setError(error);
@@ -22,7 +21,7 @@ export function useRules() {
         setIsLoading(false);
     }
 
-    const refreshRules = async (): PromiseType<void>  => {
+    const refreshRules = async (): Promise<void>  => {
         setIsRefreshing(true);
         try {
             const updatedRulesResponse = await fetch(`${location}refresh`, {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Following up from @rhystmills' comments in #305, this PR passes DbRules, not BaseRules, to the frontend.

This means we always see what's written to the database in our UI.  

## How to test

This PR is based on #305, so, following the instructions in that PR, create and update some rules. Do they appear in the UI when the page is refreshed? 