### PR TITLE
Add creation and update meta to rule model

### DIFF
--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -59,7 +59,7 @@ class RulesController(
         },
         formRule => {
           DbRule.createFromFormRule(formRule, request.user.email) match {
-            case Success(rule)  => Ok(DbRule.toJson(rule))
+            case Success(rule)  => Ok(Json.toJson(rule))
             case Failure(error) => InternalServerError(error.getMessage())
           }
         }
@@ -77,7 +77,7 @@ class RulesController(
         formRule => {
           DbRule.updateFromFormRule(formRule, id, request.user.email) match {
             case Left(result)  => result
-            case Right(dbRule) => Ok(DbRule.toJson(dbRule))
+            case Right(dbRule) => Ok(Json.toJson(dbRule))
           }
         }
       )

--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -9,19 +9,19 @@ import scalikejdbc._
 import scala.util.{Failure, Try}
 
 case class DbRule(
-    id: Option[Int],
-    ruleType: String,
-    pattern: Option[String] = None,
-    replacement: Option[String] = None,
-    category: Option[String] = None,
-    tags: Option[String] = None,
-    description: Option[String] = None,
-    ignore: Boolean,
-    notes: Option[String] = None,
-    googleSheetId: Option[String] = None,
-    forceRedRule: Option[Boolean] = None,
-    advisoryRule: Option[Boolean] = None
-) {
+                   id: Option[Int],
+                   ruleType: String,
+                   pattern: Option[String] = None,
+                   replacement: Option[String] = None,
+                   category: Option[String] = None,
+                   tags: Option[String] = None,
+                   description: Option[String] = None,
+                   ignore: Boolean,
+                   notes: Option[String] = None,
+                   googleSheetId: Option[String] = None,
+                   forceRedRule: Option[Boolean] = None,
+                   advisoryRule: Option[Boolean] = None
+                 ) {
 
   def save()(implicit session: DBSession = DbRule.autoSession): Try[DbRule] =
     DbRule.save(this)(session)
@@ -50,8 +50,6 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
     "advisory_rule"
   )
 
-  def fromSyntaxProvider(r: SyntaxProvider[DbRule])(rs: WrappedResultSet): DbRule =
-    autoConstruct(rs, r)
   def fromResultName(r: ResultName[DbRule])(rs: WrappedResultSet): DbRule = autoConstruct(rs, r)
 
   val r = DbRule.syntax("r")
@@ -65,10 +63,7 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
   }
 
   def findAll()(implicit session: DBSession = autoSession): List[DbRule] = {
-    withSQL(select.from(DbRule as r).orderBy(r.id))
-      .map(DbRule.fromResultName(r.resultName))
-      .list
-      .apply()
+    withSQL(select.from(DbRule as r).orderBy(r.id)).map(DbRule.fromResultName(r.resultName)).list.apply()
   }
 
   def countAll()(implicit session: DBSession = autoSession): Long = {

--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -243,7 +243,9 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
         Symbol("notes") -> entity.notes,
         Symbol("googleSheetId") -> entity.googleSheetId,
         Symbol("forceRedRule") -> entity.forceRedRule,
-        Symbol("advisoryRule") -> entity.advisoryRule
+        Symbol("advisoryRule") -> entity.advisoryRule,
+        Symbol("createdBy") -> entity.createdBy,
+        Symbol("updatedBy") -> entity.updatedBy
       )
     )
     SQL("""insert into rules(
@@ -257,7 +259,9 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
       notes,
       google_sheet_id,
       force_red_rule,
-      advisory_rule
+      advisory_rule,
+      created_by,
+      updated_by
     ) values (
       {ruleType},
       {pattern},
@@ -269,7 +273,9 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
       {notes},
       {googleSheetId},
       {forceRedRule},
-      {advisoryRule}
+      {advisoryRule},
+      {createdBy},
+      {updatedBy}
     )""").batchByName(params.toSeq: _*).apply[List]()
   }
 

--- a/apps/rule-manager/app/service/DbRuleManager.scala
+++ b/apps/rule-manager/app/service/DbRuleManager.scala
@@ -13,6 +13,8 @@ import com.gu.typerighter.model.{
 }
 import db.DbRule
 
