### PR TITLE
Add reason when republishing rule via modal

### DIFF
--- a/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
@@ -75,14 +75,14 @@ export function useRule(ruleId: number | undefined) {
     setIsLoading(false);
   }
 
-  const publishRule = async (ruleId: number) => {
+  const publishRule = async (ruleId: number, reason: string) => {
     setIsPublishing(true);
 
     try {
       const response = await fetch(`${location}rules/${ruleId}/publish`, {
         method: "POST",
         headers: [["Content-Type", "application/json"]],
-        body: JSON.stringify({ reason: "Placeholder reason" })
+        body: JSON.stringify({ reason })
       });
       if (!response.ok) {
         throw new Error(`Failed to publish rules: ${response.status} ${response.statusText}`);

--- a/apps/rule-manager/client/src/ts/components/modals/Reason.tsx
+++ b/apps/rule-manager/client/src/ts/components/modals/Reason.tsx
@@ -1,0 +1,71 @@
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFieldText,
+  EuiForm,
+  EuiFormRow,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+  EuiText,
+} from "@elastic/eui";
+import { Label } from "../Label";
+import { FormEventHandler, useState } from "react";
+
+const modalFormId = "modal-form";
+
+export const ReasonModal = ({
+                              onClose,
+                              onSubmit,
+                              isLoading
+                            }: {
+  onClose: () => void;
+  onSubmit: (reason: string) => void;
+  isLoading: boolean;
+}) => {
+  const [reason, setReason] = useState<string>("");
+  const handleSubmit: FormEventHandler<HTMLFormElement> = e => {
+    e.preventDefault();
+    onSubmit(reason);
+  }
+
+  return (
+    <EuiModal onClose={onClose} initialFocus="[name=popswitch]">
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>Republish rule</EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <EuiForm id={modalFormId} component="form" onSubmit={handleSubmit}>
+          <EuiText>Why is this rule being revised? This helps us understand the rule's publication history.</EuiText>
+          <EuiSpacer />
+          <EuiFormRow
+            label={<Label text="Reason" required={true} />}
+            isInvalid={!reason}
+          >
+            <EuiFieldText
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              required={true}
+              isInvalid={!reason}
+            />
+          </EuiFormRow>
+        </EuiForm>
+      </EuiModalBody>
+
+      <EuiModalFooter>
+        <EuiButtonEmpty onClick={onClose}>Cancel</EuiButtonEmpty>
+        <EuiButton
+          type="submit"
+          form={modalFormId}
+          fill
+          isLoading={isLoading}
+        >
+          Publish
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};


### PR DESCRIPTION
## What does this change?

Adds a modal asking the user to provide a reason when republishing a rule. The reason appears in the rule history.

It's mandatory at present. Too much?

![add-reason](https://github.com/guardian/typerighter/assets/7767575/f0c68528-ecd3-43ca-8e7e-c5371fe01f9d)

## How to test

Go through the workflow shown in the GIF. Does everything work as expected?