### PR TITLE
Add create rule form (first pass)

### DIFF
--- a/apps/rule-manager/client/package-lock.json
+++ b/apps/rule-manager/client/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@elastic/datemath": "^5.0.3",
-        "@elastic/eui": "^76.2.0",
+        "@elastic/eui": "^77.2.0",
         "@emotion/cache": "^11.10.5",
         "@emotion/css": "^11.10.6",
         "@emotion/react": "^11.10.6",
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
+      "integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
       "dependencies": {
         "@babel/highlight": "^7.18.6"
       },
@@ -47,11 +47,11 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz",
+      "integrity": "sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==",
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.21.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
-      "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.4.tgz",
+      "integrity": "sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@elastic/eui": {
-      "version": "76.4.0",
-      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-76.4.0.tgz",
-      "integrity": "sha512-0b3w6CloIZZ8B+URDSYLQsyTtc/GadkbNcoDg+20SeRuB8q339S+n6tbq+sVX+uk/RtRu1T/068mAd6nZZmqIg==",
+      "version": "77.2.0",
+      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-77.2.0.tgz",
+      "integrity": "sha512-6j3jqXdRmLGQ530GtdMrXyqi7rVd/XCMhymgO+FJiamf3dw5NF1LsXiOTn2+lTa/Tn3v2sJMVsr+SL+0h2Cd+A==",
       "dependencies": {
         "@types/chroma-js": "^2.0.0",
         "@types/lodash": "^4.14.160",
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@emotion/cache": {
-      "version": "11.10.5",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.5.tgz",
-      "integrity": "sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==",
+      "version": "11.10.7",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.7.tgz",
+      "integrity": "sha512-VLl1/2D6LOjH57Y8Vem1RoZ9haWF4jesHDGiHtKozDQuBIkJm2gimVo0I02sWCuzZtVACeixTVB4jeE8qvCBoQ==",
       "dependencies": {
         "@emotion/memoize": "^0.8.0",
         "@emotion/sheet": "^1.2.1",
@@ -329,10 +329,58 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
       "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.17.tgz",
+      "integrity": "sha512-E6VAZwN7diCa3labs0GYvhEPL2M94WLF8A+czO8hfjREXxba8Ng7nM5VxV+9ihNXIY1iQO1XxUU4P7hbqbICxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.17.tgz",
+      "integrity": "sha512-jaJ5IlmaDLFPNttv0ofcwy/cfeY4bh/n705Tgh+eLObbGtQBK3EPAu+CzL95JVE4nFAliyrnEu0d32Q5foavqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.17.tgz",
+      "integrity": "sha512-446zpfJ3nioMC7ASvJB1pszHVskkw4u/9Eu8s5yvvsSDTzYh4p4ZIRj0DznSl3FBF0Z/mZfrKXTtt0QCoFmoHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.14",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.14.tgz",
-      "integrity": "sha512-eoSjEuDsU1ROwgBH/c+fZzuSyJUVXQTOIN9xuLs9dE/9HbV/A5IqdXHU1p2OfIMwBwOYJ9SFVGGldxeRCUJFyw==",
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.17.tgz",
+      "integrity": "sha512-m/gwyiBwH3jqfUabtq3GH31otL/0sE0l34XKpSIqR7NjQ/XHQ3lpmQHLHbG8AHTGCw8Ao059GvV08MS0bhFIJQ==",
       "cpu": [
         "arm64"
       ],
@@ -340,6 +388,294 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.17.tgz",
+      "integrity": "sha512-4utIrsX9IykrqYaXR8ob9Ha2hAY2qLc6ohJ8c0CN1DR8yWeMrTgYFjgdeQ9LIoTOfLetXjuCu5TRPHT9yKYJVg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.17.tgz",
+      "integrity": "sha512-4PxjQII/9ppOrpEwzQ1b0pXCsFLqy77i0GaHodrmzH9zq2/NEhHMAMJkJ635Ns4fyJPFOlHMz4AsklIyRqFZWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.17.tgz",
+      "integrity": "sha512-lQRS+4sW5S3P1sv0z2Ym807qMDfkmdhUYX30GRBURtLTrJOPDpoU0kI6pVz1hz3U0+YQ0tXGS9YWveQjUewAJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.17.tgz",
+      "integrity": "sha512-biDs7bjGdOdcmIk6xU426VgdRUpGg39Yz6sT9Xp23aq+IEHDb/u5cbmu/pAANpDB4rZpY/2USPhCA+w9t3roQg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.17.tgz",
+      "integrity": "sha512-2+pwLx0whKY1/Vqt8lyzStyda1v0qjJ5INWIe+d8+1onqQxHLLi3yr5bAa4gvbzhZqBztifYEu8hh1La5+7sUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.17.tgz",
+      "integrity": "sha512-IBTTv8X60dYo6P2t23sSUYym8fGfMAiuv7PzJ+0LcdAndZRzvke+wTVxJeCq4WgjppkOpndL04gMZIFvwoU34Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.17.tgz",
+      "integrity": "sha512-WVMBtcDpATjaGfWfp6u9dANIqmU9r37SY8wgAivuKmgKHE+bWSuv0qXEFt/p3qXQYxJIGXQQv6hHcm7iWhWjiw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.17.tgz",
+      "integrity": "sha512-2kYCGh8589ZYnY031FgMLy0kmE4VoGdvfJkxLdxP4HJvWNXpyLhjOvxVsYjYZ6awqY4bgLR9tpdYyStgZZhi2A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.17.tgz",
+      "integrity": "sha512-KIdG5jdAEeAKogfyMTcszRxy3OPbZhq0PPsW4iKKcdlbk3YE4miKznxV2YOSmiK/hfOZ+lqHri3v8eecT2ATwQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.17.tgz",
+      "integrity": "sha512-Cj6uWLBR5LWhcD/2Lkfg2NrkVsNb2sFM5aVEfumKB2vYetkA/9Uyc1jVoxLZ0a38sUhFk4JOVKH0aVdPbjZQeA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.17.tgz",
+      "integrity": "sha512-lK+SffWIr0XsFf7E0srBjhpkdFVJf3HEgXCwzkm69kNbRar8MhezFpkIwpk0qo2IOQL4JE4mJPJI8AbRPLbuOQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.17.tgz",
+      "integrity": "sha512-XcSGTQcWFQS2jx3lZtQi7cQmDYLrpLRyz1Ns1DzZCtn898cWfm5Icx/DEWNcTU+T+tyPV89RQtDnI7qL2PObPg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.17.tgz",
+      "integrity": "sha512-RNLCDmLP5kCWAJR+ItLM3cHxzXRTe4N00TQyQiimq+lyqVqZWGPAvcyfUBM0isE79eEZhIuGN09rAz8EL5KdLA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.17.tgz",
+      "integrity": "sha512-PAXswI5+cQq3Pann7FNdcpSUrhrql3wKjj3gVkmuz6OHhqqYxKvi6GgRBoaHjaG22HV/ZZEgF9TlS+9ftHVigA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.17.tgz",
+      "integrity": "sha512-V63egsWKnx/4V0FMYkr9NXWrKTB5qFftKGKuZKFIrAkO/7EWLFnbBZNM1CvJ6Sis+XBdPws2YQSHF1Gqf1oj/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.17.tgz",
+      "integrity": "sha512-YtUXLdVnd6YBSYlZODjWzH+KzbaubV0YVd6UxSfoFfa5PtNJNaW+1i+Hcmjpg2nEe0YXUCNF5bkKy1NnBv1y7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.17.tgz",
+      "integrity": "sha512-yczSLRbDdReCO74Yfc5tKG0izzm+lPMYyO1fFTcn0QNwnKmc3K+HdxZWLGKg4pZVte7XVgcFku7TIZNbWEJdeQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.17.tgz",
+      "integrity": "sha512-FNZw7H3aqhF9OyRQbDDnzUApDXfC1N6fgBhkqEO2jvYCJ+DxMTfZVqg3AX0R1khg1wHTBRD5SdcibSJ+XF6bFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -378,9 +714,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.3.42",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.42.tgz",
-      "integrity": "sha512-nVFUd5+7tGniM2cT3LXaqnu3735Cu4az8A9gAKK+8sdpASI52SWuqfDBmjFCK9xG90MiVDVp2PTZr0BWqCIzpw==",
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.51.tgz",
+      "integrity": "sha512-/fdKlrs2NacLeOKrVZjCPfw5GeUIyBcJg0GDBn0+qwC3Y6k85m4aswK1sfRDF3nzyeXXoBr7YBb+/cSdFq9pVw==",
       "dev": true,
       "hasInstallScript": true,
       "engines": {
@@ -391,22 +727,30 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.42",
-        "@swc/core-darwin-x64": "1.3.42",
-        "@swc/core-linux-arm-gnueabihf": "1.3.42",
-        "@swc/core-linux-arm64-gnu": "1.3.42",
-        "@swc/core-linux-arm64-musl": "1.3.42",
-        "@swc/core-linux-x64-gnu": "1.3.42",
-        "@swc/core-linux-x64-musl": "1.3.42",
-        "@swc/core-win32-arm64-msvc": "1.3.42",
-        "@swc/core-win32-ia32-msvc": "1.3.42",
-        "@swc/core-win32-x64-msvc": "1.3.42"
+        "@swc/core-darwin-arm64": "1.3.51",
+        "@swc/core-darwin-x64": "1.3.51",
+        "@swc/core-linux-arm-gnueabihf": "1.3.51",
+        "@swc/core-linux-arm64-gnu": "1.3.51",
+        "@swc/core-linux-arm64-musl": "1.3.51",
+        "@swc/core-linux-x64-gnu": "1.3.51",
+        "@swc/core-linux-x64-musl": "1.3.51",
+        "@swc/core-win32-arm64-msvc": "1.3.51",
+        "@swc/core-win32-ia32-msvc": "1.3.51",
+        "@swc/core-win32-x64-msvc": "1.3.51"
+      },
+      "peerDependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.42",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.42.tgz",
-      "integrity": "sha512-hM6RrZFyoCM9mX3cj/zM5oXwhAqjUdOCLXJx7KTQps7NIkv/Qjvobgvyf2gAb89j3ARNo9NdIoLjTjJ6oALtiA==",
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.51.tgz",
+      "integrity": "sha512-DM15fJgaXQ+BOoTlMCBoRBSzkpC2V8vAXaAvh3BZ+BI6/03FUQ0j9CMIaSkss3VOv+WwqzllmcT71C/oVDQ7Tg==",
       "cpu": [
         "arm64"
       ],
@@ -414,6 +758,150 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.51.tgz",
+      "integrity": "sha512-EPAneufZfFQUkpkf2m8Ap8TajLvjWI+UmDQz54QaofLaigXgrnLoqTtnZHBfDbUTApGYz3GaqjfZ2fMLGiISLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.51.tgz",
+      "integrity": "sha512-sASxO3lJjlY5g8S25yCQirDOW6zqBNeDSUCBrulaVxttx0PcL64kc6qaOlM3HKlNO4W1P7RW/mGFR4bBov+yIg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.51.tgz",
+      "integrity": "sha512-z8yHRUK+5mRxSQkw9uND8QSt8lTrW0X8blmP12Q7c7RKWOHqIaGS60a3VvLuTal7k48K4YTstSevIrGwGK88sA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.51.tgz",
+      "integrity": "sha512-lMlp09lv6qDURvETw4AAZAjaJfvjwHjiAuB+JuZrgP3zdxB21M6cMas3EjAGXtNabpU1FJu+8Lsys6/GBBjsPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.51.tgz",
+      "integrity": "sha512-6zK4tDr6do6RFTJv38Rb8ZjBLdfSN7GeuyOJpblz1Qu62RqyY2Zf3fxuCZY9tkoEepZ0MvU0d4D7HhAUYKj20A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.51.tgz",
+      "integrity": "sha512-ZwW+X9XdEiAszX+zfaLdOVfi5rQP3vnVwuNAiuX9eq5jHdfOKfKaNtJaGTD8w8NgMavaBM5AMaCHshFVNF0vRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.51.tgz",
+      "integrity": "sha512-w+IX4xCIZH6RQG7RrOOrrHqIqM7JIj9BDZHM9LAYC5MIbDinwjnSUXz7bpn0L1LRusvPtmbTulLuSkmVBSSwAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.51.tgz",
+      "integrity": "sha512-Bzv/h0HkoKkTWOOoHtehId/6AS5hLBbWE5czzcQc8SWs+BNNV8zjWoq1oYn7/gLLEhdKaBAxv9q7RHzOfBx28A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.51.tgz",
+      "integrity": "sha512-dTKAdSd0e2Sfz3Sl3m6RGLQbk6jdSIh8TlFomF4iiHDHq4PxLTzjaOVvKUAP5wux9DtBnAgZeSHMuQfM4aL9oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=10"
@@ -452,9 +940,9 @@
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.192",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.192.tgz",
-      "integrity": "sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A=="
+      "version": "4.14.194",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
+      "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g=="
     },
     "node_modules/@types/mdast": {
       "version": "3.0.11",
@@ -490,9 +978,9 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/react": {
-      "version": "17.0.55",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.55.tgz",
-      "integrity": "sha512-kBcAhmT8RivFDYxHdy8QfPKu+WyfiiGjdPb9pIRtd6tj05j0zRHq5DBGW5Ogxv5cwSKd93BVgUk/HZ4I9p3zNg==",
+      "version": "17.0.58",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.58.tgz",
+      "integrity": "sha512-c1GzVY97P0fGxwGxhYq989j4XwlcHQoto6wQISOC2v6wm3h0PORRWJFHlkRjfGsiG3y1609WdQ+J+tKxvrEd6A==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -583,12 +1071,12 @@
       }
     },
     "node_modules/@vitejs/plugin-react-swc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.2.0.tgz",
-      "integrity": "sha512-IcBoXL/mcH7JdQr/nfDlDwTdIaH8Rg7LpfQDF4nAht+juHWIuv6WhpKPCSfY4+zztAaB07qdBoFz1XCZsgo3pQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.3.0.tgz",
+      "integrity": "sha512-Ycg+n2eyCOTpn/wRy+evVo859+hw7qCj9iaX5CMny6x1fx1Uoq0xBG+a98lFtwLNGfGEnpI0F26YigRuxCRkwg==",
       "dev": true,
       "dependencies": {
-        "@swc/core": "^1.3.35"
+        "@swc/core": "^1.3.42"
       },
       "peerDependencies": {
         "vite": "^4"
@@ -857,9 +1345,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -890,9 +1378,9 @@
       "dev": true
     },
     "node_modules/esbuild": {
-      "version": "0.17.14",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.14.tgz",
-      "integrity": "sha512-vOO5XhmVj/1XQR9NQ1UPq6qvMYL7QFJU57J5fKBKBKxp17uDt5PgxFDb4A2nEiXhr1qQs4x0F5+66hVVw4ruNw==",
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.17.tgz",
+      "integrity": "sha512-/jUywtAymR8jR4qsa2RujlAF7Krpt5VWi72Q2yuLD4e/hvtNcFQ0I1j8m/bxq238pf3/0KO5yuXNpuLx8BE1KA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -902,28 +1390,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.17.14",
-        "@esbuild/android-arm64": "0.17.14",
-        "@esbuild/android-x64": "0.17.14",
-        "@esbuild/darwin-arm64": "0.17.14",
-        "@esbuild/darwin-x64": "0.17.14",
-        "@esbuild/freebsd-arm64": "0.17.14",
-        "@esbuild/freebsd-x64": "0.17.14",
-        "@esbuild/linux-arm": "0.17.14",
-        "@esbuild/linux-arm64": "0.17.14",
-        "@esbuild/linux-ia32": "0.17.14",
-        "@esbuild/linux-loong64": "0.17.14",
-        "@esbuild/linux-mips64el": "0.17.14",
-        "@esbuild/linux-ppc64": "0.17.14",
-        "@esbuild/linux-riscv64": "0.17.14",
-        "@esbuild/linux-s390x": "0.17.14",
-        "@esbuild/linux-x64": "0.17.14",
-        "@esbuild/netbsd-x64": "0.17.14",
-        "@esbuild/openbsd-x64": "0.17.14",
-        "@esbuild/sunos-x64": "0.17.14",
-        "@esbuild/win32-arm64": "0.17.14",
-        "@esbuild/win32-ia32": "0.17.14",
-        "@esbuild/win32-x64": "0.17.14"
+        "@esbuild/android-arm": "0.17.17",
+        "@esbuild/android-arm64": "0.17.17",
+        "@esbuild/android-x64": "0.17.17",
+        "@esbuild/darwin-arm64": "0.17.17",
+        "@esbuild/darwin-x64": "0.17.17",
+        "@esbuild/freebsd-arm64": "0.17.17",
+        "@esbuild/freebsd-x64": "0.17.17",
+        "@esbuild/linux-arm": "0.17.17",
+        "@esbuild/linux-arm64": "0.17.17",
+        "@esbuild/linux-ia32": "0.17.17",
+        "@esbuild/linux-loong64": "0.17.17",
+        "@esbuild/linux-mips64el": "0.17.17",
+        "@esbuild/linux-ppc64": "0.17.17",
+        "@esbuild/linux-riscv64": "0.17.17",
+        "@esbuild/linux-s390x": "0.17.17",
+        "@esbuild/linux-x64": "0.17.17",
+        "@esbuild/netbsd-x64": "0.17.17",
+        "@esbuild/openbsd-x64": "0.17.17",
+        "@esbuild/sunos-x64": "0.17.17",
+        "@esbuild/win32-arm64": "0.17.17",
+        "@esbuild/win32-ia32": "0.17.17",
+        "@esbuild/win32-x64": "0.17.17"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1309,9 +1797,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -1610,10 +2098,22 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/postcss": {
-      "version": "8.4.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "version": "8.4.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.22.tgz",
+      "integrity": "sha512-XseknLAfRHzVWjCEtdviapiBtfLdgyzExD50Rg2ePaucEesyh8Wv4VPdW0nbyDa1ydbrAxV19jvMT4+LFmcNUA==",
       "dev": true,
       "funding": [
         {
@@ -1623,10 +2123,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -1939,9 +2443,9 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/react-virtualized-auto-sizer": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.9.tgz",
-      "integrity": "sha512-O1pYgygCDtFKa9GaKJtX5Ws/QRqxkx2zPlXZqEoRXCMmnNuhoMk5nhXCQqixsc1AcrUzOJwKdzEaDAU9WQ6aJQ==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.14.tgz",
+      "integrity": "sha512-UW9AiHYF2uo/8YgPYEtWHtwssFpHt/oQxs+uroTUcNI3W9/dP/+DVwQ47d2Xp3v2jVWlBuiOT+NBV2z6jam9XQ==",
       "peerDependencies": {
         "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc",
         "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc"
@@ -2113,11 +2617,11 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "version": "1.22.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
+      "integrity": "sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==",
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.12.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -2137,9 +2641,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.2.tgz",
-      "integrity": "sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==",
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.4.tgz",
+      "integrity": "sha512-n7J4tuctZXUErM9Uc916httwqmTc63zzCr2+TLCiSCpfO/Xuk3g/marGN1IlRJZi+QF3XMYx75PxXRfZDVgaRw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2153,9 +2657,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.60.0.tgz",
-      "integrity": "sha512-updbwW6fNb5gGm8qMXzVO7V4sWf7LMXnMly/JEyfbfERbVH46Fn6q02BX7/eHTdKpE7d+oTkMMQpFWNUMfFbgQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.0.tgz",
+      "integrity": "sha512-Q4USplo4pLYgCi+XlipZCWUQz5pkg/ruSSgJ0WRDSb/+3z9tXUOkQ7QPYn4XrhZKYAK4HlpaQecRwKLJX6+DBg==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -2166,7 +2670,7 @@
         "sass": "sass.js"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/scheduler": {
@@ -2682,19 +3186,19 @@
   },
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
+      "integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
       "requires": {
         "@babel/highlight": "^7.18.6"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz",
+      "integrity": "sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==",
       "requires": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.21.4"
       }
     },
     "@babel/helper-string-parser": {
@@ -2726,9 +3230,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
-      "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.4.tgz",
+      "integrity": "sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==",
       "requires": {
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -2749,9 +3253,9 @@
       }
     },
     "@elastic/eui": {
-      "version": "76.4.0",
-      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-76.4.0.tgz",
-      "integrity": "sha512-0b3w6CloIZZ8B+URDSYLQsyTtc/GadkbNcoDg+20SeRuB8q339S+n6tbq+sVX+uk/RtRu1T/068mAd6nZZmqIg==",
+      "version": "77.2.0",
+      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-77.2.0.tgz",
+      "integrity": "sha512-6j3jqXdRmLGQ530GtdMrXyqi7rVd/XCMhymgO+FJiamf3dw5NF1LsXiOTn2+lTa/Tn3v2sJMVsr+SL+0h2Cd+A==",
       "requires": {
         "@types/chroma-js": "^2.0.0",
         "@types/lodash": "^4.14.160",
@@ -2813,9 +3317,9 @@
       }
     },
     "@emotion/cache": {
-      "version": "11.10.5",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.5.tgz",
-      "integrity": "sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==",
+      "version": "11.10.7",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.7.tgz",
+      "integrity": "sha512-VLl1/2D6LOjH57Y8Vem1RoZ9haWF4jesHDGiHtKozDQuBIkJm2gimVo0I02sWCuzZtVACeixTVB4jeE8qvCBoQ==",
       "requires": {
         "@emotion/memoize": "^0.8.0",
         "@emotion/sheet": "^1.2.1",
@@ -2920,10 +3424,157 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
       "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
     },
+    "@esbuild/android-arm": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.17.tgz",
+      "integrity": "sha512-E6VAZwN7diCa3labs0GYvhEPL2M94WLF8A+czO8hfjREXxba8Ng7nM5VxV+9ihNXIY1iQO1XxUU4P7hbqbICxg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.17.tgz",
+      "integrity": "sha512-jaJ5IlmaDLFPNttv0ofcwy/cfeY4bh/n705Tgh+eLObbGtQBK3EPAu+CzL95JVE4nFAliyrnEu0d32Q5foavqg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.17.tgz",
+      "integrity": "sha512-446zpfJ3nioMC7ASvJB1pszHVskkw4u/9Eu8s5yvvsSDTzYh4p4ZIRj0DznSl3FBF0Z/mZfrKXTtt0QCoFmoHA==",
+      "dev": true,
+      "optional": true
+    },
     "@esbuild/darwin-arm64": {
-      "version": "0.17.14",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.14.tgz",
-      "integrity": "sha512-eoSjEuDsU1ROwgBH/c+fZzuSyJUVXQTOIN9xuLs9dE/9HbV/A5IqdXHU1p2OfIMwBwOYJ9SFVGGldxeRCUJFyw==",
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.17.tgz",
+      "integrity": "sha512-m/gwyiBwH3jqfUabtq3GH31otL/0sE0l34XKpSIqR7NjQ/XHQ3lpmQHLHbG8AHTGCw8Ao059GvV08MS0bhFIJQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.17.tgz",
+      "integrity": "sha512-4utIrsX9IykrqYaXR8ob9Ha2hAY2qLc6ohJ8c0CN1DR8yWeMrTgYFjgdeQ9LIoTOfLetXjuCu5TRPHT9yKYJVg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.17.tgz",
+      "integrity": "sha512-4PxjQII/9ppOrpEwzQ1b0pXCsFLqy77i0GaHodrmzH9zq2/NEhHMAMJkJ635Ns4fyJPFOlHMz4AsklIyRqFZWA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.17.tgz",
+      "integrity": "sha512-lQRS+4sW5S3P1sv0z2Ym807qMDfkmdhUYX30GRBURtLTrJOPDpoU0kI6pVz1hz3U0+YQ0tXGS9YWveQjUewAJw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.17.tgz",
+      "integrity": "sha512-biDs7bjGdOdcmIk6xU426VgdRUpGg39Yz6sT9Xp23aq+IEHDb/u5cbmu/pAANpDB4rZpY/2USPhCA+w9t3roQg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.17.tgz",
+      "integrity": "sha512-2+pwLx0whKY1/Vqt8lyzStyda1v0qjJ5INWIe+d8+1onqQxHLLi3yr5bAa4gvbzhZqBztifYEu8hh1La5+7sUw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.17.tgz",
+      "integrity": "sha512-IBTTv8X60dYo6P2t23sSUYym8fGfMAiuv7PzJ+0LcdAndZRzvke+wTVxJeCq4WgjppkOpndL04gMZIFvwoU34Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.17.tgz",
+      "integrity": "sha512-WVMBtcDpATjaGfWfp6u9dANIqmU9r37SY8wgAivuKmgKHE+bWSuv0qXEFt/p3qXQYxJIGXQQv6hHcm7iWhWjiw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.17.tgz",
+      "integrity": "sha512-2kYCGh8589ZYnY031FgMLy0kmE4VoGdvfJkxLdxP4HJvWNXpyLhjOvxVsYjYZ6awqY4bgLR9tpdYyStgZZhi2A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.17.tgz",
+      "integrity": "sha512-KIdG5jdAEeAKogfyMTcszRxy3OPbZhq0PPsW4iKKcdlbk3YE4miKznxV2YOSmiK/hfOZ+lqHri3v8eecT2ATwQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.17.tgz",
+      "integrity": "sha512-Cj6uWLBR5LWhcD/2Lkfg2NrkVsNb2sFM5aVEfumKB2vYetkA/9Uyc1jVoxLZ0a38sUhFk4JOVKH0aVdPbjZQeA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.17.tgz",
+      "integrity": "sha512-lK+SffWIr0XsFf7E0srBjhpkdFVJf3HEgXCwzkm69kNbRar8MhezFpkIwpk0qo2IOQL4JE4mJPJI8AbRPLbuOQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.17.tgz",
+      "integrity": "sha512-XcSGTQcWFQS2jx3lZtQi7cQmDYLrpLRyz1Ns1DzZCtn898cWfm5Icx/DEWNcTU+T+tyPV89RQtDnI7qL2PObPg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.17.tgz",
+      "integrity": "sha512-RNLCDmLP5kCWAJR+ItLM3cHxzXRTe4N00TQyQiimq+lyqVqZWGPAvcyfUBM0isE79eEZhIuGN09rAz8EL5KdLA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.17.tgz",
+      "integrity": "sha512-PAXswI5+cQq3Pann7FNdcpSUrhrql3wKjj3gVkmuz6OHhqqYxKvi6GgRBoaHjaG22HV/ZZEgF9TlS+9ftHVigA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.17.tgz",
+      "integrity": "sha512-V63egsWKnx/4V0FMYkr9NXWrKTB5qFftKGKuZKFIrAkO/7EWLFnbBZNM1CvJ6Sis+XBdPws2YQSHF1Gqf1oj/Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.17.tgz",
+      "integrity": "sha512-YtUXLdVnd6YBSYlZODjWzH+KzbaubV0YVd6UxSfoFfa5PtNJNaW+1i+Hcmjpg2nEe0YXUCNF5bkKy1NnBv1y7Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.17.tgz",
+      "integrity": "sha512-yczSLRbDdReCO74Yfc5tKG0izzm+lPMYyO1fFTcn0QNwnKmc3K+HdxZWLGKg4pZVte7XVgcFku7TIZNbWEJdeQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.17.tgz",
+      "integrity": "sha512-FNZw7H3aqhF9OyRQbDDnzUApDXfC1N6fgBhkqEO2jvYCJ+DxMTfZVqg3AX0R1khg1wHTBRD5SdcibSJ+XF6bFg==",
       "dev": true,
       "optional": true
     },
@@ -2959,27 +3610,90 @@
       }
     },
     "@swc/core": {
-      "version": "1.3.42",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.42.tgz",
-      "integrity": "sha512-nVFUd5+7tGniM2cT3LXaqnu3735Cu4az8A9gAKK+8sdpASI52SWuqfDBmjFCK9xG90MiVDVp2PTZr0BWqCIzpw==",
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.51.tgz",
+      "integrity": "sha512-/fdKlrs2NacLeOKrVZjCPfw5GeUIyBcJg0GDBn0+qwC3Y6k85m4aswK1sfRDF3nzyeXXoBr7YBb+/cSdFq9pVw==",
       "dev": true,
       "requires": {
-        "@swc/core-darwin-arm64": "1.3.42",
-        "@swc/core-darwin-x64": "1.3.42",
-        "@swc/core-linux-arm-gnueabihf": "1.3.42",
-        "@swc/core-linux-arm64-gnu": "1.3.42",
-        "@swc/core-linux-arm64-musl": "1.3.42",
-        "@swc/core-linux-x64-gnu": "1.3.42",
-        "@swc/core-linux-x64-musl": "1.3.42",
-        "@swc/core-win32-arm64-msvc": "1.3.42",
-        "@swc/core-win32-ia32-msvc": "1.3.42",
-        "@swc/core-win32-x64-msvc": "1.3.42"
+        "@swc/core-darwin-arm64": "1.3.51",
+        "@swc/core-darwin-x64": "1.3.51",
+        "@swc/core-linux-arm-gnueabihf": "1.3.51",
+        "@swc/core-linux-arm64-gnu": "1.3.51",
+        "@swc/core-linux-arm64-musl": "1.3.51",
+        "@swc/core-linux-x64-gnu": "1.3.51",
+        "@swc/core-linux-x64-musl": "1.3.51",
+        "@swc/core-win32-arm64-msvc": "1.3.51",
+        "@swc/core-win32-ia32-msvc": "1.3.51",
+        "@swc/core-win32-x64-msvc": "1.3.51"
       }
     },
     "@swc/core-darwin-arm64": {
-      "version": "1.3.42",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.42.tgz",
-      "integrity": "sha512-hM6RrZFyoCM9mX3cj/zM5oXwhAqjUdOCLXJx7KTQps7NIkv/Qjvobgvyf2gAb89j3ARNo9NdIoLjTjJ6oALtiA==",
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.51.tgz",
+      "integrity": "sha512-DM15fJgaXQ+BOoTlMCBoRBSzkpC2V8vAXaAvh3BZ+BI6/03FUQ0j9CMIaSkss3VOv+WwqzllmcT71C/oVDQ7Tg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-darwin-x64": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.51.tgz",
+      "integrity": "sha512-EPAneufZfFQUkpkf2m8Ap8TajLvjWI+UmDQz54QaofLaigXgrnLoqTtnZHBfDbUTApGYz3GaqjfZ2fMLGiISLQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm-gnueabihf": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.51.tgz",
+      "integrity": "sha512-sASxO3lJjlY5g8S25yCQirDOW6zqBNeDSUCBrulaVxttx0PcL64kc6qaOlM3HKlNO4W1P7RW/mGFR4bBov+yIg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-gnu": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.51.tgz",
+      "integrity": "sha512-z8yHRUK+5mRxSQkw9uND8QSt8lTrW0X8blmP12Q7c7RKWOHqIaGS60a3VvLuTal7k48K4YTstSevIrGwGK88sA==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-musl": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.51.tgz",
+      "integrity": "sha512-lMlp09lv6qDURvETw4AAZAjaJfvjwHjiAuB+JuZrgP3zdxB21M6cMas3EjAGXtNabpU1FJu+8Lsys6/GBBjsPQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-gnu": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.51.tgz",
+      "integrity": "sha512-6zK4tDr6do6RFTJv38Rb8ZjBLdfSN7GeuyOJpblz1Qu62RqyY2Zf3fxuCZY9tkoEepZ0MvU0d4D7HhAUYKj20A==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-musl": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.51.tgz",
+      "integrity": "sha512-ZwW+X9XdEiAszX+zfaLdOVfi5rQP3vnVwuNAiuX9eq5jHdfOKfKaNtJaGTD8w8NgMavaBM5AMaCHshFVNF0vRw==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-arm64-msvc": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.51.tgz",
+      "integrity": "sha512-w+IX4xCIZH6RQG7RrOOrrHqIqM7JIj9BDZHM9LAYC5MIbDinwjnSUXz7bpn0L1LRusvPtmbTulLuSkmVBSSwAg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-ia32-msvc": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.51.tgz",
+      "integrity": "sha512-Bzv/h0HkoKkTWOOoHtehId/6AS5hLBbWE5czzcQc8SWs+BNNV8zjWoq1oYn7/gLLEhdKaBAxv9q7RHzOfBx28A==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-x64-msvc": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.51.tgz",
+      "integrity": "sha512-dTKAdSd0e2Sfz3Sl3m6RGLQbk6jdSIh8TlFomF4iiHDHq4PxLTzjaOVvKUAP5wux9DtBnAgZeSHMuQfM4aL9oA==",
       "dev": true,
       "optional": true
     },
@@ -3015,9 +3729,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.192",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.192.tgz",
-      "integrity": "sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A=="
+      "version": "4.14.194",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
+      "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g=="
     },
     "@types/mdast": {
       "version": "3.0.11",
@@ -3053,9 +3767,9 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/react": {
-      "version": "17.0.55",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.55.tgz",
-      "integrity": "sha512-kBcAhmT8RivFDYxHdy8QfPKu+WyfiiGjdPb9pIRtd6tj05j0zRHq5DBGW5Ogxv5cwSKd93BVgUk/HZ4I9p3zNg==",
+      "version": "17.0.58",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.58.tgz",
+      "integrity": "sha512-c1GzVY97P0fGxwGxhYq989j4XwlcHQoto6wQISOC2v6wm3h0PORRWJFHlkRjfGsiG3y1609WdQ+J+tKxvrEd6A==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -3145,12 +3859,12 @@
       }
     },
     "@vitejs/plugin-react-swc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.2.0.tgz",
