### PR TITLE
Improve Vite behaviour when launching app with scripts

### DIFF
--- a/apps/rule-manager/client/package.json
+++ b/apps/rule-manager/client/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "type": "module",
   "scripts": {
-    "start": "vite",
+    "start": "vite --clearScreen false",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/script/start-manager
+++ b/script/start-manager
@@ -40,3 +40,8 @@ trap teardownDependencies EXIT
 checkCredentials
 setupDependencies
 runRuleManager
+
+# catches script exit events and kills the `npm run watch` process and its children
+# https://stackoverflow.com/a/22644006
+trap "exit" INT TERM
+trap "kill 0" EXIT

--- a/script/start-manager
+++ b/script/start-manager
@@ -41,7 +41,7 @@ checkCredentials
 setupDependencies
 runRuleManager
 
-# catches script exit events and kills the `npm run watch` process and its children
+# catches script exit events and kills child processes and their process trees
 # https://stackoverflow.com/a/22644006
 trap "exit" INT TERM
 trap "kill 0" EXIT


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

A few things to improve Vite behaviour when launching app with scripts:

- Stops vite removing output from previous commands from the terminal
- Makes sure the vite process ends when we stop running the app

## How to test

- Run the `start` script in the rule-manager client. It should be clear the output from Vite is not cleared.
- Harder to prove the second thing – perhaps try terminating the `start-manager` script a few times and check that vite has been properly cleared up? (The problem is intermittent, I think.)