### PR TITLE
scalafmt -> scalafmtAll in commit hook, to catch linting in tests

### DIFF
--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -12,7 +12,7 @@ else
   # Try the CLI version for performance.
   echo "Formatting code format via scalafmt..."
   echo "This step can be skipped by using the --no-verify flag for git commit."
-  $(command -v scalafmt >/dev/null 2>&1 && $(scalafmt --config "${SCALAFMT_CONFIG}" --exclude target --mode changed --non-interactive --quiet --test >/dev/null 2>&1) || $(sbt scalafmt >/dev/null 2>&1))
+  $(command -v scalafmt >/dev/null 2>&1 && $(scalafmt --config "${SCALAFMT_CONFIG}" --exclude target --mode changed --non-interactive --quiet --test >/dev/null 2>&1) || $(sbt scalafmtAll >/dev/null 2>&1))
   STATUS=$?
   if [ ! $STATUS -eq 0 ]; then
     echo ""


### PR DESCRIPTION
## What does this change?

`sbt scalafmt` does not lint tests! This PR changes the command to `scalafmtAll`, which does. (AFAIK the cli invocations do format everything, so we can leave them as-is.)

## How to test

Change a test file and run the commit hook. You should see formatting applied to tests.