### PR TITLE
Check for permissions before creating or editing rules on backend

### DIFF
--- a/apps/rule-manager/app/AppComponents.scala
+++ b/apps/rule-manager/app/AppComponents.scala
@@ -111,7 +111,8 @@ class AppComponents(
     controllerComponents,
     sheetsRuleManager,
     bucketRuleManager,
-    publicSettings
+    publicSettings,
+    config
   )
 
   lazy val router = new Routes(

--- a/apps/rule-manager/app/controllers/HomeController.scala
+++ b/apps/rule-manager/app/controllers/HomeController.scala
@@ -24,7 +24,16 @@ class HomeController(
     with PermissionsHandler {
 
   def index() = AuthAction { request =>
-    Ok(views.html.index(config.stage, request.user, userAndPermissionsToJson(request.user, List(PermissionDefinition("manage_rules", "typerighter")))))
+    Ok(
+      views.html.index(
+        config.stage,
+        request.user,
+        userAndPermissionsToJson(
+          request.user,
+          List(PermissionDefinition("manage_rules", "typerighter"))
+        )
+      )
+    )
   }
 
   def healthcheck() = Action {

--- a/apps/rule-manager/app/controllers/HomeController.scala
+++ b/apps/rule-manager/app/controllers/HomeController.scala
@@ -24,7 +24,7 @@ class HomeController(
     with PermissionsHandler {
 
   def index() = AuthAction { request =>
-    Ok(views.html.index(config.stage, request.user))
+    Ok(views.html.index(config.stage, request.user, userAndPermissionsToJson(request.user, List(PermissionDefinition("manage_rules", "typerighter")))))
   }
 
   def healthcheck() = Action {

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import com.gu.pandomainauth.PublicSettings
+import com.gu.permissions.PermissionDefinition
 import com.gu.typerighter.lib.PandaAuthentication
 import com.gu.typerighter.rules.BucketRuleManager
 
@@ -12,6 +13,11 @@ import play.api.data.FormError
 import play.api.libs.json.{JsValue, Writes}
 import play.api.mvc._
 import service.{DbRuleManager, SheetsRuleManager}
+<<<<<<< HEAD
+=======
+import utils.{PermissionsHandler, RuleManagerConfig}
+
+>>>>>>> 31ceff7 (Check for permissions before creating or editing rules on backend)
 import scala.util.{Failure, Success}
 
 /** The controller that handles the management of matcher rules.
@@ -20,9 +26,11 @@ class RulesController(
     cc: ControllerComponents,
     sheetsRuleManager: SheetsRuleManager,
     bucketRuleManager: BucketRuleManager,
-    val publicSettings: PublicSettings
+    val publicSettings: PublicSettings,
+    override val config: RuleManagerConfig
 ) extends AbstractController(cc)
-    with PandaAuthentication {
+    with PandaAuthentication
+    with PermissionsHandler {
   def refresh = ApiAuthAction {
     val maybeWrittenRules = for {
       dbRules <- sheetsRuleManager.getRules()
@@ -57,37 +65,46 @@ class RulesController(
     )
   }
 
-  def create = ApiAuthAction { implicit request =>
-    CreateRuleForm.form
-      .bindFromRequest()
-      .fold(
-        formWithErrors => {
-          val errors = formWithErrors.errors
-          BadRequest(Json.toJson(errors))
-        },
-        formRule => {
-          DbRuleDraft.createFromFormRule(formRule, request.user.email) match {
-            case Success(rule)  => Ok(Json.toJson(rule))
-            case Failure(error) => InternalServerError(error.getMessage())
-          }
-        }
-      )
+  def create = ApiAuthAction { implicit request => {
+    hasPermission(request.user, PermissionDefinition("manage_rules", "typerighter")) match {
+      case false => Unauthorized("You don't have permission to create rules")
+      case true =>
+        CreateRuleForm.form
+          .bindFromRequest()
+          .fold(
+            formWithErrors => {
+              val errors = formWithErrors.errors
+              BadRequest(Json.toJson(errors))
+            },
+            formRule => {
+              DbRuleDraft.createFromFormRule(formRule, request.user.email) match {
+                case Success(rule) => Ok(Json.toJson(rule))
+                case Failure(error) => InternalServerError(error.getMessage())
+              }
+            }
+          )
+      }
+    }
   }
 
   def update(id: Int) = ApiAuthAction { implicit request =>
-    UpdateRuleForm.form
-      .bindFromRequest()
-      .fold(
-        formWithErrors => {
-          val errors = formWithErrors.errors
-          BadRequest(Json.toJson(errors))
-        },
-        formRule => {
-          DbRuleDraft.updateFromFormRule(formRule, id, request.user.email) match {
-            case Left(result)  => result
-            case Right(dbRule) => Ok(Json.toJson(dbRule))
-          }
-        }
-      )
+    hasPermission(request.user, PermissionDefinition("manage_rules", "typerighter")) match {
+      case false => Unauthorized("You don't have permission to edit rules")
+      case true =>
+        UpdateRuleForm.form
+          .bindFromRequest()
+          .fold(
+            formWithErrors => {
+              val errors = formWithErrors.errors
+              BadRequest(Json.toJson(errors))
+            },
+            formRule => {
+              DbRuleDraft.updateFromFormRule(formRule, id, request.user.email) match {
+                case Left(result) => result
+                case Right(dbRule) => Ok(Json.toJson(dbRule))
+              }
+            }
+          )
+    }
   }
 }

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -62,24 +62,25 @@ class RulesController(
     )
   }
 
-  def create = ApiAuthAction { implicit request => {
-    hasPermission(request.user, PermissionDefinition("manage_rules", "typerighter")) match {
-      case false => Unauthorized("You don't have permission to create rules")
-      case true =>
-        CreateRuleForm.form
-          .bindFromRequest()
-          .fold(
-            formWithErrors => {
-              val errors = formWithErrors.errors
-              BadRequest(Json.toJson(errors))
-            },
-            formRule => {
-              DbRuleDraft.createFromFormRule(formRule, request.user.email) match {
-                case Success(rule) => Ok(Json.toJson(rule))
-                case Failure(error) => InternalServerError(error.getMessage())
+  def create = ApiAuthAction { implicit request =>
+    {
+      hasPermission(request.user, PermissionDefinition("manage_rules", "typerighter")) match {
+        case false => Unauthorized("You don't have permission to create rules")
+        case true =>
+          CreateRuleForm.form
+            .bindFromRequest()
+            .fold(
+              formWithErrors => {
+                val errors = formWithErrors.errors
+                BadRequest(Json.toJson(errors))
+              },
+              formRule => {
+                DbRuleDraft.createFromFormRule(formRule, request.user.email) match {
+                  case Success(rule)  => Ok(Json.toJson(rule))
+                  case Failure(error) => InternalServerError(error.getMessage())
+                }
               }
-            }
-          )
+            )
       }
     }
   }
@@ -97,7 +98,7 @@ class RulesController(
             },
             formRule => {
               DbRuleDraft.updateFromFormRule(formRule, id, request.user.email) match {
-                case Left(result) => result
+                case Left(result)  => result
                 case Right(dbRule) => Ok(Json.toJson(dbRule))
               }
             }

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -13,11 +13,8 @@ import play.api.data.FormError
 import play.api.libs.json.{JsValue, Writes}
 import play.api.mvc._
 import service.{DbRuleManager, SheetsRuleManager}
-<<<<<<< HEAD
-=======
 import utils.{PermissionsHandler, RuleManagerConfig}
 
->>>>>>> 31ceff7 (Check for permissions before creating or editing rules on backend)
 import scala.util.{Failure, Success}
 
 /** The controller that handles the management of matcher rules.

--- a/apps/rule-manager/app/utils/Permissions.scala
+++ b/apps/rule-manager/app/utils/Permissions.scala
@@ -34,21 +34,25 @@ trait PermissionsHandler {
     JsObject(
       Seq(
         "permissions" -> JsArray(
-          permissions.map(permission =>
-            JsObject(
-              Seq(
-                "permission" -> JsString(permission.name),
-                "active" -> JsBoolean(hasPermission(user, permission))
+          permissions
+            .map(permission =>
+              JsObject(
+                Seq(
+                  "permission" -> JsString(permission.name),
+                  "active" -> JsBoolean(hasPermission(user, permission))
+                )
               )
             )
-          ).toIndexedSeq
+            .toIndexedSeq
         ),
-        "user" -> JsObject(Seq(
+        "user" -> JsObject(
+          Seq(
             "firstName" -> JsString(user.firstName),
             "lastName" -> JsString(user.lastName),
             "email" -> JsString(user.email),
             "avatarUrl" -> JsString(user.avatarUrl.getOrElse(""))
-        ))
+          )
+        )
       )
     )
   }

--- a/apps/rule-manager/app/utils/Permissions.scala
+++ b/apps/rule-manager/app/utils/Permissions.scala
@@ -1,9 +1,9 @@
 package utils
 
 import com.gu.permissions._
-
 import com.gu.pandomainauth.model.User
 import com.gu.typerighter.lib.CommonConfig
+import play.api.libs.json.{JsArray, JsBoolean, JsObject, JsString, JsValue}
 
 trait PermissionsHandler {
   def config: CommonConfig
@@ -28,5 +28,28 @@ trait PermissionsHandler {
       case User(_, _, email, _) => permissions.hasPermission(permission, email)
       case _                    => false
     }
+  }
+
+  def userAndPermissionsToJson(user: User, permissions: List[PermissionDefinition]): JsValue = {
+    JsObject(
+      Seq(
+        "permissions" -> JsArray(
+          permissions.map(permission =>
+            JsObject(
+              Seq(
+                "permission" -> JsString(permission.name),
+                "active" -> JsBoolean(hasPermission(user, permission))
+              )
+            )
+          ).toIndexedSeq
+        ),
+        "user" -> JsObject(Seq(
+            "firstName" -> JsString(user.firstName),
+            "lastName" -> JsString(user.lastName),
+            "email" -> JsString(user.email),
+            "avatarUrl" -> JsString(user.avatarUrl.getOrElse(""))
+        ))
+      )
+    )
   }
 }

--- a/apps/rule-manager/app/views/index.scala.html
+++ b/apps/rule-manager/app/views/index.scala.html
@@ -1,6 +1,7 @@
 @import com.gu.pandomainauth.model.User
 
-@(stage: String, user: User)
+@import play.api.libs.json.JsValue
+@(stage: String, user: User, userWithPermissions: JsValue)
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -29,7 +30,7 @@
     <link rel="icon" href="static/favicon.@{stage.toUpperCase}.svg">
   </head>
   <body>
-    <script id="data" type="application/json">@{Html(user.toJson)}</script>
+    <script id="data" type="application/json">@{Html(userWithPermissions.toString())}</script>
     <div id="rule-manager-app"></div>
   </body>
 </html>

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -6,8 +6,7 @@ import { RuleMetadata } from "./RuleMetadata";
 import { createRule } from "./api/createRule";
 import { FeatureSwitchesContext } from "./context/featureSwitches";
 import { updateRule } from "./api/updateRule";
-import { PageContext } from "../utils/window";
-import { hasCreateEditPermissions } from "./helpers/hasCreateEditPermissions";
+import { useCreateEditPermissions } from "./RulesTable";
 
 export type RuleType = 'regex' | 'languageToolXML';
 
@@ -41,11 +40,10 @@ export const RuleForm = ({onRuleUpdate, ruleData, setRuleData, createRuleFormOpe
         createRuleFormOpen: boolean, 
         setCreateRuleFormOpen: Dispatch<SetStateAction<boolean>>,
         updateMode: boolean, 
-        setUpdateMode: Dispatch<SetStateAction<boolean>>
+        setUpdateMode: Dispatch<SetStateAction<boolean>>,
     }) => {
     const [showErrors, setShowErrors] = useState(false);
     const [errors, setErrors] = useState<FormError[]>([]);
-    const pageData = useContext(PageContext)
 
     const openCreateRuleForm = () => {
         setRuleData(baseForm);
@@ -95,12 +93,13 @@ export const RuleForm = ({onRuleUpdate, ruleData, setRuleData, createRuleFormOpe
     }
 
     const { getFeatureSwitchValue } = useContext(FeatureSwitchesContext);
+    const hasCreatePermissions = useCreateEditPermissions();
 
     return <EuiForm component="form">
         {getFeatureSwitchValue("create-and-edit") && 
-            <EuiToolTip content={pageData && hasCreateEditPermissions(pageData.permissions) ? "" : "You do not have the correct permissions to create a rule. Please contact Central Production if you need to create rules."}>
-                <EuiButton 
-                    isDisabled={createRuleFormOpen || (pageData ? !hasCreateEditPermissions(pageData.permissions) : true)} 
+            <EuiToolTip content={hasCreatePermissions ? "" : "You do not have the correct permissions to create a rule. Please contact Central Production if you need to create rules."}>
+                <EuiButton
+                    isDisabled={createRuleFormOpen || !hasCreatePermissions} 
                     onClick={openCreateRuleForm}
                 >Create Rule</EuiButton>
             </EuiToolTip>

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -1,4 +1,4 @@
-import { EuiButton, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiForm, EuiSpacer, EuiText } from "@elastic/eui";
+import { EuiButton, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiForm, EuiSpacer, EuiText, EuiToolTip } from "@elastic/eui";
 import React, { Dispatch, SetStateAction, useContext, useEffect, useState } from "react"
 import { RuleContent } from "./RuleContent";
 import { RuleType } from "./RuleType";
@@ -97,7 +97,14 @@ export const RuleForm = ({onRuleUpdate, ruleData, setRuleData, createRuleFormOpe
     const { getFeatureSwitchValue } = useContext(FeatureSwitchesContext);
 
     return <EuiForm component="form">
-        {getFeatureSwitchValue("create-and-edit") && <EuiButton isDisabled={createRuleFormOpen || (pageData ? !hasCreateEditPermissions(pageData.permissions) : true)} onClick={openCreateRuleForm}>Create Rule</EuiButton>}
+        {getFeatureSwitchValue("create-and-edit") && 
+            <EuiToolTip content={pageData && hasCreateEditPermissions(pageData.permissions) ? "" : "You do not have the correct permissions to create a rule. Please contact Central Production if you need to create rules."}>
+                <EuiButton 
+                    isDisabled={createRuleFormOpen || (pageData ? !hasCreateEditPermissions(pageData.permissions) : true)} 
+                    onClick={openCreateRuleForm}
+                >Create Rule</EuiButton>
+            </EuiToolTip>
+        }
         <EuiSpacer />
         {createRuleFormOpen ? <EuiFlexGroup  direction="column">
             <RuleContent ruleData={ruleData} partiallyUpdateRuleData={partiallyUpdateRuleData} errors={errors} showErrors={showErrors}/>

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -8,6 +8,8 @@ import { Rule } from "./RulesTable";
 import { FeatureSwitchesContext } from "./context/featureSwitches";
 import { updateRule } from "./api/updateRule";
 import { responseHandler } from "./api/parseResponse";
+import { PageContext } from "../utils/window";
+import { hasCreateEditPermissions } from "./helpers/hasCreateEditPermissions";
 
 export type RuleType = 'regex' | 'languageToolXML';
 
@@ -45,6 +47,7 @@ export const RuleForm = ({onRuleUpdate, ruleData, setRuleData, createRuleFormOpe
     }) => {
     const [showErrors, setShowErrors] = useState(false);
     const [errors, setErrors] = useState<FormError[]>([]);
+    const pageData = useContext(PageContext)
 
     const openCreateRuleForm = () => {
         setRuleData(baseForm);
@@ -96,7 +99,7 @@ export const RuleForm = ({onRuleUpdate, ruleData, setRuleData, createRuleFormOpe
     const { getFeatureSwitchValue } = useContext(FeatureSwitchesContext);
 
     return <EuiForm component="form">
-        {getFeatureSwitchValue("create-and-edit") && <EuiButton isDisabled={createRuleFormOpen} onClick={openCreateRuleForm}>Create Rule</EuiButton>}
+        {getFeatureSwitchValue("create-and-edit") && <EuiButton isDisabled={createRuleFormOpen || (pageData ? !hasCreateEditPermissions(pageData.permissions) : true)} onClick={openCreateRuleForm}>Create Rule</EuiButton>}
         <EuiSpacer />
         {createRuleFormOpen ? <EuiFlexGroup  direction="column">
             <RuleContent ruleData={ruleData} partiallyUpdateRuleData={partiallyUpdateRuleData} errors={errors} showErrors={showErrors}/>

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -4,10 +4,8 @@ import { RuleContent } from "./RuleContent";
 import { RuleType } from "./RuleType";
 import { RuleMetadata } from "./RuleMetadata";
 import { createRule } from "./api/createRule";
-import { Rule } from "./RulesTable";
 import { FeatureSwitchesContext } from "./context/featureSwitches";
 import { updateRule } from "./api/updateRule";
-import { responseHandler } from "./api/parseResponse";
 import { PageContext } from "../utils/window";
 import { hasCreateEditPermissions } from "./helpers/hasCreateEditPermissions";
 

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -16,7 +16,6 @@ import { useRules } from "./hooks/useRules";
 import { css } from "@emotion/react";
 import { baseForm, RuleForm, RuleFormData } from './RuleForm';
 import { getRule } from './api/getRule';
-import { responseHandler } from './api/parseResponse';
 
 const sorting = {
     sort: {

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -19,6 +19,7 @@ import { baseForm, RuleForm, RuleFormData } from './RuleForm';
 import { getRule } from './api/getRule';
 import { PageContext, PageDataProvider } from '../utils/window';
 import { hasCreateEditPermissions } from './helpers/hasCreateEditPermissions';
+import styled from '@emotion/styled';
 
 const sorting = {
     sort: {
@@ -71,23 +72,39 @@ const createColumns = (editRule: (ruleId: number) => void, editIsEnabled: boolea
         name: 'Description'
     },
     {
-        name: <EuiToolTip content={editIsEnabled ? "" : "You do not have the correct permissions to edit a rule. Please contact Central Production if you need to edit rules."}>
-            <EuiIcon type="pencil"/>
-        </EuiToolTip>,
+        name: <EuiIcon type="pencil"/>,
         actions: [{
             name: 'Edit',
+            render: (item, enabled) => <EditRule editIsEnabled={enabled} editRule={editRule} rule={item}/>,
             isPrimary: true,
             description: 'Edit this rule',
-            icon: 'pencil',
-            type: 'icon',
             onClick: (rule) => {
                 editRule(Number(rule.id))
             },
-            enabled: () => editIsEnabled,  
+            enabled: (item) => editIsEnabled,
             'data-test-subj': 'action-edit',
         }]
     }
 ];
+
+// We use our own button rather than an EuiIconButton because that component won't allow us to
+// show a tooltip on hover when the button is disabled
+const EditRule = ({editIsEnabled, editRule, rule}: {editIsEnabled: boolean, editRule: (ruleId: number) => void, rule: Rule}) => {
+    return <EuiToolTip content={editIsEnabled ? "" : "You do not have the correct permissions to edit a rule. Please contact Central Production if you need to edit rules."}>
+        <EditRuleButton editIsEnabled={editIsEnabled} onClick={() => (editIsEnabled ? editRule(Number(rule.id)) : () => null)}>
+            <EuiIcon type="pencil"/>
+        </EditRuleButton>
+    </EuiToolTip>
+}
+
+type EditRuleButtonProps = {
+    editIsEnabled: boolean;
+}
+
+const EditRuleButton = styled.button<EditRuleButtonProps>(props => ({
+    width: '16px',
+    cursor: props.editIsEnabled ? 'pointer' : 'not-allowed',
+}))
 
 const RulesTable = () => {
     const {rules, isLoading, error, refreshRules, isRefreshing, setError, fetchRules} = useRules();

--- a/apps/rule-manager/client/src/ts/components/helpers/hasCreateEditPermissions.ts
+++ b/apps/rule-manager/client/src/ts/components/helpers/hasCreateEditPermissions.ts
@@ -1,0 +1,4 @@
+import { Permission } from "../../utils/window";
+
+export const hasCreateEditPermissions = (permissions: Permission[]) => 
+    permissions.some(permission => permission.permission === "manage_rules" && permission.active === true)

--- a/apps/rule-manager/client/src/ts/components/layout/Header.tsx
+++ b/apps/rule-manager/client/src/ts/components/layout/Header.tsx
@@ -39,7 +39,7 @@ export const Header = () => {
 
   const ProfileMenuButton = (
     <UserActionMenu onClick={toggleProfileMenu}>
-      {pageData?.user.firstName} {pageData?.user.lastName} &nbsp;
+      {pageData.user?.firstName} {pageData.user?.lastName} &nbsp;
       <DownChevron />
     </UserActionMenu>
   );

--- a/apps/rule-manager/client/src/ts/components/layout/Header.tsx
+++ b/apps/rule-manager/client/src/ts/components/layout/Header.tsx
@@ -39,7 +39,7 @@ export const Header = () => {
 
   const ProfileMenuButton = (
     <UserActionMenu onClick={toggleProfileMenu}>
-      {pageData?.firstName} {pageData?.lastName} &nbsp;
+      {pageData?.user.firstName} {pageData?.user.lastName} &nbsp;
       <DownChevron />
     </UserActionMenu>
   );

--- a/apps/rule-manager/client/src/ts/utils/window.tsx
+++ b/apps/rule-manager/client/src/ts/utils/window.tsx
@@ -1,10 +1,18 @@
 import React, { createContext } from "react";
 
+export type Permission = {
+  permission: string,
+  active: boolean
+}
+
 type PageData = {
-  firstName: string;
-  lastName: string;
-  email: string;
-  avatarUrl: string;
+  user: {
+    firstName: string;
+    lastName: string;
+    email: string;
+    avatarUrl: string;
+  },
+  permissions: Permission[]
 };
 
 const getPageData = (): PageData | undefined => {

--- a/apps/rule-manager/client/src/ts/utils/window.tsx
+++ b/apps/rule-manager/client/src/ts/utils/window.tsx
@@ -6,7 +6,7 @@ export type Permission = {
 }
 
 type PageData = {
-  user: {
+  user?: {
     firstName: string;
     lastName: string;
     email: string;
@@ -15,13 +15,13 @@ type PageData = {
   permissions: Permission[]
 };
 
-const getPageData = (): PageData | undefined => {
+const getPageData = (): PageData => {
   const scriptId = "data";
   const pageData = document.getElementById(scriptId);
   return JSON.parse(pageData?.innerHTML!);
 };
 
-export const PageContext = createContext<PageData | undefined>(undefined);
+export const PageContext = createContext<PageData>({permissions: []});
 
 export const PageDataProvider: React.FC = ({ children }) => {
   const pageData = getPageData();


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

1. Check for create and edit permissions on the backend before accepting a users request.
2. Only allow users to request rule creation or edit changes on the frontend if they have correct permissions.

![Kapture 2023-05-15 at 10 56 40](https://github.com/guardian/typerighter/assets/34686302/eff6ad60-fc3a-4dd4-89ef-e6399e052216)

## How to test

1. Run Typerighter locally according to the instructions in the readme.
2. Visit [manager.typerighter.local.dev-gutools.co.uk](https://manager.typerighter.local.dev-gutools.co.uk/)
3. Make sure you have 'Manage rules' Typerighter permissions [on permissions CODE](https://permissions.code.dev-gutools.co.uk/admin/user/111318226344948727644). Wait a minute for them to apply. Can you create and edit rules in the Typerighter manager locally?
4. Remove the permissions and wait a minute or so for the changes to persist. Can you no longer create and edit rules locally in Typerighter manager?