+import java.time.LocalDateTime
+
 object DbRuleManager extends Loggable {
   object RuleType {
     val regex = "regex"
@@ -23,7 +25,7 @@ object DbRuleManager extends Loggable {
   def baseRuleToDbRule(rule: BaseRule): DbRule = {
     rule match {
       case RegexRule(id, category, description, _, replacement, regex) =>
-        DbRule(
+        DbRule.withUser(
           id = None,
           ruleType = RuleType.regex,
           pattern = Some(regex.toString()),
@@ -31,10 +33,11 @@ object DbRuleManager extends Loggable {
           description = Some(description),
           replacement = replacement.map(_.text),
           ignore = false,
-          googleSheetId = Some(id)
+          googleSheetId = Some(id),
+          user = "Google Sheet"
         )
       case LTRuleXML(id, xml, category, description) =>
-        DbRule(
+        DbRule.withUser(
           id = None,
           ruleType = RuleType.languageToolXML,
           pattern = Some(xml),
@@ -42,14 +45,16 @@ object DbRuleManager extends Loggable {
           description = Some(description),
           replacement = None,
           ignore = false,
-          googleSheetId = Some(id)
+          googleSheetId = Some(id),
+          user = "Google Sheet"
         )
       case LTRuleCore(_, languageToolRuleId) =>
-        DbRule(
+        DbRule.withUser(
           id = None,
           ruleType = RuleType.languageToolCore,
           googleSheetId = Some(languageToolRuleId),
-          ignore = false
+          ignore = false,
+          user = "Google Sheet"
         )
     }
   }
@@ -67,6 +72,10 @@ object DbRuleManager extends Loggable {
             _,
             _,
             Some(googleSheetId),
+            _,
+            _,
+            _,
+            _,
             _,
             _
           ) =>
@@ -92,6 +101,10 @@ object DbRuleManager extends Loggable {
             _,
             Some(googleSheetId),
             _,
+            _,
+            _,
+            _,
+            _,
             _
           ) =>
         Right(
@@ -102,7 +115,24 @@ object DbRuleManager extends Loggable {
             xml = pattern
           )
         )
-      case DbRule(_, RuleType.languageToolCore, _, _, _, _, _, _, _, Some(googleSheetId), _, _) =>
+      case DbRule(
+            _,
+            RuleType.languageToolCore,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            Some(googleSheetId),
+            _,
+            _,
+            _,
+            _,
+            _,
+            _
+          ) =>
         Right(LTRuleCore(googleSheetId, googleSheetId))
       case other => Left(s"Could not derive BaseRule from DbRule for: $other")
     }

--- a/apps/rule-manager/conf/evolutions/default/3.sql
+++ b/apps/rule-manager/conf/evolutions/default/3.sql
@@ -1,0 +1,15 @@
+-- !Ups
+
+ALTER TABLE rules
+  ADD COLUMN created_by TEXT NOT NULL DEFAULT 'Google Sheet',
+  ADD COLUMN created_at timestamp DEFAULT current_timestamp,
+  ADD COLUMN updated_by TEXT NOT NULL DEFAULT 'Google Sheet',
+  ADD COLUMN updated_at timestamp DEFAULT current_timestamp;
+
+-- !Downs
+
+ALTER TABLE rules
+  DROP COLUMN created_by,
+  DROP COLUMN created_at,
+  DROP COLUMN updated_by,
+  DROP COLUMN updated_at;

--- a/apps/rule-manager/conf/evolutions/default/3.sql
+++ b/apps/rule-manager/conf/evolutions/default/3.sql
@@ -1,10 +1,17 @@
 -- !Ups
 
+-- Initialise existing rows with the default user 'Google Sheet',
+-- which will be the source of any existing rows.
 ALTER TABLE rules
   ADD COLUMN created_by TEXT NOT NULL DEFAULT 'Google Sheet',
   ADD COLUMN created_at timestamptz DEFAULT now(),
   ADD COLUMN updated_by TEXT NOT NULL DEFAULT 'Google Sheet',
   ADD COLUMN updated_at timestamptz DEFAULT now();
+
+-- Remove that default for future rows.
+ALTER TABLE rules
+  ALTER COLUMN created_by DROP DEFAULT,
+  ALTER COLUMN updated_by DROP DEFAULT;
 
 -- !Downs
 

--- a/apps/rule-manager/conf/evolutions/default/3.sql
+++ b/apps/rule-manager/conf/evolutions/default/3.sql
@@ -2,9 +2,9 @@
 
 ALTER TABLE rules
   ADD COLUMN created_by TEXT NOT NULL DEFAULT 'Google Sheet',
-  ADD COLUMN created_at timestamp DEFAULT current_timestamp,
+  ADD COLUMN created_at timestamptz DEFAULT now(),
   ADD COLUMN updated_by TEXT NOT NULL DEFAULT 'Google Sheet',
-  ADD COLUMN updated_at timestamp DEFAULT current_timestamp;
+  ADD COLUMN updated_at timestamptz DEFAULT now();
 
 -- !Downs
 

--- a/apps/rule-manager/package-lock.json
+++ b/apps/rule-manager/package-lock.json
@@ -1,0 +1,375 @@
+{
+  "name": "rule-manager",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/immutable": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
+      "dev": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/sass": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.60.0.tgz",
+      "integrity": "sha512-updbwW6fNb5gGm8qMXzVO7V4sWf7LMXnMly/JEyfbfERbVH46Fn6q02BX7/eHTdKpE7d+oTkMMQpFWNUMfFbgQ==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    }
+  },
+  "dependencies": {
+    "anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "immutable": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "sass": {
+      "version": "https://registry.npmjs.org/sass/-/sass-1.60.0.tgz",
+      "integrity": "sha512-updbwW6fNb5gGm8qMXzVO7V4sWf7LMXnMly/JEyfbfERbVH46Fn6q02BX7/eHTdKpE7d+oTkMMQpFWNUMfFbgQ==",
+      "dev": true,
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      }
+    },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    }
+  }
+}

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -17,7 +17,7 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
 
   override def fixture(implicit session: DBSession) {
     sql"ALTER SEQUENCE rules_id_seq RESTART WITH 1".update.apply()
-    sql"insert into rules (rule_type, pattern, replacement, category, tags, description, ignore, notes, google_sheet_id, force_red_rule, advisory_rule) values (${"regex"}, ${"pattern"}, ${"replacement"}, ${"category"}, ${"someTags"}, ${"description"}, false, ${"notes"}, ${"googleSheetId"}, false, false)".update
+    sql"insert into rules (rule_type, pattern, replacement, category, tags, description, ignore, notes, google_sheet_id, force_red_rule, advisory_rule, created_by, updated_by) values (${"regex"}, ${"pattern"}, ${"replacement"}, ${"category"}, ${"someTags"}, ${"description"}, false, ${"notes"}, ${"googleSheetId"}, false, false, 'test.user', 'test.user')".update
       .apply()
   }
 

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -47,7 +47,7 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     count should be > (0L)
   }
   it should "create new record" in { implicit session =>
-    val created = DbRule.create(ruleType = "regex", pattern = Some("MyString"), ignore = false)
+    val created = DbRule.create(ruleType = "regex", pattern = Some("MyString"), ignore = false, user = "test.user")
     created should not be (null)
   }
   it should "create a new record from a form rule" in { implicit session =>
@@ -64,17 +64,18 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
       forceRedRule = None,
       advisoryRule = None
     )
-    val dbRule = DbRule.createFromFormRule(formRule)
+    val dbRule = DbRule.createFromFormRule(formRule, user = "test.user")
     dbRule should not be (null)
   }
-  it should "update an existing record using a form rule" in { implicit session =>
-    val existingRule = DbRule.create(ruleType = "regex", pattern = Some("MyString"), ignore = false)
+
+  it should "edit an existing record using a form rule" in { implicit session =>
+    val existingRule = DbRule.create(ruleType = "regex", pattern = Some("MyString"), ignore = false, user = "test.user").get
     val existingId = existingRule.id.get
     val formRule = UpdateRuleForm(
       ruleType = Some("regex"),
       pattern = Some("NewString")
     )
-    val dbRule = DbRule.updateFromFormRule(formRule, existingId)
+    val dbRule = DbRule.updateFromFormRule(formRule, existingId, "test.user")
     val rule = dbRule.getOrElse(null)
     rule.id should be(Some(existingId))
     rule.pattern should be(Some("NewString"))
@@ -86,7 +87,7 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
         pattern = Some("NewString")
       )
       val nonExistentRuleId = 2000
-      val dbRule = DbRule.updateFromFormRule(formRule, nonExistentRuleId)
+      val dbRule = DbRule.updateFromFormRule(formRule, nonExistentRuleId, "test.user")
       dbRule should be(Left(NotFound("Rule not found matching ID")))
   }
   it should "save a record" in { implicit session =>
@@ -109,7 +110,7 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     batchInserted.size should be > (0)
   }
   it should "return a JSON representation of a rule" in { implicit session =>
-    val created = DbRule.create(ruleType = "regex", pattern = Some("MyString"), ignore = false)
+    val created = DbRule.create(ruleType = "regex", pattern = Some("MyString"), ignore = false, user = "test.user").get
     val json = DbRule.toJson(created)
     val expected = Json.parse(s"""
     {

--- a/apps/rule-manager/test/db/RulesSpec.scala
+++ b/apps/rule-manager/test/db/RulesSpec.scala
@@ -9,6 +9,7 @@ import scalikejdbc._
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.Results.NotFound
 
+import java.time.{ZoneOffset, ZonedDateTime}
 import scala.util.Success
 
 class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with DBTest {
@@ -18,6 +19,10 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     sql"ALTER SEQUENCE rules_id_seq RESTART WITH 1".update.apply()
     sql"insert into rules (rule_type, pattern, replacement, category, tags, description, ignore, notes, google_sheet_id, force_red_rule, advisory_rule) values (${"regex"}, ${"pattern"}, ${"replacement"}, ${"category"}, ${"someTags"}, ${"description"}, false, ${"notes"}, ${"googleSheetId"}, false, false)".update
       .apply()
+  }
+
+  def assertDatesAreWithinRangeMs(date1: ZonedDateTime, date2: ZonedDateTime, range: Int) = {
+    date1.toInstant().toEpochMilli should be(date2.toInstant().toEpochMilli +- range)
   }
 
   behavior of "Rules"
@@ -46,9 +51,15 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     val count = DbRule.countBy(sqls.eq(r.id, 1))
     count should be > (0L)
   }
-  it should "create new record" in { implicit session =>
-    val created = DbRule.create(ruleType = "regex", pattern = Some("MyString"), ignore = false, user = "test.user")
-    created should not be (null)
+  it should "create new record and autofill createdAt and updatedAt" in { implicit session =>
+    val created = DbRule
+      .create(ruleType = "regex", pattern = Some("MyString"), ignore = false, user = "test.user")
+      .get
+
+    created.createdBy shouldBe "test.user"
+    created.updatedBy shouldBe "test.user"
+    assertDatesAreWithinRangeMs(created.createdAt, ZonedDateTime.now, 1000)
+    assertDatesAreWithinRangeMs(created.updatedAt, ZonedDateTime.now, 1000)
   }
   it should "create a new record from a form rule" in { implicit session =>
     val formRule = CreateRuleForm(
@@ -68,18 +79,34 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     dbRule should not be (null)
   }
 
-  it should "edit an existing record using a form rule" in { implicit session =>
-    val existingRule = DbRule.create(ruleType = "regex", pattern = Some("MyString"), ignore = false, user = "test.user").get
-    val existingId = existingRule.id.get
-    val formRule = UpdateRuleForm(
-      ruleType = Some("regex"),
-      pattern = Some("NewString")
-    )
-    val dbRule = DbRule.updateFromFormRule(formRule, existingId, "test.user")
-    val rule = dbRule.getOrElse(null)
-    rule.id should be(Some(existingId))
-    rule.pattern should be(Some("NewString"))
+  it should "edit an existing record using a form rule, updating the user and updated datetime" in {
+    implicit session =>
+      val existingRule = DbRule
+        .create(ruleType = "regex", pattern = Some("MyString"), ignore = false, user = "test.user")
+        .get
+      val existingId = existingRule.id.get
+      val formRule = UpdateRuleForm(
+        ruleType = Some("regex"),
+        pattern = Some("NewString")
+      )
+
+      val dbRule = DbRule.updateFromFormRule(formRule, existingId, "another.user").getOrElse(null)
+
+      dbRule.id should be(Some(existingId))
+      dbRule.pattern should be(Some("NewString"))
+      dbRule.updatedBy should be("another.user")
+      dbRule.updatedAt.toInstant.toEpochMilli should be > existingRule.updatedAt.toInstant.toEpochMilli
   }
+
+  it should "save a record, updating the modified fields" in { implicit session =>
+    val entity = DbRule.findAll().head
+    val modified = entity.copy(pattern = Some("NotMyString"))
+    val updated = DbRule.save(modified, "test.user").get
+    updated.pattern should equal(Some("NotMyString"))
+    updated.updatedBy should equal("test.user")
+    updated.updatedAt.toInstant.toEpochMilli should be > entity.updatedAt.toInstant.toEpochMilli
+  }
+
   it should "return an error when attempting to update a record that doesn't exist" in {
     implicit session =>
       val formRule = UpdateRuleForm(
@@ -90,12 +117,7 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
       val dbRule = DbRule.updateFromFormRule(formRule, nonExistentRuleId, "test.user")
       dbRule should be(Left(NotFound("Rule not found matching ID")))
   }
-  it should "save a record" in { implicit session =>
-    val entity = DbRule.findAll().head
-    val modified = entity.copy(pattern = Some("NotMyString"))
-    val updated = DbRule.save(modified)
-    updated should equal(Success(modified))
-  }
+
   it should "destroy a record" in { implicit session =>
     val entity = DbRule.findAll().head
     val deleted = DbRule.destroy(entity)
@@ -108,26 +130,5 @@ class RulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with 
     entities.foreach(e => DbRule.destroy(e))
     val batchInserted = DbRule.batchInsert(entities)
     batchInserted.size should be > (0)
-  }
-  it should "return a JSON representation of a rule" in { implicit session =>
-    val created = DbRule.create(ruleType = "regex", pattern = Some("MyString"), ignore = false, user = "test.user").get
-    val json = DbRule.toJson(created)
-    val expected = Json.parse(s"""
-    {
-      "ruleType" : "regex",
-      "forceRedRule": null,
-      "replacement": null,
-      "advisoryRule": null,
-      "id": ${created.id.get},
-      "category": null,
-      "notes": null,
-      "ignore": false,
-      "pattern": "MyString",
-      "googleSheetId": null,
-      "description": null,
-      "tags": null
-    }
-    """)
-    json should equal(expected)
   }
 }


### PR DESCRIPTION
**NB:** based on https://github.com/guardian/typerighter/pull/306 – please review that first!

## What does this change?

Adds `createdAt`, `createdBy`, `updatedAt` and `updatedBy` to the rule model. They're updated automatically as rules are created and modified.

### This happens in the application logic! Why not write a database trigger to update `updatedAt`?

We could! But we'd still have to write the user data – it made some sense to me to keep all of the logic for our meta in one domain. If there's a preference for a DB trigger, we could do that instead. One advantage would be that there's no possibility of us missing an update as a result of an error in application code.

## How to test

- The automated tests should pass, and you should be convinced they cover both creation and updating cases.
- Try creating and updating rules in Postman, following the instructions in #305. When you create or update rules, are creation/update values correct? E.g. with Postman:

<img width="516" alt="Screenshot 2023-04-18 at 18 12 36" src="https://user-images.githubusercontent.com/7767575/232857682-505a70be-cacc-41f3-a877-e06bda3cce7a.png">


