### PR TITLE
Fix migration

### DIFF
--- a/apps/rule-manager/conf/evolutions/default/7.sql
+++ b/apps/rule-manager/conf/evolutions/default/7.sql
@@ -2,7 +2,7 @@
 
 ALTER TABLE rules_live
   DROP COLUMN id, -- We no longer use id as a primary key, so it's no longer necessary
-  ADD COLUMN rule_order INT NOT NULL,
+  ADD COLUMN rule_order SERIAL,
   ADD COLUMN is_active BOOLEAN NOT NULL DEFAULT FALSE;
 
 CREATE UNIQUE INDEX rules_live_is_active ON rules_live (external_id, is_active) where is_active = true;
@@ -10,6 +10,9 @@ CREATE UNIQUE INDEX rules_live_unique_order ON rules_live (rule_order, is_active
 CREATE UNIQUE INDEX rules_live_composite_pkey ON rules_live (external_id, revision_id);
 
 DROP INDEX rules_live_external_id_index;
+ALTER TABLE rules_live
+  ALTER COLUMN rule_order DROP DEFAULT;
+DROP SEQUENCE rules_live_rule_order_seq;
 
 -- !Downs
 


### PR DESCRIPTION
## What does this change?

Fixes a bad migration by providing a DEFAULT value for `rule_order`.

The order of rules as they currently exist in the live table is somewhat ad-hoc – it's derived from the pk of the draft rules, because the order in which rules are inserted matches their order in the spreadsheet.

Adding a `SERIAL` column replicates this order in the live table. We then remove the sequence to ensure that `rule_order` is specified explicitly.

## How to test

Deploy to CODE. The deploy should be successful, indicating the migration succeeded. Inspecting the DB should show the rules are correctly ordered.

- [x] Deployed to CODE
- [x] Manually resolved in PROD