### PR TITLE
Add API routes to manage tags

### DIFF
--- a/apps/checker/app/AppComponents.scala
+++ b/apps/checker/app/AppComponents.scala
@@ -15,7 +15,7 @@ import controllers.{
   AuditController,
   CapiProxyController,
   HomeController,
-  RulesController,
+  RulesController
 }
 import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext

--- a/apps/checker/app/AppComponents.scala
+++ b/apps/checker/app/AppComponents.scala
@@ -15,7 +15,7 @@ import controllers.{
   AuditController,
   CapiProxyController,
   HomeController,
-  RulesController
+  RulesController,
 }
 import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext
@@ -135,7 +135,6 @@ class AppComponents(
     publicSettings,
     ruleManagerUrl
   )
-  val tagsController = new TagsController()
   val homeController = new HomeController(controllerComponents, matcherPool, publicSettings)
   val auditController = new AuditController(controllerComponents, publicSettings)
   val capiProxyController =

--- a/apps/checker/app/AppComponents.scala
+++ b/apps/checker/app/AppComponents.scala
@@ -135,6 +135,7 @@ class AppComponents(
     publicSettings,
     ruleManagerUrl
   )
+  val tagsController = new TagsController()
   val homeController = new HomeController(controllerComponents, matcherPool, publicSettings)
   val auditController = new AuditController(controllerComponents, publicSettings)
   val capiProxyController =

--- a/apps/rule-manager/app/AppComponents.scala
+++ b/apps/rule-manager/app/AppComponents.scala
@@ -2,7 +2,7 @@ import play.api.ApplicationLoader.Context
 import play.filters.HttpFiltersComponents
 import play.api.BuiltInComponentsFromContext
 import play.api.libs.ws.ahc.AhcWSComponents
-import controllers.{AssetsComponents, HomeController, RulesController}
+import controllers.{AssetsComponents, HomeController, RulesController, TagsController}
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.gu.pandomainauth.{PanDomainAuthSettingsRefresher, PublicSettings}
@@ -98,10 +98,17 @@ class AppComponents(
     config
   )
 
+  val tagsController = new TagsController(
+    controllerComponents,
+    publicSettings,
+    config
+  )
+
   lazy val router = new Routes(
     httpErrorHandler,
     homeController,
     rulesController,
+    tagsController,
     assets
   )
 }

--- a/apps/rule-manager/app/controllers/TagsController.scala
+++ b/apps/rule-manager/app/controllers/TagsController.scala
@@ -13,13 +13,13 @@ import db.Tags
 import db.Tags.format
 
 class TagsController(
-  cc: ControllerComponents,
-  val publicSettings: PublicSettings,
-  override val config: RuleManagerConfig
+    cc: ControllerComponents,
+    val publicSettings: PublicSettings,
+    override val config: RuleManagerConfig
 ) extends AbstractController(cc)
