### PR TITLE
Correct evolution comment

### DIFF
--- a/apps/rule-manager/conf/evolutions/default/5.sql
+++ b/apps/rule-manager/conf/evolutions/default/5.sql
@@ -1,6 +1,6 @@
 -- !Ups
 
--- Add live rules table, dropping rules marked as ignore
+-- Add live rules table
 CREATE TABLE rules_live (LIKE rules INCLUDING DEFAULTS);
 
 ALTER TABLE rules_live


### PR DESCRIPTION
The dropping of the 'ignore' column no longer occurs in the evolution. Instead this happens on import.

This could be a problem if (a) we apply this evolution in PROD, (b) a user edits a rule, then (c) a user publishes the rule artefact - without the user importing at any point. This would publish an artefact with rules designed to be ignored. 

However this scenario is highly unlikely - the update form postdates this PR, the ability to publish updated rules has yet to be released!