-      "integrity": "sha512-IcBoXL/mcH7JdQr/nfDlDwTdIaH8Rg7LpfQDF4nAht+juHWIuv6WhpKPCSfY4+zztAaB07qdBoFz1XCZsgo3pQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.3.0.tgz",
+      "integrity": "sha512-Ycg+n2eyCOTpn/wRy+evVo859+hw7qCj9iaX5CMny6x1fx1Uoq0xBG+a98lFtwLNGfGEnpI0F26YigRuxCRkwg==",
       "dev": true,
       "requires": {
-        "@swc/core": "^1.3.35"
+        "@swc/core": "^1.3.42"
       }
     },
     "ansi-styles": {
@@ -3343,9 +4057,9 @@
       }
     },
     "csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "detect-node-es": {
       "version": "1.1.0",
@@ -3372,33 +4086,33 @@
       "dev": true
     },
     "esbuild": {
-      "version": "0.17.14",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.14.tgz",
-      "integrity": "sha512-vOO5XhmVj/1XQR9NQ1UPq6qvMYL7QFJU57J5fKBKBKxp17uDt5PgxFDb4A2nEiXhr1qQs4x0F5+66hVVw4ruNw==",
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.17.tgz",
+      "integrity": "sha512-/jUywtAymR8jR4qsa2RujlAF7Krpt5VWi72Q2yuLD4e/hvtNcFQ0I1j8m/bxq238pf3/0KO5yuXNpuLx8BE1KA==",
       "dev": true,
       "requires": {
-        "@esbuild/android-arm": "0.17.14",
-        "@esbuild/android-arm64": "0.17.14",
-        "@esbuild/android-x64": "0.17.14",
-        "@esbuild/darwin-arm64": "0.17.14",
-        "@esbuild/darwin-x64": "0.17.14",
-        "@esbuild/freebsd-arm64": "0.17.14",
-        "@esbuild/freebsd-x64": "0.17.14",
-        "@esbuild/linux-arm": "0.17.14",
-        "@esbuild/linux-arm64": "0.17.14",
-        "@esbuild/linux-ia32": "0.17.14",
-        "@esbuild/linux-loong64": "0.17.14",
-        "@esbuild/linux-mips64el": "0.17.14",
-        "@esbuild/linux-ppc64": "0.17.14",
-        "@esbuild/linux-riscv64": "0.17.14",
-        "@esbuild/linux-s390x": "0.17.14",
-        "@esbuild/linux-x64": "0.17.14",
-        "@esbuild/netbsd-x64": "0.17.14",
-        "@esbuild/openbsd-x64": "0.17.14",
-        "@esbuild/sunos-x64": "0.17.14",
-        "@esbuild/win32-arm64": "0.17.14",
-        "@esbuild/win32-ia32": "0.17.14",
-        "@esbuild/win32-x64": "0.17.14"
+        "@esbuild/android-arm": "0.17.17",
+        "@esbuild/android-arm64": "0.17.17",
+        "@esbuild/android-x64": "0.17.17",
+        "@esbuild/darwin-arm64": "0.17.17",
+        "@esbuild/darwin-x64": "0.17.17",
+        "@esbuild/freebsd-arm64": "0.17.17",
+        "@esbuild/freebsd-x64": "0.17.17",
+        "@esbuild/linux-arm": "0.17.17",
+        "@esbuild/linux-arm64": "0.17.17",
+        "@esbuild/linux-ia32": "0.17.17",
+        "@esbuild/linux-loong64": "0.17.17",
+        "@esbuild/linux-mips64el": "0.17.17",
+        "@esbuild/linux-ppc64": "0.17.17",
+        "@esbuild/linux-riscv64": "0.17.17",
+        "@esbuild/linux-s390x": "0.17.17",
+        "@esbuild/linux-x64": "0.17.17",
+        "@esbuild/netbsd-x64": "0.17.17",
+        "@esbuild/openbsd-x64": "0.17.17",
+        "@esbuild/sunos-x64": "0.17.17",
+        "@esbuild/win32-arm64": "0.17.17",
+        "@esbuild/win32-ia32": "0.17.17",
+        "@esbuild/win32-x64": "0.17.17"
       }
     },
     "escape-string-regexp": {
@@ -3682,9 +4396,9 @@
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
     },
     "is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -3894,13 +4608,19 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
     "postcss": {
-      "version": "8.4.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "version": "8.4.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.22.tgz",
+      "integrity": "sha512-XseknLAfRHzVWjCEtdviapiBtfLdgyzExD50Rg2ePaucEesyh8Wv4VPdW0nbyDa1ydbrAxV19jvMT4+LFmcNUA==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -4119,9 +4839,9 @@
       }
     },
     "react-virtualized-auto-sizer": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.9.tgz",