-  with PandaAuthentication
-  with PermissionsHandler
-  with FormHelpers {
+    with PandaAuthentication
+    with PermissionsHandler
+    with FormHelpers {
 
   def list = ApiAuthAction {
     Ok(Json.toJson(Tags.findAll()))
@@ -56,7 +56,7 @@ class TagsController(
               },
               formRule => {
                 Tags.createFromTagForm(formRule) match {
-                  case Success(tag)  => Ok(Json.toJson(tag))
+                  case Success(tag)   => Ok(Json.toJson(tag))
                   case Failure(error) => InternalServerError(error.getMessage())
                 }
               }
@@ -78,7 +78,7 @@ class TagsController(
             },
             tagForm => {
               Tags.updateFromTagForm(id, tagForm) match {
-                case Left(result) => result
+                case Left(result)  => result
                 case Right(dbRule) => Ok(Json.toJson(dbRule))
               }
             }

--- a/apps/rule-manager/app/controllers/TagsController.scala
+++ b/apps/rule-manager/app/controllers/TagsController.scala
@@ -80,6 +80,7 @@ class TagsController(
               Tags.updateFromTagForm(id, tagForm) match {
                 case Left(NotFoundException(message)) => NotFound(message)
                 case Left(DbException(message))       => InternalServerError(message)
+                case Left(e: Exception)               => InternalServerError(e.getMessage)
                 case Right(tag)                       => Ok(Json.toJson(tag))
               }
             }

--- a/apps/rule-manager/app/controllers/TagsController.scala
+++ b/apps/rule-manager/app/controllers/TagsController.scala
@@ -1,0 +1,57 @@
+package controllers
+
+import com.gu.pandomainauth.PublicSettings
+import com.gu.permissions.PermissionDefinition
+import com.gu.typerighter.lib.PandaAuthentication
+import model.CreateTagForm
+import play.api.libs.json.Json
+import play.api.mvc._
+import utils.{FormHelpers, PermissionsHandler, RuleManagerConfig}
+
+import scala.util.{Failure, Success}
+import db.Tags
+import db.Tags.format
+
+class TagsController(
+  cc: ControllerComponents,
+  val publicSettings: PublicSettings,
+  override val config: RuleManagerConfig
+) extends AbstractController(cc)
+  with PandaAuthentication
+  with PermissionsHandler
+  with FormHelpers {
+
+  def list = ApiAuthAction {
+    Ok(Json.toJson(Tags.findAll()))
+  }
+
+  def get(id: Int) = ApiAuthAction {
+    Tags.find(id) match {
+      case None => NotFound("Tag not found matching ID")
+      case Some(tag) =>
+        Ok(Json.toJson(tag))
+    }
+  }
+  def create = ApiAuthAction { implicit request =>
+    {
+      hasPermission(request.user, PermissionDefinition("manage_rules", "typerighter")) match {
+        case false => Unauthorized("You don't have permission to create tags")
+        case true =>
+          CreateTagForm.form
+            .bindFromRequest()
+            .fold(
+              formWithErrors => {
+                val errors = formWithErrors.errors
+                BadRequest(Json.toJson(errors))
+              },
+              formRule => {
+                Tags.createFromTagForm(formRule) match {
+                  case Success(tag)  => Ok(Json.toJson(tag))
+                  case Failure(error) => InternalServerError(error.getMessage())
+                }
+              }
+            )
+      }
+    }
+  }
+}

--- a/apps/rule-manager/app/controllers/TagsController.scala
+++ b/apps/rule-manager/app/controllers/TagsController.scala
@@ -3,10 +3,10 @@ package controllers
 import com.gu.pandomainauth.PublicSettings
 import com.gu.permissions.PermissionDefinition
 import com.gu.typerighter.lib.PandaAuthentication
-import model.{TagForm}
+import model.TagForm
 import play.api.libs.json.Json
 import play.api.mvc._
-import utils.{FormHelpers, PermissionsHandler, RuleManagerConfig}
+import utils.{DbException, FormHelpers, NotFoundException, PermissionsHandler, RuleManagerConfig}
 
 import scala.util.{Failure, Success}
 import db.Tags
@@ -78,8 +78,9 @@ class TagsController(
             },
             tagForm => {
               Tags.updateFromTagForm(id, tagForm) match {
-                case Left(result)  => result
-                case Right(tag) => Ok(Json.toJson(tag))
+                case Left(NotFoundException(message)) => NotFound(message)
+                case Left(DbException(message))       => InternalServerError(message)
+                case Right(tag)                       => Ok(Json.toJson(tag))
               }
             }
           )

--- a/apps/rule-manager/app/controllers/TagsController.scala
+++ b/apps/rule-manager/app/controllers/TagsController.scala
@@ -79,7 +79,7 @@ class TagsController(
             tagForm => {
               Tags.updateFromTagForm(id, tagForm) match {
                 case Left(result)  => result
-                case Right(dbRule) => Ok(Json.toJson(dbRule))
+                case Right(tag) => Ok(Json.toJson(tag))
               }
             }
           )

--- a/apps/rule-manager/app/db/Tags.scala
+++ b/apps/rule-manager/app/db/Tags.scala
@@ -1,4 +1,6 @@
 package db
+import model.{CreateTagForm}
+import play.api.libs.json.{Format, Json}
 import scalikejdbc._
 
 import scala.util.Try
@@ -9,6 +11,8 @@ case class Tag(
     name: String
 )
 object Tags extends SQLSyntaxSupport[Tag] {
+  implicit val format: Format[Tag] = Json.format[Tag]
+
   override val tableName = "tags"
 
   override val columns = Seq("id", "name")
@@ -72,6 +76,14 @@ object Tags extends SQLSyntaxSupport[Tag] {
           )
         )
     }
+  }
+
+  def createFromTagForm(tagForm: CreateTagForm)(implicit
+      session: DBSession = autoSession
+  ) = {
+    Tags.create(
+      name = tagForm.name
+    )
   }
 
   def batchInsert(

--- a/apps/rule-manager/app/db/Tags.scala
+++ b/apps/rule-manager/app/db/Tags.scala
@@ -90,7 +90,8 @@ object Tags extends SQLSyntaxSupport[Tag] {
   def updateFromTagForm(id: Int, tagForm: TagForm)(implicit
       session: DBSession = autoSession
   ) = {
-    val tag = Tags.find(id)
+    val tag = Tags
+      .find(id)
       .toRight(NotFound("Rule not found matching ID"))
       .map(existingRule =>
         existingRule.copy(
@@ -101,7 +102,7 @@ object Tags extends SQLSyntaxSupport[Tag] {
       case Right(tag) => {
         Tags.save(tag).toEither match {
           case Left(e: Throwable) => Left(InternalServerError(e.getMessage))
-          case Right(dbRule) => Right(dbRule)
+          case Right(dbRule)      => Right(dbRule)
         }
       }
       case Left(result) => Left(result)

--- a/apps/rule-manager/app/db/Tags.scala
+++ b/apps/rule-manager/app/db/Tags.scala
@@ -89,7 +89,7 @@ object Tags extends SQLSyntaxSupport[Tag] {
 
   def updateFromTagForm(id: Int, tagForm: TagForm)(implicit
       session: DBSession = autoSession
-  ) = {
+  ): Either[Exception, Tag] = {
     val tag = Tags
       .find(id)
       .toRight(NotFoundException("Rule not found matching ID"))
@@ -101,8 +101,8 @@ object Tags extends SQLSyntaxSupport[Tag] {
     tag match {
       case Right(tag) => {
         Tags.save(tag) match {
-          case Left(e: Exception) => Left(e: Exception)
-          case Right(dbRule)      => Right(dbRule)
+          case Left(e)       => Left(e)
+          case Right(dbRule) => Right(dbRule)
         }
       }
       case Left(result) => Left(result)
@@ -124,7 +124,9 @@ object Tags extends SQLSyntaxSupport[Tag] {
     )""").batchByName(params.toSeq: _*).apply[List]()
   }
 
-  def save(entity: Tag)(implicit session: DBSession = autoSession): Either[DbException, Tag] = {
+  def save(
+      entity: Tag
+  )(implicit session: DBSession = autoSession): Either[Exception, Tag] = {
     withSQL {
       update(Tags)
         .set(

--- a/apps/rule-manager/app/model/CreateTagForm.scala
+++ b/apps/rule-manager/app/model/CreateTagForm.scala
@@ -3,13 +3,13 @@ package model
 import play.api.data.Form
 import play.api.data.Forms.{mapping, nonEmptyText}
 
-object CreateTagForm {
+object TagForm {
   val form = Form(
     mapping(
       "name" -> nonEmptyText()
-    )(CreateTagForm.apply)(CreateTagForm.unapply)
+    )(TagForm.apply)(TagForm.unapply)
   )
 }
-case class CreateTagForm(
+case class TagForm(
     name: String
 )

--- a/apps/rule-manager/app/model/CreateTagForm.scala
+++ b/apps/rule-manager/app/model/CreateTagForm.scala
@@ -1,0 +1,15 @@
+package model
+
+import play.api.data.Form
+import play.api.data.Forms.{mapping, nonEmptyText}
+
+object CreateTagForm {
+  val form = Form(
+    mapping(
+      "name" -> nonEmptyText()
+    )(CreateTagForm.apply)(CreateTagForm.unapply)
+  )
+}
+case class CreateTagForm(
+    name: String
+)

--- a/apps/rule-manager/app/utils/Errors.scala
+++ b/apps/rule-manager/app/utils/Errors.scala
@@ -1,0 +1,4 @@
+package utils
+
+case class NotFoundException(message: String) extends Exception(message)
+case class DbException(message: String) extends Exception(message)

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -30,6 +30,10 @@ GET     /tags                       controllers.TagsController.list()
 POST    /tags                       controllers.TagsController.create()
 +nocsrf
 GET     /tags/:id                   controllers.TagsController.get(id: Int)
++nocsrf
+POST    /tags/:id                   controllers.TagsController.update(id: Int)
++nocsrf
+DELETE  /tags/:id                   controllers.TagsController.delete(id: Int)
 
 # Map static resources from the /public folder to the correct URL path
 GET     /*file                      controllers.Assets.versioned(path="/public/", file: Asset)

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -23,5 +23,13 @@ POST    /rules/:id                  controllers.RulesController.update(id: Int)
 +nocsrf
 POST    /rules/:id/publish          controllers.RulesController.publish(id: Int)
 
+# Tags
++nocsrf
+GET     /tags                       controllers.TagsController.list()
++nocsrf
+POST    /tags                       controllers.TagsController.create()
++nocsrf
+GET     /tags/:id                   controllers.TagsController.get(id: Int)
+
 # Map static resources from the /public folder to the correct URL path
 GET     /*file                      controllers.Assets.versioned(path="/public/", file: Asset)

--- a/apps/rule-manager/test/db/TagsSpec.scala
+++ b/apps/rule-manager/test/db/TagsSpec.scala
@@ -52,7 +52,7 @@ class TagsSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback with D
   it should "save a record, updating the modified fields" in { implicit session =>
     val entity = Tags.findAll().head
     val modified = entity.copy(name = "bar")
-    val updated = Tags.save(modified).get
+    val updated = Tags.save(modified).getOrElse(null)
     updated.name should equal("bar")
   }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds the following API routes for managing Tags:
- `GET     /tags`
- `POST    /tags`
- `GET     /tags/:id`
- `POST    /tags/:id`
- `DELETE  /tags/:id`

Following PRs will support managing the relationships between rules and tags.

## How to test

Run the rule manager locally (`.script/start`) and hit the above endpoints, e.g. https://manager.typerighter.local.dev-gutools.co.uk/tags

Can you:
- Retrieve the list of tags
- Add a new tag
- Get a specific tag by id
- Modify a tag's `name`
- Delete a tag by id