### PR TITLE
Add checkboxes to select multiple rules

### DIFF
--- a/apps/rule-manager/client/src/ts/components/RuleHistory.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleHistory.tsx
@@ -63,7 +63,7 @@ export const RuleHistory = ({ruleHistory}: { ruleHistory: RuleData['history'] })
       {!sortedHistory.length && "This rule has not yet been published."}
       {sortedHistory.map((rule, index) => {
         const isFirstPublished = index === (sortedHistory.length - 1)
-        return <Event>
+        return <Event key={rule.revisionId}>
           <EventTimeline isFirstPublished={isFirstPublished}>
             <EventTimelinePersonContainer>
               {rule.updatedBy.includes("Google Sheet") ? <SheetIcon/> : <Person/>}

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -1,4 +1,4 @@
-import React, {useContext, useMemo, useState} from 'react';
+import React, {useContext, useEffect, useMemo, useState} from 'react';
 import {
   EuiSearchBarProps,
   EuiBasicTableColumn,
@@ -143,9 +143,11 @@ const RulesTable = () => {
 
   const columns = createColumns(openEditRulePanel);
 
-  const [selectedItems, setSelectedItems] = useState<Rule[]>([]);
-  const onSelectionChange = (selectedItems: Rule[]) => {
-    setSelectedItems(selectedItems);
+  const [selectedRules, setSelectedRules] = useState<Rule[]>([]);
+
+  const onSelectionChange = (selectedRules: Rule[]) => {
+    setSelectedRules(selectedRules);
+    openEditRulePanel(Number(selectedRules[0]?.id));
   }
 
   const selection: EuiTableSelectionType<Rule> = {
@@ -154,6 +156,12 @@ const RulesTable = () => {
     onSelectionChange,
     initialSelected: [],
   }
+
+  useEffect(() => {
+    if (selectedRules.length === 0) {
+        setFormMode('closed')
+    }
+  }, [selectedRules])
 
   return <>
     <EuiFlexGroup>

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -11,7 +11,8 @@ import {
   EuiButtonIcon,
   EuiFlexGrid,
   EuiIcon,
-  EuiToolTip, EuiSpacer
+  EuiToolTip, EuiSpacer,
+  EuiTableSelectionType
 } from '@elastic/eui';
 import {useRules} from "./hooks/useRules";
 import {css} from "@emotion/react";
@@ -142,6 +143,18 @@ const RulesTable = () => {
 
   const columns = createColumns(openEditRulePanel);
 
+  const [selectedItems, setSelectedItems] = useState<Rule[]>([]);
+  const onSelectionChange = (selectedItems: Rule[]) => {
+    setSelectedItems(selectedItems);
+  }
+
+  const selection: EuiTableSelectionType<Rule> = {
+    selectable: () => hasCreatePermissions,
+    selectableMessage: (selectable, rule) => !selectable ? "You don't have edit permissions" : '',
+    onSelectionChange,
+    initialSelected: [],
+  }
+
   return <>
     <EuiFlexGroup>
       <EuiFlexItem grow={false} css={css`padding-bottom: 20px;`}>
@@ -195,11 +208,14 @@ const RulesTable = () => {
           <EuiInMemoryTable
             tableCaption="Demo of EuiInMemoryTable"
             items={rules}
+            itemId="id"
             columns={columns}
             pagination={true}
             sorting={sorting}
             search={search}
             hasActions={true}
+            selection={selection}
+            isSelectable={true}
           />
         }
       </EuiFlexItem>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Add checkboxes to the rules table to enable users to select multiple rows in preparation for the batch editing feature to come. 

Clicking the header checkbox will select all the rows in the current page. Selecting one or multiple rows will bring up the edit form. If multiple rules are selected, the details of the first selected rule will show up. The form does not do anything in relation to batch editing for now but we'll bring the relevant changes in subsequent PRs.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
<img width="1215" alt="image" src="https://github.com/guardian/typerighter/assets/47318984/05a3ae5e-5342-437d-80f8-475ea547724e">

## How to test
Run this locally or on CODE and check that one more more rules can be selected. The edit form should show up upon selecting one or more rows.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

