### PR TITLE
Add revisionId to rule model

### DIFF
--- a/apps/rule-manager/app/db/DbRule.scala
+++ b/apps/rule-manager/app/db/DbRule.scala
@@ -25,7 +25,8 @@ case class DbRule(
     createdAt: ZonedDateTime,
     createdBy: String,
     updatedAt: ZonedDateTime,
-    updatedBy: String
+    updatedBy: String,
+    revisionId: Int = 0
 )
 
 object DbRule extends SQLSyntaxSupport[DbRule] {
@@ -49,7 +50,8 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
     "created_at",
     "created_by",
     "updated_at",
-    "updated_by"
+    "updated_by",
+    "revision_id"
   )
 
   def fromResultName(r: ResultName[DbRule])(rs: WrappedResultSet): DbRule = autoConstruct(rs, r)
@@ -298,7 +300,8 @@ object DbRule extends SQLSyntaxSupport[DbRule] {
           column.createdAt -> entity.createdAt,
           column.createdBy -> entity.createdBy,
           column.updatedAt -> ZonedDateTime.now(),
-          column.updatedBy -> user
+          column.updatedBy -> user,
+          column.revisionId -> sqls"${column.revisionId} + 1"
         )
         .where
         .eq(column.id, entity.id)

--- a/apps/rule-manager/app/service/DbRuleManager.scala
+++ b/apps/rule-manager/app/service/DbRuleManager.scala
@@ -77,6 +77,7 @@ object DbRuleManager extends Loggable {
             _,
             _,
             _,
+            _,
             _
           ) =>
         Right(
@@ -105,6 +106,7 @@ object DbRuleManager extends Loggable {
             _,
             _,
             _,
+            _,
             _
           ) =>
         Right(
@@ -126,6 +128,7 @@ object DbRuleManager extends Loggable {
             _,
             _,
             Some(googleSheetId),
+            _,
             _,
             _,
             _,

--- a/apps/rule-manager/conf/evolutions/default/4.sql
+++ b/apps/rule-manager/conf/evolutions/default/4.sql
@@ -1,0 +1,7 @@
+-- !Ups
+
+ALTER TABLE rules ADD COLUMN revision_id INT NOT NULL DEFAULT 0;
+
+-- !Downs
+
+ALTER TABLE rules DROP COLUMN revision_id;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a revisionId to the rule model. It's incremented in the application logic when we call `save`.

## How to test

- The automated tests should pass – they check for the increment.
- Create and update a rule via the instructions in #305. You should see a revisionId in the output, which should increment on every update. 
