### PR TITLE
Add published status to rules table

### DIFF
--- a/apps/rule-manager/app/db/DB.scala
+++ b/apps/rule-manager/app/db/DB.scala
@@ -1,6 +1,5 @@
 package db
 
-import scalikejdbc.ConnectionPool.close
 import scalikejdbc._
 
 class DB(url: String, user: String, password: String) {
@@ -19,5 +18,5 @@ class DB(url: String, user: String, password: String) {
     dbString == "HELLO WORLD"
   }
 
-  def closeAll = close(ConnectionPool)
+  def closeAll = ConnectionPool.closeAll()
 }

--- a/apps/rule-manager/app/db/DB.scala
+++ b/apps/rule-manager/app/db/DB.scala
@@ -1,5 +1,6 @@
 package db
 
+import scalikejdbc.ConnectionPool.close
 import scalikejdbc._
 
 class DB(url: String, user: String, password: String) {
@@ -18,5 +19,5 @@ class DB(url: String, user: String, password: String) {
     dbString == "HELLO WORLD"
   }
 
-  def closeAll = ConnectionPool.closeAll()
+  def closeAll = close(ConnectionPool)
 }

--- a/apps/rule-manager/app/db/DbRuleDraft.scala
+++ b/apps/rule-manager/app/db/DbRuleDraft.scala
@@ -161,7 +161,8 @@ object DbRuleDraft extends SQLSyntaxSupport[DbRuleDraft] {
         SELECT
              ${rd.*}, ${rl.externalId} IS NOT NULL AS is_published
         FROM
-            ${DbRuleDraft as rd} LEFT JOIN ${DbRuleLive as rl} ON ${rd.externalId} = ${rl.externalId}
+            ${DbRuleDraft as rd}
+        LEFT JOIN ${DbRuleLive as rl} ON ${rd.externalId} = ${rl.externalId} AND ${rl.isActive} = true
         ORDER BY ${rd.id}
        """
       .map(DbRuleDraft.fromRow)

--- a/apps/rule-manager/app/db/DbRuleDraft.scala
+++ b/apps/rule-manager/app/db/DbRuleDraft.scala
@@ -144,7 +144,10 @@ object DbRuleDraft extends SQLSyntaxSupport[DbRuleDraft] {
         SELECT
              ${rd.*}, ${rl.externalId} IS NOT NULL AS is_published
         FROM
-            ${DbRuleDraft as rd} LEFT JOIN ${DbRuleLive as rl} ON ${rd.externalId} = ${rl.externalId}
+            ${DbRuleDraft as rd}
+        LEFT JOIN ${DbRuleLive as rl}
+            ON ${rd.externalId} = ${rl.externalId}
+            AND ${rl.isActive} = TRUE
         WHERE
             ${rd.id} = $id
        """
@@ -159,6 +162,7 @@ object DbRuleDraft extends SQLSyntaxSupport[DbRuleDraft] {
              ${rd.*}, ${rl.externalId} IS NOT NULL AS is_published
         FROM
             ${DbRuleDraft as rd} LEFT JOIN ${DbRuleLive as rl} ON ${rd.externalId} = ${rl.externalId}
+        ORDER BY ${rd.id}
        """
       .map(DbRuleDraft.fromRow)
       .list()

--- a/apps/rule-manager/app/service/RuleManager.scala
+++ b/apps/rule-manager/app/service/RuleManager.scala
@@ -206,7 +206,8 @@ object RuleManager extends Loggable {
     val persistedRules = getDraftRules()
 
     val persistedRulesToCompare = persistedRules.map(_.copy(id = None))
-    val incomingRulesToCompare = incomingRules.map(_.copy(id = None))
+    val incomingRulesToCompare =
+      incomingRules.map(rule => rule.copy(id = None, isPublished = !rule.ignore))
 
     if (persistedRulesToCompare == incomingRulesToCompare) {
       publishLiveRules(bucketRuleResource)

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -60,10 +60,6 @@ const createColumns = (editRule: (ruleId: number) => void): Array<EuiBasicTableC
       name: 'Type',
     },
     {
-      field: 'externalId',
-      name: 'ID'
-    },
-    {
       field: 'category',
       name: 'Category',
     },
@@ -78,6 +74,11 @@ const createColumns = (editRule: (ruleId: number) => void): Array<EuiBasicTableC
     {
       field: 'description',
       name: 'Description'
+    },
+    {
+      field: 'isPublished',
+      name: 'Status',
+      render: value =>  value ? "Live" : "Draft"
     },
     {
       name: <EuiIcon type="pencil"/>,

--- a/apps/rule-manager/client/src/ts/components/hooks/useRules.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRules.ts
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
+import {Rule} from "../RulesTable";
 
 export function useRules() {
     const { location } = window;
-    const [rules, setRules] = useState(null);
+    const [rules, setRules] = useState<Rule[] | null>(null);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState(null);
     const [isRefreshing, setIsRefreshing] = useState(false);

--- a/apps/rule-manager/test/db/DraftRulesSpec.scala
+++ b/apps/rule-manager/test/db/DraftRulesSpec.scala
@@ -38,7 +38,7 @@ class DraftRulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback 
 
   it should "find all records and return published status" in { implicit session =>
     val toBePublished = DbRuleDraft
-      .create(ruleType = "regex", pattern = Some("MyString"), user = "test.user", ignore = false)
+      .create(ruleType = "regex", pattern = Some("2"), user = "test.user", ignore = false)
       .get
     DbRuleLive.create(toBePublished.toLive("reason"), "user")
 

--- a/apps/rule-manager/test/db/RuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/RuleManagerSpec.scala
@@ -208,7 +208,9 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
 
       RuleManager.destructivelyPublishRules(allRules, bucketRuleResource)
 
-      DbRuleDraft.findAll() shouldMatchTo allRules
+      DbRuleDraft.findAll() shouldMatchTo allRules.map(rule =>
+        rule.copy(isPublished = !rule.ignore)
+      )
       DbRuleLive.findAll() shouldMatchTo unignoredRules.map(
         _.toLive("Imported from Google Sheet").copy(isActive = true)
       )

--- a/apps/rule-manager/test/db/RuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/RuleManagerSpec.scala
@@ -287,7 +287,7 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
     }
   }
 
-  "getRuleAndRevisions" should "return the current draft rule" in { () =>
+  "getAllRuleData" should "return the current draft rule" in { () =>
     val ruleToPublish = createPublishableRule
 
     RuleManager.getAllRuleData(ruleToPublish.id.get) match {
@@ -298,7 +298,7 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
     }
   }
 
-  "getRuleAndRevisions" should "return the current draft rule, the live rule if it exists, and the publication history" in {
+  "getAllRuleData" should "return the current draft rule, the live rule if it exists, and the publication history" in {
     () =>
       val ruleToPublish = createPublishableRule
 


### PR DESCRIPTION
## What does this change?

Adds a 'status' column to the rule table, showing the publication status of a rule. (It'll also, eventually, show archived status.)

The UUID column is removed to make room for it, which satisfies the user story `I want to not have to worry about secondary rule information (ie. ID)`. You can still search by UUID.

<img width="842" alt="Screenshot 2023-06-07 at 08 59 40" src="https://github.com/guardian/typerighter/assets/7767575/ecb40823-e959-4353-a740-f11580ac4f48">

@Fweddi if this has a painful overlap with your 'archived' feature, let's chat, it might be simpler for me to rebase this on top of your work!

## How to test

- The automated tests should pass, and give us some confidence the query is correct.
- Load rules from the sheet into the management system with 'refresh rules'. They should all be live.
- Create a new new rule. It should be marked draft.
- Publish the rule, following the instructions in #324. It should now be marked live. 