-      "integrity": "sha512-O1pYgygCDtFKa9GaKJtX5Ws/QRqxkx2zPlXZqEoRXCMmnNuhoMk5nhXCQqixsc1AcrUzOJwKdzEaDAU9WQ6aJQ==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.14.tgz",
+      "integrity": "sha512-UW9AiHYF2uo/8YgPYEtWHtwssFpHt/oQxs+uroTUcNI3W9/dP/+DVwQ47d2Xp3v2jVWlBuiOT+NBV2z6jam9XQ==",
       "requires": {}
     },
     "react-window": {
@@ -4249,11 +4969,11 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "version": "1.22.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
+      "integrity": "sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==",
       "requires": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.12.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -4264,18 +4984,18 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
     "rollup": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.2.tgz",
-      "integrity": "sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==",
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.4.tgz",
+      "integrity": "sha512-n7J4tuctZXUErM9Uc916httwqmTc63zzCr2+TLCiSCpfO/Xuk3g/marGN1IlRJZi+QF3XMYx75PxXRfZDVgaRw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
     },
     "sass": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.60.0.tgz",
-      "integrity": "sha512-updbwW6fNb5gGm8qMXzVO7V4sWf7LMXnMly/JEyfbfERbVH46Fn6q02BX7/eHTdKpE7d+oTkMMQpFWNUMfFbgQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.0.tgz",
+      "integrity": "sha512-Q4USplo4pLYgCi+XlipZCWUQz5pkg/ruSSgJ0WRDSb/+3z9tXUOkQ7QPYn4XrhZKYAK4HlpaQecRwKLJX6+DBg==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",

--- a/apps/rule-manager/client/package.json
+++ b/apps/rule-manager/client/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
-    "@elastic/eui": "^76.2.0",
+    "@elastic/eui": "^77.2.0",
     "@emotion/cache": "^11.10.5",
     "@emotion/css": "^11.10.6",
     "@emotion/react": "^11.10.6",

