### PR TITLE
Give None rather than Some("") for replacement, tags and notes

### DIFF
--- a/apps/checker/test/scala/matchers/RegexMatcherTest.scala
+++ b/apps/checker/test/scala/matchers/RegexMatcherTest.scala
@@ -317,4 +317,16 @@ class RegexMatcherTest extends AsyncFlatSpec with Matchers {
       firstMatch.markAsCorrect shouldBe true
     }
   }
+
+  it should "should not throw an error when the replacement is empty" in {
+    val eventuallyMatches = checkTextWithRegex(
+      new ComparableRegex("(?i)\\bcaf(e|é|è|ë|ê)"),
+      "",
+      "Allowed to have up to 15 people in their home per day, and this rule applies to holiday accomodation. cafes, bars, and restaurants will be able to seat 100 indoors and 200 outdoors, within the density limit"
+    )
+
+    eventuallyMatches.map { matches =>
+      matches.size shouldBe 1
+    }
+  }
 }

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/model/Suggestion.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/model/Suggestion.scala
@@ -17,7 +17,7 @@ sealed trait Suggestion {
   /** If our suggestion is at the start of a sentence, cap up the first letter.
     */
   def ensureCorrectCase(isStartOfSentence: Boolean): Suggestion = this match {
-    case TextSuggestion(text) if isStartOfSentence =>
+    case TextSuggestion(text) if isStartOfSentence && text.nonEmpty =>
       TextSuggestion(text = s"${text.charAt(0).toUpper}${text.slice(1, text.length)}")
     case suggestion => suggestion
   }

--- a/apps/rule-manager/app/service/SheetsRuleManager.scala
+++ b/apps/rule-manager/app/service/SheetsRuleManager.scala
@@ -113,12 +113,12 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String) extends 
                 id = None,
                 ruleType = ruleType,
                 pattern = row.lift(PatternRuleCols.Pattern).asInstanceOf[Option[String]],
-                replacement = row.lift(PatternRuleCols.Replacement).asInstanceOf[Option[String]],
+                replacement = cellToOptionalString(row, PatternRuleCols.Replacement),
                 category = row.lift(PatternRuleCols.Category).asInstanceOf[Option[String]],
-                tags = row.lift(PatternRuleCols.Tags).asInstanceOf[Option[String]],
+                tags = cellToOptionalString(row, PatternRuleCols.Tags),
                 description = row.lift(PatternRuleCols.Description).asInstanceOf[Option[String]],
                 ignore = if (ignore.toString == "TRUE") true else false,
-                notes = row.lift(PatternRuleCols.Replacement).asInstanceOf[Option[String]],
+                notes = cellToOptionalString(row, PatternRuleCols.Replacement),
                 googleSheetId = Some(id),
                 forceRedRule = Some(
                   row.lift(PatternRuleCols.ForceRed).asInstanceOf[Option[String]].contains("y")
@@ -138,6 +138,12 @@ class SheetsRuleManager(credentialsJson: String, spreadsheetId: String) extends 
       }
     }
   }
+
+  private def cellToOptionalString(row: List[Any], col: Int): Option[String] =
+    row(col).asInstanceOf[String] match {
+      case "" => None
+      case s  => Some(s)
+    }
 
   /** Creates an authorized Credential object.
     *


### PR DESCRIPTION
## What does this change?

Gives `None` rather than `Some` for replacement, tags and notes, when parsing a Google sheet into a `DbRule`.

This matches [behaviour prior to #300](https://github.com/guardian/typerighter/blame/fc17274c6ed9c4cffee68487b1a52cbef7925f8a/apps/common-lib/src/main/scala/com/gu/typerighter/rules/SheetsRuleManager.scala#L144) for the replacement  field – the behaviour in #300 produced a replacement field with an empty string, which blew up in our checker code.

We probably shouldn't blow up when encountering empty replacements, so I've added a defence against that, too, and a test.

## How to test

The new test should pass. We currently don't have any tests for the sheet translation logic. If we continue to introduce regressions it will be worth adding some – this PR aims to fix forward, so I haven't added them here.

Run locally or in CODE on an existing piece (e.g. [this one in CODE.](https://composer.code.dev-gutools.co.uk/content/56aa04a1e4b0375b9c5eec1f)) Previous to this change, the fact that replacements were present for each rule would mean that every rule came in as red, and errors would be thrown attempting to match:

<img width="262" alt="Screenshot 2023-05-05 at 09 58 51" src="https://user-images.githubusercontent.com/7767575/236417079-dc8ea61e-a352-4ff4-a649-50801f0cee76.png">

Now, we should see orange and red rules, and no errors:
<img width="262" alt="Screenshot 2023-05-05 at 10 04 18" src="https://user-images.githubusercontent.com/7767575/236418309-7a09d08d-42fd-4876-b961-ac748295087f.png">