--- a/apps/rule-manager/client/src/css/reset.css
+++ b/apps/rule-manager/client/src/css/reset.css
@@ -25,5 +25,5 @@ p, h1, h2, h3, h4, h5, h6 {
 
 /* Ensure headings are the correct font – EUI does not have a separate font for headings. */
 h1, h2, h3, h4, h5, h6 {
-  font-family: "Guardian Egyptian Text" !important;
+  font-family: "Guardian Egyptian Text";
 }

--- a/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
@@ -3,23 +3,35 @@ import {EuiFormRow, EuiComboBox} from "@elastic/eui";
 import React from "react";
 import { PartiallyUpdateRuleData, RuleFormData } from "./RuleForm";
 
+export type MetadataOption = {label: string}
 export const CategorySelector = ({ruleData, partiallyUpdateRuleData}: {
     ruleData: RuleFormData,
     partiallyUpdateRuleData: PartiallyUpdateRuleData,
 }) => {
-    type Category = {label: string}
-    const categories: Category[] = [
-        {
-            label: 'Category A',
-        },
-        {
-            label: 'Category B',
-        }
+    const categories: MetadataOption[] = [
+        {label: "Check this"},
+        {label: "Guardian convention"},
+        {label: "Style guide and names"},
+        {label: "General"},
+        {label: "Names"},
+        {label: "Typos"},
+        {label: "Tokyo 2020: General"},
+        {label: "Tokyo 2020: Diving"},
+        {label: "Tokyo 2020: Equestrian"},
+        {label: "Tokyo 2020: Cycling"},
+        {label: "Tokyo 2020: Rugby"},
+        {label: "Tokyo 2020: Boxing"},
+        {label: "Tokyo 2020: Football"},
+        {label: "Tokyo 2020: Swimming"},
+        {label: "Coronavirus"},
+        {label: "Typography"},
+        {label: "Dates"},
+        {label: "Style Guide"}
     ]
     const [options, updateOptions] = useState(categories);
     // This is an array in order to match the expected type for EuiComboBox, but 
     // it will never have more than one category selected
-    const [selectedCategory, setSelectedCategory] = useState<Category[]>([]);
+    const [selectedCategory, setSelectedCategory] = useState<MetadataOption[]>([]);
 
     const onChange = (selectedOption) => {
         setSelectedCategory(selectedOption);

--- a/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
@@ -1,24 +1,31 @@
-import {useState} from "react";
+import {useEffect, useState} from "react";
 import {EuiFormRow, EuiComboBox} from "@elastic/eui";
 import React from "react";
+import { PartiallyUpdateRuleData, RuleFormData } from "./RuleForm";
 
-export const CategorySelector = () => {
-    const [options, updateOptions] = useState([
+export const CategorySelector = ({ruleData, partiallyUpdateRuleData}: {
+    ruleData: RuleFormData,
+    partiallyUpdateRuleData: PartiallyUpdateRuleData,
+}) => {
+    type Category = {label: string}
+    const categories: Category[] = [
         {
             label: 'Category A',
         },
         {
             label: 'Category B',
         }
-    ]);
+    ]
+    const [options, updateOptions] = useState(categories);
+    // This is an array in order to match the expected type for EuiComboBox, but 
+    // it will never have more than one category selected
+    const [selectedCategory, setSelectedCategory] = useState<Category[]>([]);
 
-    const [selectedOptions, setSelected] = useState([]);
-
-    const onChange = (selectedOptions) => {
-        setSelected(selectedOptions);
+    const onChange = (selectedOption) => {
+        setSelectedCategory(selectedOption);
     };
 
-    const onCreateOption = (searchValue, flattenedOptions) => {
+    const onCreateOption = (searchValue: string, flattenedOptions) => {
         const normalizedSearchValue = searchValue.trim().toLowerCase();
 
         if (!normalizedSearchValue) {
@@ -39,15 +46,20 @@ export const CategorySelector = () => {
         }
 
         // Select the option.
-        setSelected((prevSelected) => [...prevSelected, newOption]);
+        setSelectedCategory([newOption]);
     };
+
+    useEffect(() => {
+        const newCategory = selectedCategory.length ? selectedCategory[0].label : undefined;
+        partiallyUpdateRuleData(ruleData, {category: newCategory})
+    }, [selectedCategory])
 
     return (
         <EuiFormRow label='Categories'>
             <EuiComboBox
                 options={options}
                 singleSelection={{ asPlainText: true }}
-                selectedOptions={selectedOptions}
+                selectedOptions={selectedCategory}
                 onChange={onChange}
                 onCreateOption={onCreateOption}
                 isClearable={true}

--- a/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { PartiallyUpdateRuleData, RuleFormData } from "./RuleForm";
 
 export type MetadataOption = {label: string}
+const singleSelectionOptions = { asPlainText: true };
 export const CategorySelector = ({ruleData, partiallyUpdateRuleData}: {
     ruleData: RuleFormData,
     partiallyUpdateRuleData: PartiallyUpdateRuleData,
@@ -70,7 +71,7 @@ export const CategorySelector = ({ruleData, partiallyUpdateRuleData}: {
         <EuiFormRow label='Categories'>
             <EuiComboBox
                 options={options}
-                singleSelection={{ asPlainText: true }}
+                singleSelection={singleSelectionOptions}
                 selectedOptions={selectedCategory}
                 onChange={onChange}
                 onCreateOption={onCreateOption}

--- a/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
@@ -29,7 +29,6 @@ export const CategorySelector = ({ruleData, partiallyUpdateRuleData}: {
         {label: "Dates"},
         {label: "Style Guide"}
     ]
-    const [options, updateOptions] = useState(categories);
     // This is an array in order to match the expected type for EuiComboBox, but 
     // it will never have more than one category selected
     const [selectedCategory, setSelectedCategory] = useState<MetadataOption[]>([]);
@@ -38,43 +37,18 @@ export const CategorySelector = ({ruleData, partiallyUpdateRuleData}: {
         setSelectedCategory(selectedOption);
     };
 
-    const onCreateOption = (searchValue: string, flattenedOptions) => {
-        const normalizedSearchValue = searchValue.trim().toLowerCase();
-
-        if (!normalizedSearchValue) {
-            return;
-        }
-
-        const newOption = {
-            label: searchValue,
-        };
-
-        // Create the option if it doesn't exist.
-        if (
-            flattenedOptions.findIndex(
-                (option) => option.label.trim().toLowerCase() === normalizedSearchValue
-            ) === -1
-        ) {
-            updateOptions([...options, newOption]);
-        }
-
-        // Select the option.
-        setSelectedCategory([newOption]);
-    };
-
     useEffect(() => {
         const newCategory = selectedCategory.length ? selectedCategory[0].label : undefined;
         partiallyUpdateRuleData(ruleData, {category: newCategory})
     }, [selectedCategory])
 
     return (
-        <EuiFormRow label='Categories'>
+        <EuiFormRow label='Category'>
             <EuiComboBox
-                options={options}
+                options={categories}
                 singleSelection={singleSelectionOptions}
                 selectedOptions={selectedCategory}
                 onChange={onChange}
-                onCreateOption={onCreateOption}
                 isClearable={true}
                 isCaseSensitive
             />

--- a/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
@@ -1,0 +1,57 @@
+import {useState} from "react";
+import {EuiFormRow, EuiComboBox} from "@elastic/eui";
+
+export const CategorySelector = () => {
+    const [options, updateOptions] = useState([
+        {
+            label: 'Category A',
+        },
+        {
+            label: 'Category B',
+        }
+    ]);
+
+    const [selectedOptions, setSelected] = useState([]);
+
+    const onChange = (selectedOptions) => {
+        setSelected(selectedOptions);
+    };
+
+    const onCreateOption = (searchValue, flattenedOptions) => {
+        const normalizedSearchValue = searchValue.trim().toLowerCase();
+
+        if (!normalizedSearchValue) {
+            return;
+        }
+
+        const newOption = {
+            label: searchValue,
+        };
+
+        // Create the option if it doesn't exist.
+        if (
+            flattenedOptions.findIndex(
+                (option) => option.label.trim().toLowerCase() === normalizedSearchValue
+            ) === -1
+        ) {
+            updateOptions([...options, newOption]);
+        }
+
+        // Select the option.
+        setSelected((prevSelected) => [...prevSelected, newOption]);
+    };
+
+    return (
+        <EuiFormRow label='Categories'>
+            <EuiComboBox
+                options={options}
+                singleSelection={{ asPlainText: true }}
+                selectedOptions={selectedOptions}
+                onChange={onChange}
+                onCreateOption={onCreateOption}
+                isClearable={true}
+                isCaseSensitive
+            />
+        </EuiFormRow>
+    );
+}

--- a/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
@@ -2,6 +2,7 @@ import {useEffect, useState} from "react";
 import {EuiFormRow, EuiComboBox} from "@elastic/eui";
 import React from "react";
 import { PartiallyUpdateRuleData, RuleFormData } from "./RuleForm";
+import { existingCategories } from "../constants/constants";
 
 export type MetadataOption = {label: string}
 const singleSelectionOptions = { asPlainText: true };
@@ -9,30 +10,10 @@ export const CategorySelector = ({ruleData, partiallyUpdateRuleData}: {
     ruleData: RuleFormData,
     partiallyUpdateRuleData: PartiallyUpdateRuleData,
 }) => {
-    const categories: MetadataOption[] = [
-        {label: "Check this"},
-        {label: "Guardian convention"},
-        {label: "Style guide and names"},
-        {label: "General"},
-        {label: "Names"},
-        {label: "Typos"},
-        {label: "Tokyo 2020: General"},
-        {label: "Tokyo 2020: Diving"},
-        {label: "Tokyo 2020: Equestrian"},
-        {label: "Tokyo 2020: Cycling"},
-        {label: "Tokyo 2020: Rugby"},
-        {label: "Tokyo 2020: Boxing"},
-        {label: "Tokyo 2020: Football"},
-        {label: "Tokyo 2020: Swimming"},
-        {label: "Coronavirus"},
-        {label: "Typography"},
-        {label: "Dates"},
-        {label: "Style Guide"}
-    ]
     // This is an array in order to match the expected type for EuiComboBox, but 
     // it will never have more than one category selected
     const [selectedCategory, setSelectedCategory] = useState<MetadataOption[]>([]);
-
+    const categories = existingCategories.map(category => {return {label: category} as MetadataOption});
     const onChange = (selectedOption) => {
         setSelectedCategory(selectedOption);
     };

--- a/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
@@ -1,5 +1,6 @@
 import {useState} from "react";
 import {EuiFormRow, EuiComboBox} from "@elastic/eui";
+import React from "react";
 
 export const CategorySelector = () => {
     const [options, updateOptions] = useState([

--- a/apps/rule-manager/client/src/ts/components/Label.tsx
+++ b/apps/rule-manager/client/src/ts/components/Label.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export const Label = ({text, required}: {text: string, required: boolean}) => {
+    return <>
+        {text} {required ? <span style={{fontWeight: "normal"}}>(required)</span> : null}
+    </>
+}

--- a/apps/rule-manager/client/src/ts/components/LineBreak.tsx
+++ b/apps/rule-manager/client/src/ts/components/LineBreak.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export const LineBreak = () => <hr style={{
+    height: '1px',
+    width: '100%',
+    borderStyle: 'solid',
+    borderColor: '#F1F4FA',
+    borderBottom: 'none',
+    marginTop: '8px',
+    marginBottom: '8px'
+}}/>;

--- a/apps/rule-manager/client/src/ts/components/LineBreak.tsx
+++ b/apps/rule-manager/client/src/ts/components/LineBreak.tsx
@@ -1,11 +1,11 @@
-import React from "react";
+import styled from "@emotion/styled";
 
-export const LineBreak = () => <hr style={{
-    height: '1px',
-    width: '100%',
-    borderStyle: 'solid',
-    borderColor: '#F1F4FA',
-    borderBottom: 'none',
-    marginTop: '8px',
-    marginBottom: '8px'
-}}/>;
+export const LineBreak = styled.hr`
+    height: 1px;
+    width: 100%;
+    border-style: solid;
+    border-color: #F1F4FA;
+    border-bottom: none;
+    margin-top: 8px;
+    margin-bottom: 8px;
+`

--- a/apps/rule-manager/client/src/ts/components/RuleContent.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleContent.tsx
@@ -1,11 +1,17 @@
-import { EuiFieldText, EuiFlexItem, EuiFormRow, EuiRadioGroup } from "@elastic/eui"
-import { css } from "@emotion/react";
-import React, { useState } from "react"
-import { RuleFormSection } from "./RuleFormSection";
+import {EuiFieldText, EuiFlexItem, EuiFormRow, EuiRadioGroup} from "@elastic/eui"
+import {css} from "@emotion/react";
+import React, {useState} from "react"
+import {RuleFormSection} from "./RuleFormSection";
 import {LineBreak} from "./LineBreak";
-import { PartiallyUpdateRuleData, RuleFormData, RuleType } from "./RuleForm";
+import {FormError, PartiallyUpdateRuleData, RuleFormData, RuleType} from "./RuleForm";
+import {Label} from "./Label";
 
-export const RuleContent = ({ruleData, partiallyUpdateRuleData}: {ruleData: RuleFormData, partiallyUpdateRuleData: PartiallyUpdateRuleData}) => {
+export const RuleContent = ({ruleData, partiallyUpdateRuleData, errors, showErrors}: {
+        ruleData: RuleFormData,
+        partiallyUpdateRuleData: PartiallyUpdateRuleData,
+        errors: FormError[],
+        showErrors: boolean
+    }) => {
     type RuleTypeOption = {
         id: RuleType,
         label: string,
@@ -23,40 +29,48 @@ export const RuleContent = ({ruleData, partiallyUpdateRuleData}: {ruleData: Rule
     const [ruleTypeSelected, setRuleTypeSelected] = useState(ruleTypeOptions[0].id);
 
     return <RuleFormSection title="RULE CONTENT">
-            <LineBreak/>
-            <EuiFlexItem>
-                <EuiFormRow
-                    label="Pattern"
-                >
-                    <EuiFieldText value={ruleData.pattern} onChange={(_ => partiallyUpdateRuleData(ruleData, {pattern: _.target.value}))}/>
-                </EuiFormRow>
-                <EuiFormRow
-                    label="Replacement"
-                    helpText="What is the ideal term as per the house style?"
-                >
-                    <EuiFieldText value={ruleData.replacement} onChange={(_ => partiallyUpdateRuleData(ruleData, {replacement: _.target.value}))}/>
-                </EuiFormRow>
-                <EuiFormRow
-                    label="Description"
-                    helpText="What will the users see in Composer?"
-                >
-                    <EuiFieldText value={ruleData.description} onChange={(_ => partiallyUpdateRuleData(ruleData, {description: _.target.value}))}/>
-                </EuiFormRow>
-                <EuiRadioGroup
-                    options={ruleTypeOptions}
-                    idSelected={ruleTypeSelected}
-                    onChange={(ruleType)=> {
-                        setRuleTypeSelected(ruleType as RuleType);
-                        partiallyUpdateRuleData(ruleData, {ruleType: ruleType as RuleType});
-                    }}
-                    css={css`
+        <LineBreak/>
+        <EuiFlexItem>
+            <EuiFormRow
+                label={<Label text='Pattern' required={true}/>}
+                isInvalid={showErrors && ruleData.pattern === ""}
+            >
+                <EuiFieldText
+                    value={ruleData.pattern}
+                    onChange={(_ => partiallyUpdateRuleData(ruleData, {pattern: _.target.value}))}
+                    required={true}
+                    isInvalid={showErrors && ruleData.pattern === ""}
+                />
+            </EuiFormRow>
+            <EuiFormRow
+                label="Replacement"
+                helpText="What is the ideal term as per the house style?"
+            >
+                <EuiFieldText value={ruleData.replacement}
+                              onChange={(_ => partiallyUpdateRuleData(ruleData, {replacement: _.target.value}))}/>
+            </EuiFormRow>
+            <EuiFormRow
+                label="Description"
+                helpText="What will the users see in Composer?"
+            >
+                <EuiFieldText value={ruleData.description}
+                              onChange={(_ => partiallyUpdateRuleData(ruleData, {description: _.target.value}))}/>
+            </EuiFormRow>
+            <EuiRadioGroup
+                options={ruleTypeOptions}
+                idSelected={ruleTypeSelected}
+                onChange={(ruleType) => {
+                    setRuleTypeSelected(ruleType as RuleType);
+                    partiallyUpdateRuleData(ruleData, {ruleType: ruleType as RuleType});
+                }}
+                css={css`
                         flex-direction: row;
                         display: flex;
                         gap: 1rem;
                         align-items: flex-end;
                         margin-top: 8px;
                     `}
-                />
-            </EuiFlexItem>
+            />
+        </EuiFlexItem>
     </RuleFormSection>
 }

--- a/apps/rule-manager/client/src/ts/components/RuleContent.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleContent.tsx
@@ -3,9 +3,14 @@ import { css } from "@emotion/react";
 import React, { useState } from "react"
 import { RuleFormSection } from "./RuleFormSection";
 import {LineBreak} from "./LineBreak";
+import { PartiallyUpdateRuleData, RuleFormData, RuleType } from "./RuleForm";
 
-export const RuleContent = () => {
-    const ruleTypeOptions = [
+export const RuleContent = ({ruleData, partiallyUpdateRuleData}: {ruleData: RuleFormData, partiallyUpdateRuleData: PartiallyUpdateRuleData}) => {
+    type RuleTypeOption = {
+        id: RuleType,
+        label: string,
+    }
+    const ruleTypeOptions: RuleTypeOption[] = [
         {
             id: "regex",
             label: 'Regex',
@@ -21,27 +26,28 @@ export const RuleContent = () => {
             <LineBreak/>
             <EuiFlexItem>
                 <EuiFormRow
+                    label="Pattern"
+                >
+                    <EuiFieldText value={ruleData.pattern} onChange={(_ => partiallyUpdateRuleData(ruleData, {pattern: _.target.value}))}/>
+                </EuiFormRow>
+                <EuiFormRow
                     label="Replacement"
                     helpText="What is the ideal term as per the house style?"
                 >
-                    <EuiFieldText />
+                    <EuiFieldText value={ruleData.replacement} onChange={(_ => partiallyUpdateRuleData(ruleData, {replacement: _.target.value}))}/>
                 </EuiFormRow>
                 <EuiFormRow
                     label="Description"
                     helpText="What will the users see in Composer?"
                 >
-                    <EuiFieldText/>
-                </EuiFormRow>
-                <EuiFormRow
-                    label="Pattern"
-                >
-                    <EuiFieldText/>
+                    <EuiFieldText value={ruleData.description} onChange={(_ => partiallyUpdateRuleData(ruleData, {description: _.target.value}))}/>
                 </EuiFormRow>
                 <EuiRadioGroup
                     options={ruleTypeOptions}
                     idSelected={ruleTypeSelected}
-                    onChange={(id)=> {
-                        setRuleTypeSelected(id)
+                    onChange={(ruleType)=> {
+                        setRuleTypeSelected(ruleType as RuleType);
+                        partiallyUpdateRuleData(ruleData, {ruleType: ruleType as RuleType});
                     }}
                     css={css`
                         flex-direction: row;

--- a/apps/rule-manager/client/src/ts/components/RuleContent.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleContent.tsx
@@ -31,7 +31,6 @@ export const RuleContent = () => {
             </EuiFormRow>
             <EuiFormRow
                 label="Pattern"
-                helpText=""
             >
                 <EuiFieldText/>
             </EuiFormRow>

--- a/apps/rule-manager/client/src/ts/components/RuleContent.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleContent.tsx
@@ -33,13 +33,13 @@ export const RuleContent = ({ruleData, partiallyUpdateRuleData, errors, showErro
         <EuiFlexItem>
             <EuiFormRow
                 label={<Label text='Pattern' required={true}/>}
-                isInvalid={showErrors && ruleData.pattern === ""}
+                isInvalid={showErrors && !ruleData.pattern}
             >
                 <EuiFieldText
                     value={ruleData.pattern}
                     onChange={(_ => partiallyUpdateRuleData(ruleData, {pattern: _.target.value}))}
                     required={true}
-                    isInvalid={showErrors && ruleData.pattern === ""}
+                    isInvalid={showErrors && !ruleData.pattern}
                 />
             </EuiFormRow>
             <EuiFormRow

--- a/apps/rule-manager/client/src/ts/components/RuleContent.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleContent.tsx
@@ -19,11 +19,11 @@ export const RuleContent = ({ruleData, partiallyUpdateRuleData, errors, showErro
     const ruleTypeOptions: RuleTypeOption[] = [
         {
             id: "regex",
-            label: 'Regex',
+            label: "Regex",
         },
         {
-            id: "languageTool",
-            label: 'LanguageTool',
+            id: "languageToolXML",
+            label: "LanguageTool",
         },
     ]
     const [ruleTypeSelected, setRuleTypeSelected] = useState(ruleTypeOptions[0].id);

--- a/apps/rule-manager/client/src/ts/components/RuleContent.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleContent.tsx
@@ -1,0 +1,52 @@
+import { EuiFieldText, EuiFlexItem, EuiForm, EuiFormRow, EuiRadioGroup } from "@elastic/eui"
+import { css } from "@emotion/react";
+import React, { useState } from "react"
+import { RuleFormSection } from "./RuleFormSection";
+
+export const RuleContent = () => {
+    const ruleTypeOptions = [
+        {
+            id: "regex",
+            label: 'Regex',
+        },
+        {
+            id: "languageTool",
+            label: 'LanguageTool',
+        },
+    ]
+    const [ruleTypeSelected, setRuleTypeSelected] = useState(ruleTypeOptions[0].id);
+
+    return <RuleFormSection title="RULE CONTENT">
+            <EuiFormRow
+                label="Replacement"
+                helpText="What is the ideal term as per the house style?"
+            >
+                <EuiFieldText/>
+            </EuiFormRow>
+            <EuiFormRow
+                label="Description"
+                helpText="What will the users see in Composer?"
+            >
+                <EuiFieldText/>
+            </EuiFormRow>
+            <EuiFormRow
+                label="Pattern"
+                helpText=""
+            >
+                <EuiFieldText/>
+            </EuiFormRow>
+            <EuiRadioGroup
+                options={ruleTypeOptions}
+                idSelected={ruleTypeSelected}
+                onChange={(id)=> {
+                    setRuleTypeSelected(id)
+                }}
+                css={css`
+                    flex-direction: row;
+                    display: flex;
+                    gap: 1rem;
+                    align-items: flex-end;
+                `}
+            />
+    </RuleFormSection>
+}

--- a/apps/rule-manager/client/src/ts/components/RuleContent.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleContent.tsx
@@ -1,7 +1,8 @@
-import { EuiFieldText, EuiFlexItem, EuiForm, EuiFormRow, EuiRadioGroup } from "@elastic/eui"
+import { EuiFieldText, EuiFlexItem, EuiFormRow, EuiRadioGroup } from "@elastic/eui"
 import { css } from "@emotion/react";
 import React, { useState } from "react"
 import { RuleFormSection } from "./RuleFormSection";
+import {LineBreak} from "./LineBreak";
 
 export const RuleContent = () => {
     const ruleTypeOptions = [
@@ -17,35 +18,39 @@ export const RuleContent = () => {
     const [ruleTypeSelected, setRuleTypeSelected] = useState(ruleTypeOptions[0].id);
 
     return <RuleFormSection title="RULE CONTENT">
-            <EuiFormRow
-                label="Replacement"
-                helpText="What is the ideal term as per the house style?"
-            >
-                <EuiFieldText/>
-            </EuiFormRow>
-            <EuiFormRow
-                label="Description"
-                helpText="What will the users see in Composer?"
-            >
-                <EuiFieldText/>
-            </EuiFormRow>
-            <EuiFormRow
-                label="Pattern"
-            >
-                <EuiFieldText/>
-            </EuiFormRow>
-            <EuiRadioGroup
-                options={ruleTypeOptions}
-                idSelected={ruleTypeSelected}
-                onChange={(id)=> {
-                    setRuleTypeSelected(id)
-                }}
-                css={css`
-                    flex-direction: row;
-                    display: flex;
-                    gap: 1rem;
-                    align-items: flex-end;
-                `}
-            />
+            <LineBreak/>
+            <EuiFlexItem>
+                <EuiFormRow
+                    label="Replacement"
+                    helpText="What is the ideal term as per the house style?"
+                >
+                    <EuiFieldText />
+                </EuiFormRow>
+                <EuiFormRow
+                    label="Description"
+                    helpText="What will the users see in Composer?"
+                >
+                    <EuiFieldText/>
+                </EuiFormRow>
+                <EuiFormRow
+                    label="Pattern"
+                >
+                    <EuiFieldText/>
+                </EuiFormRow>
+                <EuiRadioGroup
+                    options={ruleTypeOptions}
+                    idSelected={ruleTypeSelected}
+                    onChange={(id)=> {
+                        setRuleTypeSelected(id)
+                    }}
+                    css={css`
+                        flex-direction: row;
+                        display: flex;
+                        gap: 1rem;
+                        align-items: flex-end;
+                        margin-top: 8px;
+                    `}
+                />
+            </EuiFlexItem>
     </RuleFormSection>
 }

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -1,14 +1,15 @@
-import { EuiFieldText, EuiFlexGroup, EuiFlexItem, EuiForm, EuiFormRow, EuiRadioGroup } from "@elastic/eui"
-import { css } from "@emotion/react";
-import React, { useState } from "react"
+import { EuiFlexGroup, EuiForm } from "@elastic/eui";
+import React from "react"
 import { RuleContent } from "./RuleContent";
 import { RuleType } from "./RuleType";
+import {RuleMetadata} from "./RuleMetadata";
 
 export const RuleForm = () => {
     return <EuiForm component="form">
             <EuiFlexGroup  direction="column">   
                 <RuleContent />
                 <RuleType />
+                <RuleMetadata />
         </EuiFlexGroup>
     </EuiForm>
 }

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from "react"
 import { RuleContent } from "./RuleContent";
 import { RuleType } from "./RuleType";
 import {RuleMetadata} from "./RuleMetadata";
-import { createRule } from "./helpers/createRule";
+import { createRule, transformRuleFormData } from "./helpers/createRule";
 
 export type RuleType = 'regex' | 'languageTool';
 
@@ -40,7 +40,6 @@ export const RuleForm = ({fetchRules}: {fetchRules: () => Promise<void>}) => {
     const partiallyUpdateRuleData: PartiallyUpdateRuleData = (existing, partialReplacement) => {
         setRuleData({...existing, ...partialReplacement});
     }
-    // useEffect(() => console.log(ruleData), [ruleData])
 
     useEffect(() => {
         const emptyPatternFieldError = {id: 'pattern', value: 'A pattern is required'}
@@ -67,10 +66,9 @@ export const RuleForm = ({fetchRules}: {fetchRules: () => Promise<void>}) => {
             return;
         }
 
-        createRule(ruleData)
+        createRule(transformRuleFormData(ruleData))
             .then(response => response.json())
             .then(data => {
-                console.log(data);
                 setRuleData(baseForm);
                 fetchRules();
             })

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -5,7 +5,7 @@ import { RuleType } from "./RuleType";
 import {RuleMetadata} from "./RuleMetadata";
 import { createRule, transformRuleFormData } from "./helpers/createRule";
 
-export type RuleType = 'regex' | 'languageTool';
+export type RuleType = 'regex' | 'languageToolXML';
 
 export type RuleFormData = {
     ruleType: RuleType,

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -43,12 +43,18 @@ export const RuleForm = ({fetchRules}: {fetchRules: () => Promise<void>}) => {
     // useEffect(() => console.log(ruleData), [ruleData])
 
     useEffect(() => {
+        const emptyPatternFieldError = {id: 'pattern', value: 'A pattern is required'}
+        setErrors(errors.filter(error => !(error.id === emptyPatternFieldError.id && error.value === emptyPatternFieldError.value)));
         if(!ruleData.pattern) {
-            setErrors([...errors, {id: 'pattern', value: 'A pattern is required'}]);
-        } else {
-            setErrors(errors.filter(error => !(error.id === 'pattern' && error.value === 'A pattern is required')));
+            setErrors([...errors, emptyPatternFieldError]);
         }
     }, [ruleData])
+
+    useEffect(() => {
+        if(errors.length === 0) {
+            setShowErrors(false);
+        }
+    }, [errors])
 
     // We need the errors at the form level, so that we can prevent save etc. when there are errors
     // We need to be able to change the errors depending on which fields are invalid
@@ -59,8 +65,6 @@ export const RuleForm = ({fetchRules}: {fetchRules: () => Promise<void>}) => {
         if(errors.length > 0) {
             setShowErrors(true);
             return;
-        } else {
-            setShowErrors(false);
         }
 
         createRule(ruleData)
@@ -79,7 +83,7 @@ export const RuleForm = ({fetchRules}: {fetchRules: () => Promise<void>}) => {
         {createRuleFormOpen ? <EuiFlexGroup  direction="column">   
             <RuleContent ruleData={ruleData} partiallyUpdateRuleData={partiallyUpdateRuleData} errors={errors} showErrors={showErrors}/>
             <RuleType ruleData={ruleData} partiallyUpdateRuleData={partiallyUpdateRuleData} />
-            <RuleMetadata />
+            <RuleMetadata ruleData={ruleData} partiallyUpdateRuleData={partiallyUpdateRuleData} />
             <EuiFlexGroup>
                 <EuiFlexItem>
                     <EuiButton onClick={() => {
@@ -92,6 +96,7 @@ export const RuleForm = ({fetchRules}: {fetchRules: () => Promise<void>}) => {
                 </EuiFlexItem>
             </EuiFlexGroup>
             {showErrors ? <EuiCallOut title="Please resolve the following errors:" color="danger" iconType="error">
+                { errors.map(error => <EuiText>{`${error.value}`}</EuiText>)}
             </EuiCallOut> : null}
         </EuiFlexGroup> : null}
     </EuiForm>

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -1,4 +1,4 @@
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiForm, EuiSpacer } from "@elastic/eui";
+import { EuiButton, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiForm, EuiSpacer, EuiText } from "@elastic/eui";
 import React, { useEffect, useState } from "react"
 import { RuleContent } from "./RuleContent";
 import { RuleType } from "./RuleType";
@@ -40,15 +40,15 @@ export const RuleForm = ({fetchRules}: {fetchRules: () => Promise<void>}) => {
     const partiallyUpdateRuleData: PartiallyUpdateRuleData = (existing, partialReplacement) => {
         setRuleData({...existing, ...partialReplacement});
     }
-    useEffect(() => console.log(ruleData), [ruleData])
+    // useEffect(() => console.log(ruleData), [ruleData])
 
     useEffect(() => {
-        if(ruleData.pattern === '') {
+        if(!ruleData.pattern) {
             setErrors([...errors, {id: 'pattern', value: 'A pattern is required'}]);
         } else {
             setErrors(errors.filter(error => !(error.id === 'pattern' && error.value === 'A pattern is required')));
         }
-    }, [errors, ruleData])
+    }, [ruleData])
 
     // We need the errors at the form level, so that we can prevent save etc. when there are errors
     // We need to be able to change the errors depending on which fields are invalid
@@ -91,6 +91,8 @@ export const RuleForm = ({fetchRules}: {fetchRules: () => Promise<void>}) => {
                     <EuiButton fill={true} onClick={saveRuleHandler}>Save Rule</EuiButton>
                 </EuiFlexItem>
             </EuiFlexGroup>
+            {showErrors ? <EuiCallOut title="Please resolve the following errors:" color="danger" iconType="error">
+            </EuiCallOut> : null}
         </EuiFlexGroup> : null}
     </EuiForm>
 }

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -1,15 +1,29 @@
-import { EuiFlexGroup, EuiForm } from "@elastic/eui";
-import React from "react"
+import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiForm, EuiSpacer } from "@elastic/eui";
+import React, { useReducer, useState } from "react"
 import { RuleContent } from "./RuleContent";
 import { RuleType } from "./RuleType";
 import {RuleMetadata} from "./RuleMetadata";
 
 export const RuleForm = () => {
+    const [createRuleFormOpen, setCreateRuleFormOpen] = useState(false);
+    const openCreateRuleForm = () => {
+        setCreateRuleFormOpen(true);
+    }
     return <EuiForm component="form">
-            <EuiFlexGroup  direction="column">   
-                <RuleContent />
-                <RuleType />
-                <RuleMetadata />
-        </EuiFlexGroup>
+        <EuiButton isDisabled={createRuleFormOpen} onClick={openCreateRuleForm}>Create Rule</EuiButton>
+        <EuiSpacer />
+        {createRuleFormOpen ? <EuiFlexGroup  direction="column">   
+            <RuleContent />
+            <RuleType />
+            <RuleMetadata />
+            <EuiFlexGroup>
+                <EuiFlexItem>
+                    <EuiButton onClick={() => setCreateRuleFormOpen(false)}>Discard Rule</EuiButton>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                    <EuiButton fill={true}>Save Rule</EuiButton>
+                </EuiFlexItem>
+            </EuiFlexGroup>
+        </EuiFlexGroup> : null}
     </EuiForm>
 }

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -23,7 +23,7 @@ export type PartiallyUpdateRuleData = (existing: RuleFormData, partialReplacemen
 
 export type FormError = { id: string; value: string }
 
-export const RuleForm = ({fetchRules}: {fetchRules: () => Promise<void>}) => {
+export const RuleForm = ({onRuleUpdate}: {onRuleUpdate: () => Promise<void>}) => {
     const [createRuleFormOpen, setCreateRuleFormOpen] = useState(false);
     const [showErrors, setShowErrors] = useState(false);
     const [errors, setErrors] = useState<FormError[]>([]);
@@ -70,7 +70,7 @@ export const RuleForm = ({fetchRules}: {fetchRules: () => Promise<void>}) => {
             .then(response => response.json())
             .then(data => {
                 setRuleData(baseForm);
-                fetchRules();
+                onRuleUpdate();
             })
         setCreateRuleFormOpen(false);
     }

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -1,24 +1,55 @@
 import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiForm, EuiSpacer } from "@elastic/eui";
-import React, { useReducer, useState } from "react"
+import React, { useEffect, useState } from "react"
 import { RuleContent } from "./RuleContent";
 import { RuleType } from "./RuleType";
 import {RuleMetadata} from "./RuleMetadata";
+
+export type RuleType = 'regex' | 'languageTool';
+
+export type RuleFormData = {
+    ruleType: RuleType,
+    pattern?: string,
+    replacement?: string,
+    category?: string,
+    tags: string[],
+    description?: string,
+    ignore: boolean,
+    forceRedRule?: boolean,
+    advisoryRule?: boolean
+}
+
+export type PartiallyUpdateRuleData = (existing: RuleFormData, partialReplacement: Partial<RuleFormData>) => void;
 
 export const RuleForm = () => {
     const [createRuleFormOpen, setCreateRuleFormOpen] = useState(false);
     const openCreateRuleForm = () => {
         setCreateRuleFormOpen(true);
     }
+    const baseForm = {
+        ruleType: 'regex' as RuleType,
+        tags: [] as string[],
+        ignore: false,
+    }
+    const [ruleData, setRuleData] = useState<RuleFormData>(baseForm);
+    const partiallyUpdateRuleData: PartiallyUpdateRuleData = (existing, partialReplacement) => {
+        setRuleData({...existing, ...partialReplacement});
+    }
+    useEffect(() => console.log(ruleData), [ruleData])
+
+
     return <EuiForm component="form">
         <EuiButton isDisabled={createRuleFormOpen} onClick={openCreateRuleForm}>Create Rule</EuiButton>
         <EuiSpacer />
         {createRuleFormOpen ? <EuiFlexGroup  direction="column">   
-            <RuleContent />
+            <RuleContent ruleData={ruleData} partiallyUpdateRuleData={partiallyUpdateRuleData} />
             <RuleType />
             <RuleMetadata />
             <EuiFlexGroup>
                 <EuiFlexItem>
-                    <EuiButton onClick={() => setCreateRuleFormOpen(false)}>Discard Rule</EuiButton>
+                    <EuiButton onClick={() => {
+                        setCreateRuleFormOpen(false);
+                        setRuleData(baseForm);
+                    }}>Discard Rule</EuiButton>
                 </EuiFlexItem>
                 <EuiFlexItem>
                     <EuiButton fill={true}>Save Rule</EuiButton>

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react"
 import { RuleContent } from "./RuleContent";
 import { RuleType } from "./RuleType";
 import {RuleMetadata} from "./RuleMetadata";
+import { createRule } from "./helpers/createRule";
 
 export type RuleType = 'regex' | 'languageTool';
 
@@ -20,7 +21,7 @@ export type RuleFormData = {
 
 export type PartiallyUpdateRuleData = (existing: RuleFormData, partialReplacement: Partial<RuleFormData>) => void;
 
-export const RuleForm = () => {
+export const RuleForm = ({fetchRules}: {fetchRules: () => Promise<void>}) => {
     const [createRuleFormOpen, setCreateRuleFormOpen] = useState(false);
     const openCreateRuleForm = () => {
         setCreateRuleFormOpen(true);
@@ -36,6 +37,16 @@ export const RuleForm = () => {
     }
     useEffect(() => console.log(ruleData), [ruleData])
 
+    const saveRuleHandler = () => {
+        createRule(ruleData)
+            .then(response => response.json())
+            .then(data => {
+                console.log(data);
+                setRuleData(baseForm);
+                fetchRules();
+            })
+        setCreateRuleFormOpen(false);
+    }
 
     return <EuiForm component="form">
         <EuiButton isDisabled={createRuleFormOpen} onClick={openCreateRuleForm}>Create Rule</EuiButton>
@@ -52,7 +63,7 @@ export const RuleForm = () => {
                     }}>Discard Rule</EuiButton>
                 </EuiFlexItem>
                 <EuiFlexItem>
-                    <EuiButton fill={true}>Save Rule</EuiButton>
+                    <EuiButton fill={true} onClick={saveRuleHandler}>Save Rule</EuiButton>
                 </EuiFlexItem>
             </EuiFlexGroup>
         </EuiFlexGroup> : null}

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -42,7 +42,7 @@ export const RuleForm = () => {
         <EuiSpacer />
         {createRuleFormOpen ? <EuiFlexGroup  direction="column">   
             <RuleContent ruleData={ruleData} partiallyUpdateRuleData={partiallyUpdateRuleData} />
-            <RuleType />
+            <RuleType ruleData={ruleData} partiallyUpdateRuleData={partiallyUpdateRuleData} />
             <RuleMetadata />
             <EuiFlexGroup>
                 <EuiFlexItem>

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -2,8 +2,8 @@ import { EuiButton, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiForm, EuiSpacer, E
 import React, { useEffect, useState } from "react"
 import { RuleContent } from "./RuleContent";
 import { RuleType } from "./RuleType";
-import {RuleMetadata} from "./RuleMetadata";
-import { createRule, transformRuleFormData } from "./helpers/createRule";
+import { RuleMetadata } from "./RuleMetadata";
+import { createRule } from "./api/createRule";
 
 export type RuleType = 'regex' | 'languageToolXML';
 
@@ -66,7 +66,7 @@ export const RuleForm = ({fetchRules}: {fetchRules: () => Promise<void>}) => {
             return;
         }
 
-        createRule(transformRuleFormData(ruleData))
+        createRule(ruleData)
             .then(response => response.json())
             .then(data => {
                 setRuleData(baseForm);

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -1,0 +1,14 @@
+import { EuiFieldText, EuiFlexGroup, EuiFlexItem, EuiForm, EuiFormRow, EuiRadioGroup } from "@elastic/eui"
+import { css } from "@emotion/react";
+import React, { useState } from "react"
+import { RuleContent } from "./RuleContent";
+import { RuleType } from "./RuleType";
+
+export const RuleForm = () => {
+    return <EuiForm component="form">
+            <EuiFlexGroup  direction="column">   
+                <RuleContent />
+                <RuleType />
+        </EuiFlexGroup>
+    </EuiForm>
+}

--- a/apps/rule-manager/client/src/ts/components/RuleFormSection.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleFormSection.tsx
@@ -13,7 +13,7 @@ export const RuleFormSection = ({title, children} : {title?: string, children: J
         `}>
         {
             title ? <h2 style={{
-                fontFamily: 'Open Sans',
+                fontFamily: 'Guardian Agate Sans',
                 color: '#1A1C21',
                 fontWeight: '700',
             }}>{title}</h2> : null

--- a/apps/rule-manager/client/src/ts/components/RuleFormSection.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleFormSection.tsx
@@ -1,7 +1,6 @@
 import { EuiFlexItem } from "@elastic/eui"
 import { css } from "@emotion/react"
 import React from "react"
-import { ReactElement } from "react"
 
 export const RuleFormSection = ({title, children} : {title?: string, children: JSX.Element | JSX.Element[]}) => {
     return <EuiFlexItem css={css`
@@ -9,7 +8,7 @@ export const RuleFormSection = ({title, children} : {title?: string, children: J
             padding-top: 12px;
             padding-bottom: 12px;
             padding-left: 12px;
-            padding-right: 48px;
+            padding-right: 12px;
             border-radius: 4px;
         `}>
         {
@@ -17,7 +16,6 @@ export const RuleFormSection = ({title, children} : {title?: string, children: J
                 fontFamily: 'Open Sans',
                 color: '#1A1C21',
                 fontWeight: '700',
-                paddingBottom: '20px'
             }}>{title}</h2> : null
         }
         {children}

--- a/apps/rule-manager/client/src/ts/components/RuleFormSection.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleFormSection.tsx
@@ -1,0 +1,25 @@
+import { EuiFlexItem } from "@elastic/eui"
+import { css } from "@emotion/react"
+import React from "react"
+import { ReactElement } from "react"
+
+export const RuleFormSection = ({title, children} : {title?: string, children: JSX.Element | JSX.Element[]}) => {
+    return <EuiFlexItem css={css`
+            background-color: #D3DAE6;
+            padding-top: 12px;
+            padding-bottom: 12px;
+            padding-left: 12px;
+            padding-right: 48px;
+            border-radius: 4px;
+        `}>
+        {
+            title ? <h2 style={{
+                fontFamily: 'Open Sans',
+                color: '#1A1C21',
+                fontWeight: '700',
+                paddingBottom: '20px'
+            }}>{title}</h2> : null
+        }
+        {children}
+    </EuiFlexItem>
+}

--- a/apps/rule-manager/client/src/ts/components/RuleMetadata.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleMetadata.tsx
@@ -2,6 +2,7 @@ import {RuleFormSection} from "./RuleFormSection";
 import {LineBreak} from "./LineBreak";
 import {TagsSelector} from "./TagsSelector";
 import {CategorySelector} from "./CategorySelector";
+import React from "react";
 
 export const RuleMetadata = () => {
 

--- a/apps/rule-manager/client/src/ts/components/RuleMetadata.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleMetadata.tsx
@@ -13,6 +13,6 @@ export const RuleMetadata = ({ruleData, partiallyUpdateRuleData}: {
     return <RuleFormSection title="RULE METADATA">
         <LineBreak/>
         <CategorySelector ruleData={ruleData} partiallyUpdateRuleData={partiallyUpdateRuleData}/>
-        <TagsSelector/>
+        <TagsSelector ruleData={ruleData} partiallyUpdateRuleData={partiallyUpdateRuleData}/>
     </RuleFormSection>
 }

--- a/apps/rule-manager/client/src/ts/components/RuleMetadata.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleMetadata.tsx
@@ -1,0 +1,13 @@
+import {RuleFormSection} from "./RuleFormSection";
+import {LineBreak} from "./LineBreak";
+import {TagsSelector} from "./TagsSelector";
+import {CategorySelector} from "./CategorySelector";
+
+export const RuleMetadata = () => {
+
+    return <RuleFormSection title="RULE METADATA">
+        <LineBreak/>
+        <CategorySelector/>
+        <TagsSelector/>
+    </RuleFormSection>
+}

--- a/apps/rule-manager/client/src/ts/components/RuleMetadata.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleMetadata.tsx
@@ -3,12 +3,16 @@ import {LineBreak} from "./LineBreak";
 import {TagsSelector} from "./TagsSelector";
 import {CategorySelector} from "./CategorySelector";
 import React from "react";
+import { PartiallyUpdateRuleData, RuleFormData } from "./RuleForm";
 
-export const RuleMetadata = () => {
+export const RuleMetadata = ({ruleData, partiallyUpdateRuleData}: {
+    ruleData: RuleFormData,
+    partiallyUpdateRuleData: PartiallyUpdateRuleData,
+}) => {
 
     return <RuleFormSection title="RULE METADATA">
         <LineBreak/>
-        <CategorySelector/>
+        <CategorySelector ruleData={ruleData} partiallyUpdateRuleData={partiallyUpdateRuleData}/>
         <TagsSelector/>
     </RuleFormSection>
 }

--- a/apps/rule-manager/client/src/ts/components/RuleType.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleType.tsx
@@ -1,0 +1,45 @@
+import { EuiRadioGroup } from "@elastic/eui";
+import { css } from "@emotion/react";
+import React, { useState } from "react"
+import { RuleFormSection } from "./RuleFormSection"
+
+export const RuleType = () => {
+    const ruleTypeOptions = [
+        {
+            id: "actionable",
+            label: 'Actionable (Amend or OK)',
+        },
+        {
+            id: "ambiguous",
+            label: 'Ambiguous (Review)',
+        },
+    ]
+    const [ruleTypeSelected, setRuleTypeSelected] = useState(ruleTypeOptions[0].id);
+    
+    return <RuleFormSection title="RULE TYPE">
+        <EuiRadioGroup
+            options={[
+                {
+                    id: "regex",
+                    label: 'Regex',
+                },
+                {
+                    id: "languageTool",
+                    label: 'LanguageTool',
+                },
+            ]}
+            idSelected={ruleTypeSelected}
+            onChange={(id)=> {
+                setRuleTypeSelected(id)
+            }}
+            css={css`
+                flex-direction: row;
+                display: flex;
+                gap: 1rem;
+                align-items: flex-end;
+            `}
+        />
+    
+   
+    </RuleFormSection>
+}

--- a/apps/rule-manager/client/src/ts/components/RuleType.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleType.tsx
@@ -1,4 +1,4 @@
-import { EuiRadioGroup } from "@elastic/eui";
+import { EuiFormRow, EuiRadioGroup, EuiSwitch } from "@elastic/eui";
 import { css } from "@emotion/react";
 import React, { useState } from "react"
 import { RuleFormSection } from "./RuleFormSection"
@@ -15,31 +15,38 @@ export const RuleType = () => {
         },
     ]
     const [ruleTypeSelected, setRuleTypeSelected] = useState(ruleTypeOptions[0].id);
+    const [isAdvisory, setIsAdvisory] = useState(false);
+
+    const onIsAdvisoryChange = (e) => {
+        setIsAdvisory(e.target.checked);
+    };
     
     return <RuleFormSection title="RULE TYPE">
-        <EuiRadioGroup
-            options={[
-                {
-                    id: "regex",
-                    label: 'Regex',
-                },
-                {
-                    id: "languageTool",
-                    label: 'LanguageTool',
-                },
-            ]}
-            idSelected={ruleTypeSelected}
-            onChange={(id)=> {
-                setRuleTypeSelected(id)
-            }}
-            css={css`
-                flex-direction: row;
-                display: flex;
-                gap: 1rem;
-                align-items: flex-end;
-            `}
-        />
-    
-   
+        <EuiFormRow
+            label="Pattern"
+        >
+            <EuiRadioGroup
+                options={ruleTypeOptions}
+                idSelected={ruleTypeSelected}
+                onChange={(id)=> {
+                    setRuleTypeSelected(id)
+                }}
+                css={css`
+                    flex-direction: row;
+                    display: flex;
+                    gap: 1rem;
+                    align-items: flex-end;
+                `}
+            />
+        </EuiFormRow>
+        <EuiFormRow
+            helpText="Flag only once per session"
+        >
+            <EuiSwitch
+                label="Advisory rule"
+                checked={isAdvisory}
+                onChange={(e) => onIsAdvisoryChange(e)}
+            />
+        </EuiFormRow>
     </RuleFormSection>
 }

--- a/apps/rule-manager/client/src/ts/components/RuleType.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleType.tsx
@@ -1,10 +1,11 @@
-import { EuiFormRow, EuiRadioGroup, EuiSwitch } from "@elastic/eui";
+import { EuiFormRow, EuiRadioGroup, EuiSwitch, EuiSwitchEvent } from "@elastic/eui";
 import { css } from "@emotion/react";
 import React, { useState } from "react"
 import { RuleFormSection } from "./RuleFormSection"
 import {LineBreak} from "./LineBreak";
+import { PartiallyUpdateRuleData, RuleFormData } from "./RuleForm";
 
-export const RuleType = () => {
+export const RuleType = ({ruleData, partiallyUpdateRuleData}: {ruleData: RuleFormData, partiallyUpdateRuleData: PartiallyUpdateRuleData}) => {
     const ruleTypeOptions = [
         {
             id: "actionable",
@@ -18,8 +19,9 @@ export const RuleType = () => {
     const [ruleTypeSelected, setRuleTypeSelected] = useState(ruleTypeOptions[0].id);
     const [isAdvisory, setIsAdvisory] = useState(false);
 
-    const onIsAdvisoryChange = (e) => {
+    const onIsAdvisoryChange = (e: EuiSwitchEvent) => {
         setIsAdvisory(e.target.checked);
+        partiallyUpdateRuleData(ruleData, {advisoryRule: e.target.checked})
     };
     
     return <RuleFormSection title="RULE TYPE">

--- a/apps/rule-manager/client/src/ts/components/RuleType.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleType.tsx
@@ -1,22 +1,9 @@
 import { EuiFormRow, EuiRadioGroup, EuiSwitch, EuiSwitchEvent } from "@elastic/eui";
-import { css } from "@emotion/react";
 import React, { useState } from "react"
 import { RuleFormSection } from "./RuleFormSection"
-import {LineBreak} from "./LineBreak";
 import { PartiallyUpdateRuleData, RuleFormData } from "./RuleForm";
 
 export const RuleType = ({ruleData, partiallyUpdateRuleData}: {ruleData: RuleFormData, partiallyUpdateRuleData: PartiallyUpdateRuleData}) => {
-    const ruleTypeOptions = [
-        {
-            id: "actionable",
-            label: 'Actionable (Amend or OK)',
-        },
-        {
-            id: "ambiguous",
-            label: 'Ambiguous (Review)',
-        },
-    ]
-    const [ruleTypeSelected, setRuleTypeSelected] = useState(ruleTypeOptions[0].id);
     const [isAdvisory, setIsAdvisory] = useState(false);
 
     const onIsAdvisoryChange = (e: EuiSwitchEvent) => {
@@ -25,24 +12,6 @@ export const RuleType = ({ruleData, partiallyUpdateRuleData}: {ruleData: RuleFor
     };
     
     return <RuleFormSection title="RULE TYPE">
-        <LineBreak/>
-
-        <EuiRadioGroup
-            options={ruleTypeOptions}
-            idSelected={ruleTypeSelected}
-            onChange={(id)=> {
-                setRuleTypeSelected(id)
-            }}
-            css={css`
-                flex-direction: row;
-                display: flex;
-                gap: 1rem;
-                align-items: flex-end;
-            `}
-        />
-
-        <LineBreak/>
-
         <EuiFormRow
             helpText="Flag only once per session"
         >

--- a/apps/rule-manager/client/src/ts/components/RuleType.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleType.tsx
@@ -2,6 +2,7 @@ import { EuiFormRow, EuiRadioGroup, EuiSwitch } from "@elastic/eui";
 import { css } from "@emotion/react";
 import React, { useState } from "react"
 import { RuleFormSection } from "./RuleFormSection"
+import {LineBreak} from "./LineBreak";
 
 export const RuleType = () => {
     const ruleTypeOptions = [
@@ -22,23 +23,24 @@ export const RuleType = () => {
     };
     
     return <RuleFormSection title="RULE TYPE">
-        <EuiFormRow
-            label="Pattern"
-        >
-            <EuiRadioGroup
-                options={ruleTypeOptions}
-                idSelected={ruleTypeSelected}
-                onChange={(id)=> {
-                    setRuleTypeSelected(id)
-                }}
-                css={css`
-                    flex-direction: row;
-                    display: flex;
-                    gap: 1rem;
-                    align-items: flex-end;
-                `}
-            />
-        </EuiFormRow>
+        <LineBreak/>
+
+        <EuiRadioGroup
+            options={ruleTypeOptions}
+            idSelected={ruleTypeSelected}
+            onChange={(id)=> {
+                setRuleTypeSelected(id)
+            }}
+            css={css`
+                flex-direction: row;
+                display: flex;
+                gap: 1rem;
+                align-items: flex-end;
+            `}
+        />
+
+        <LineBreak/>
+
         <EuiFormRow
             helpText="Flag only once per session"
         >

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -141,7 +141,7 @@ const RulesTable = () => {
                 }
             </EuiFlexItem>
             <EuiFlexItem grow={1}>
-                <RuleForm fetchRules={fetchRules}/>
+                <RuleForm onRuleUpdate={fetchRules}/>
             </EuiFlexItem>
         </EuiFlexGroup>
 

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -10,6 +10,9 @@ import {
     EuiLoadingSpinner,
     EuiButtonIcon,
     EuiFlexGrid,
+    EuiForm,
+    EuiFormRow,
+    EuiFieldText,
 } from '@elastic/eui';
 import {useRules} from "./hooks/useRules";
 import {css} from "@emotion/react";
@@ -122,16 +125,46 @@ const RulesTable = () => {
 
             }
         </EuiFlexGrid>
-        {rules &&
-            <EuiInMemoryTable
-                tableCaption="Demo of EuiInMemoryTable"
-                items={rules}
-                columns={columns}
-                pagination={true}
-                sorting={sorting}
-                search={search}
-            />
-        }
+
+        <EuiFlexGroup>
+            <EuiFlexItem grow={2}>
+                {rules &&
+                    <EuiInMemoryTable
+                        tableCaption="Demo of EuiInMemoryTable"
+                        items={rules}
+                        columns={columns}
+                        pagination={true}
+                        sorting={sorting}
+                        search={search}
+                    />
+                }
+            </EuiFlexItem>
+
+            <EuiFlexItem grow={1} css={css`
+                  background-color: #D3DAE6;
+                  padding-top: 12px;
+                  padding-bottom: 48px;
+                  padding-left: 12px;
+                  padding-right: 48px;
+                  border-radius: 4px;
+                `}>
+                <h2 style={{
+                    fontFamily: 'Open Sans',
+                    color: '#1A1C21',
+                    fontWeight: '700',
+                    paddingBottom: '20px'
+                }}>RULE CONTENT</h2>
+                <EuiForm component="form">
+                    <EuiFormRow
+                        label="Replacement"
+                        helpText="What is the ideal term as per the house style?"
+                    >
+                        <EuiFieldText/>
+                    </EuiFormRow>
+                </EuiForm>
+            </EuiFlexItem>
+        </EuiFlexGroup>
+
     </>
 }
 

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -71,7 +71,7 @@ const columns: Array<EuiBasicTableColumn<Rule>> = [
 ];
 
 const RulesTable = () => {
-    const {rules, isLoading, error, refreshRules, isRefreshing, setError} = useRules();
+    const {rules, isLoading, error, refreshRules, isRefreshing, setError, fetchRules} = useRules();
     const search: EuiSearchBarProps = {
         box: {
             incremental: true,
@@ -141,7 +141,7 @@ const RulesTable = () => {
                 }
             </EuiFlexItem>
             <EuiFlexItem grow={1}>
-                <RuleForm />
+                <RuleForm fetchRules={fetchRules}/>
             </EuiFlexItem>
         </EuiFlexGroup>
 

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -16,6 +16,7 @@ import {
 } from '@elastic/eui';
 import {useRules} from "./hooks/useRules";
 import {css} from "@emotion/react";
+import { RuleForm } from './RuleForm';
 
 const sorting = {
     sort: {
@@ -139,29 +140,8 @@ const RulesTable = () => {
                     />
                 }
             </EuiFlexItem>
-
-            <EuiFlexItem grow={1} css={css`
-                  background-color: #D3DAE6;
-                  padding-top: 12px;
-                  padding-bottom: 48px;
-                  padding-left: 12px;
-                  padding-right: 48px;
-                  border-radius: 4px;
-                `}>
-                <h2 style={{
-                    fontFamily: 'Open Sans',
-                    color: '#1A1C21',
-                    fontWeight: '700',
-                    paddingBottom: '20px'
-                }}>RULE CONTENT</h2>
-                <EuiForm component="form">
-                    <EuiFormRow
-                        label="Replacement"
-                        helpText="What is the ideal term as per the house style?"
-                    >
-                        <EuiFieldText/>
-                    </EuiFormRow>
-                </EuiForm>
+            <EuiFlexItem grow={1}>
+                <RuleForm />
             </EuiFlexItem>
         </EuiFlexGroup>
 

--- a/apps/rule-manager/client/src/ts/components/TagsSelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsSelector.tsx
@@ -1,8 +1,13 @@
-import {useState} from "react";
+import {useEffect, useState} from "react";
 import {EuiFormRow, EuiComboBox} from "@elastic/eui";
 import React from "react";
+import { MetadataOption } from "./CategorySelector";
+import { PartiallyUpdateRuleData, RuleFormData } from "./RuleForm";
 
-export const TagsSelector = () => {
+export const TagsSelector = ({ruleData, partiallyUpdateRuleData}: {
+    ruleData: RuleFormData,
+    partiallyUpdateRuleData: PartiallyUpdateRuleData,
+}) => {
     const [options, updateOptions] = useState([
         {
             label: 'Tag A',
@@ -12,10 +17,10 @@ export const TagsSelector = () => {
         }
     ]);
 
-    const [selectedOptions, setSelected] = useState([]);
+    const [selectedTags, setSelectedTags] = useState<MetadataOption[]>([]);
 
-    const onChange = (selectedOptions) => {
-        setSelected(selectedOptions);
+    const onChange = (selectedTags) => {
+        setSelectedTags(selectedTags);
     };
 
     const onCreateOption = (searchValue, flattenedOptions) => {
@@ -39,14 +44,23 @@ export const TagsSelector = () => {
         }
 
         // Select the option.
-        setSelected((prevSelected) => [...prevSelected, newOption]);
+        setSelectedTags((prevSelected) => [...prevSelected, newOption]);
     };
+
+    useEffect(() => {
+        if (selectedTags.length) {
+            const newTags = selectedTags.map(tag => tag.label)
+            partiallyUpdateRuleData(ruleData, {tags: newTags})
+        } else {
+            partiallyUpdateRuleData(ruleData, {tags: undefined})
+        }
+    }, [selectedTags])
 
     return (
         <EuiFormRow label='Tags'>
             <EuiComboBox
                 options={options}
-                selectedOptions={selectedOptions}
+                selectedOptions={selectedTags}
                 onChange={onChange}
                 onCreateOption={onCreateOption}
                 isClearable={true}

--- a/apps/rule-manager/client/src/ts/components/TagsSelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsSelector.tsx
@@ -1,0 +1,56 @@
+import {useState} from "react";
+import {EuiFormRow, EuiComboBox} from "@elastic/eui";
+
+export const TagsSelector = () => {
+    const [options, updateOptions] = useState([
+        {
+            label: 'Tag A',
+        },
+        {
+            label: 'Tag B',
+        }
+    ]);
+
+    const [selectedOptions, setSelected] = useState([]);
+
+    const onChange = (selectedOptions) => {
+        setSelected(selectedOptions);
+    };
+
+    const onCreateOption = (searchValue, flattenedOptions) => {
+        const normalizedSearchValue = searchValue.trim().toLowerCase();
+
+        if (!normalizedSearchValue) {
+            return;
+        }
+
+        const newOption = {
+            label: searchValue,
+        };
+
+        // Create the option if it doesn't exist.
+        if (
+            flattenedOptions.findIndex(
+                (option) => option.label.trim().toLowerCase() === normalizedSearchValue
+            ) === -1
+        ) {
+            updateOptions([...options, newOption]);
+        }
+
+        // Select the option.
+        setSelected((prevSelected) => [...prevSelected, newOption]);
+    };
+
+    return (
+        <EuiFormRow label='Tags'>
+            <EuiComboBox
+                options={options}
+                selectedOptions={selectedOptions}
+                onChange={onChange}
+                onCreateOption={onCreateOption}
+                isClearable={true}
+                isCaseSensitive
+            />
+        </EuiFormRow>
+    );
+}

--- a/apps/rule-manager/client/src/ts/components/TagsSelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsSelector.tsx
@@ -1,5 +1,6 @@
 import {useState} from "react";
 import {EuiFormRow, EuiComboBox} from "@elastic/eui";
+import React from "react";
 
 export const TagsSelector = () => {
     const [options, updateOptions] = useState([

--- a/apps/rule-manager/client/src/ts/components/TagsSelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsSelector.tsx
@@ -3,32 +3,7 @@ import {EuiFormRow, EuiComboBox} from "@elastic/eui";
 import React from "react";
 import { MetadataOption } from "./CategorySelector";
 import { PartiallyUpdateRuleData, RuleFormData } from "./RuleForm";
-
-const existingTags = [
-    "SG",
-    "General",
-    "US spelling",
-    "Unnecessary contraction?",
-    "Swearword!",
-    "13?",
-    "Offensive?",
-    "US term",
-    "Taste?",
-    "Names",
-    "Coronavirus",
-    "Poss typo",
-    "SG ",
-    "Guardian convention",
-    "Legal",
-    "Tokyo 2020",
-    "Names",
-    "MP",
-    "LanguageTool",
-    "dates",
-    "Semantics",
-    "Typography",
-    "Typos"
-];
+import { existingTags } from "../constants/constants";
 
 export const TagsSelector = ({ruleData, partiallyUpdateRuleData}: {
     ruleData: RuleFormData,

--- a/apps/rule-manager/client/src/ts/components/TagsSelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsSelector.tsx
@@ -4,47 +4,42 @@ import React from "react";
 import { MetadataOption } from "./CategorySelector";
 import { PartiallyUpdateRuleData, RuleFormData } from "./RuleForm";
 
+const existingTags = [
+    "SG",
+    "General",
+    "US spelling",
+    "Unnecessary contraction?",
+    "Swearword!",
+    "13?",
+    "Offensive?",
+    "US term",
+    "Taste?",
+    "Names",
+    "Coronavirus",
+    "Poss typo",
+    "SG ",
+    "Guardian convention",
+    "Legal",
+    "Tokyo 2020",
+    "Names",
+    "MP",
+    "LanguageTool",
+    "dates",
+    "Semantics",
+    "Typography",
+    "Typos"
+];
+
 export const TagsSelector = ({ruleData, partiallyUpdateRuleData}: {
     ruleData: RuleFormData,
     partiallyUpdateRuleData: PartiallyUpdateRuleData,
 }) => {
-    const [options, updateOptions] = useState([
-        {
-            label: 'Tag A',
-        },
-        {
-            label: 'Tag B',
-        }
-    ]);
+    const options = existingTags.map(tag => {return {label: tag}});
 
     const [selectedTags, setSelectedTags] = useState<MetadataOption[]>([]);
 
     const onChange = (selectedTags) => {
         setSelectedTags(selectedTags);
-    };
-
-    const onCreateOption = (searchValue, flattenedOptions) => {
-        const normalizedSearchValue = searchValue.trim().toLowerCase();
-
-        if (!normalizedSearchValue) {
-            return;
-        }
-
-        const newOption = {
-            label: searchValue,
-        };
-
-        // Create the option if it doesn't exist.
-        if (
-            flattenedOptions.findIndex(
-                (option) => option.label.trim().toLowerCase() === normalizedSearchValue
-            ) === -1
-        ) {
-            updateOptions([...options, newOption]);
-        }
-
-        // Select the option.
-        setSelectedTags((prevSelected) => [...prevSelected, newOption]);
     };
 
     useEffect(() => {
@@ -62,7 +57,6 @@ export const TagsSelector = ({ruleData, partiallyUpdateRuleData}: {
                 options={options}
                 selectedOptions={selectedTags}
                 onChange={onChange}
-                onCreateOption={onCreateOption}
                 isClearable={true}
                 isCaseSensitive
             />

--- a/apps/rule-manager/client/src/ts/components/api/createRule.ts
+++ b/apps/rule-manager/client/src/ts/components/api/createRule.ts
@@ -12,17 +12,18 @@ type FormDataForApiEndpoint =  {
     advisoryRule?: boolean
 }
 
-export const transformRuleFormData = (ruleForm: RuleFormData): FormDataForApiEndpoint => {
-    return {...ruleForm, tags: ruleForm.tags ? ruleForm.tags.toString() : undefined};
+const transformRuleFormData = (ruleForm: RuleFormData): FormDataForApiEndpoint => {
+    return {...ruleForm, tags: ruleForm.tags ? ruleForm.tags.join(",") : undefined};
 }
 
-export const createRule = async (ruleForm: FormDataForApiEndpoint) => {
-   const createRuleResponse = fetch(`${location}rules`, {
+export const createRule = async (ruleForm: RuleFormData) => {
+    const transformedRuleFormData = transformRuleFormData(ruleForm);
+    const createRuleResponse = fetch(`${location}rules`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'
         },
-        body: JSON.stringify(ruleForm)
+        body: JSON.stringify(transformedRuleFormData)
     });
     return createRuleResponse
 }

--- a/apps/rule-manager/client/src/ts/components/helpers/createRule.ts
+++ b/apps/rule-manager/client/src/ts/components/helpers/createRule.ts
@@ -1,0 +1,12 @@
+import { RuleFormData } from "../RuleForm";
+
+export const createRule = async (ruleForm: RuleFormData) => {
+   const createRuleResponse = fetch(`${location}rules`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(ruleForm)
+    });
+    return createRuleResponse
+}

--- a/apps/rule-manager/client/src/ts/components/helpers/createRule.ts
+++ b/apps/rule-manager/client/src/ts/components/helpers/createRule.ts
@@ -5,7 +5,7 @@ type FormDataForApiEndpoint =  {
     pattern?: string,
     replacement?: string,
     category?: string,
-    tags: string,
+    tags?: string,
     description?: string,
     ignore: boolean,
     forceRedRule?: boolean,
@@ -13,7 +13,7 @@ type FormDataForApiEndpoint =  {
 }
 
 export const transformRuleFormData = (ruleForm: RuleFormData): FormDataForApiEndpoint => {
-    return {...ruleForm, tags: ruleForm.tags.toString()};
+    return {...ruleForm, tags: ruleForm.tags ? ruleForm.tags.toString() : undefined};
 }
 
 export const createRule = async (ruleForm: FormDataForApiEndpoint) => {

--- a/apps/rule-manager/client/src/ts/components/helpers/createRule.ts
+++ b/apps/rule-manager/client/src/ts/components/helpers/createRule.ts
@@ -1,6 +1,22 @@
 import { RuleFormData } from "../RuleForm";
 
-export const createRule = async (ruleForm: RuleFormData) => {
+type FormDataForApiEndpoint =  {
+    ruleType: string,
+    pattern?: string,
+    replacement?: string,
+    category?: string,
+    tags: string,
+    description?: string,
+    ignore: boolean,
+    forceRedRule?: boolean,
+    advisoryRule?: boolean
+}
+
+export const transformRuleFormData = (ruleForm: RuleFormData): FormDataForApiEndpoint => {
+    return {...ruleForm, tags: ruleForm.tags.toString()};
+}
+
+export const createRule = async (ruleForm: FormDataForApiEndpoint) => {
    const createRuleResponse = fetch(`${location}rules`, {
         method: 'POST',
         headers: {

--- a/apps/rule-manager/client/src/ts/components/hooks/useRules.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRules.ts
@@ -46,5 +46,5 @@ export function useRules() {
         fetchRules();
     }, []);
 
-    return { rules, isLoading, error, refreshRules, isRefreshing, setError };
+    return { rules, isLoading, error, refreshRules, isRefreshing, setError, fetchRules };
 }

--- a/apps/rule-manager/client/src/ts/constants/constants.ts
+++ b/apps/rule-manager/client/src/ts/constants/constants.ts
@@ -2,3 +2,50 @@ export const colors = {
   backgroundColorDark: "#2B2B29",
   backgroundColorLight: "#DBDBDB",
 }
+
+export const existingTags = [
+  "SG",
+  "General",
+  "US spelling",
+  "Unnecessary contraction?",
+  "Swearword!",
+  "13?",
+  "Offensive?",
+  "US term",
+  "Taste?",
+  "Names",
+  "Coronavirus",
+  "Poss typo",
+  "SG ",
+  "Guardian convention",
+  "Legal",
+  "Tokyo 2020",
+  "Names",
+  "MP",
+  "LanguageTool",
+  "dates",
+  "Semantics",
+  "Typography",
+  "Typos"
+];
+
+export const existingCategories = [  
+  "Check this",
+  "Guardian convention",
+  "Style guide and names",
+  "General",
+  "Names",
+  "Typos",
+  "Tokyo 2020: General",
+  "Tokyo 2020: Diving",
+  "Tokyo 2020: Equestrian",
+  "Tokyo 2020: Cycling",
+  "Tokyo 2020: Rugby",
+  "Tokyo 2020: Boxing",
+  "Tokyo 2020: Football",
+  "Tokyo 2020: Swimming",
+  "Coronavirus",
+  "Typography",
+  "Dates",
+  "Style Guide"
+];


### PR DESCRIPTION
Co-authored-by @Fweddi 

## What does this change?

This PR adds a 'create rule' form. Currently the form is very permissive, and only the 'rule' is required.

<img width="1193" alt="image" src="https://user-images.githubusercontent.com/34686302/235632974-0b6cbe30-99a9-455c-87c0-50bd2aedb350.png">

The DB model for categories and and tags are subject to change (tags also currently aren't save to the database, PR-pending). In this PR, categories are a hardcoded list, in the future we'd want to use an endpoint, drawing from existing tags. We'd also want tags to be drawn from the database in the future, with users able to add their own tags.

The position of the form in this PR is subject to change - we've tried to cover the core functionality of the form (managing form data and submitting to the backend) as the UI will be finalised later.

## How to test

With Composer credentials, run `typerighter` locally using `./script/start`. Can you add a new rule via the form as intended?

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [X] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
