### PR TITLE
Add permission to access permissions

### DIFF
--- a/cdk/lib/index.ts
+++ b/cdk/lib/index.ts
@@ -75,6 +75,11 @@ export class Typerighter extends GuStack {
       bucketName: "pan-domain-auth-settings",
     });
 
+    const permissionsFilePolicyStatement = new GuGetS3ObjectsPolicy(this, "PermissionsPolicy", {
+      bucketName: "permissions-cache",
+      paths: [`${this.stage}/*`]
+    });
+
     const lowercaseStage = this.stage.toLowerCase();
 
     const typerighterBucketName = `typerighter-app-${lowercaseStage}`;
@@ -103,7 +108,10 @@ export class Typerighter extends GuStack {
         noMonitoring: true,
       },
       roleConfiguration: {
-        additionalPolicies: [pandaAuthPolicy],
+        additionalPolicies: [
+          pandaAuthPolicy,
+          permissionsFilePolicyStatement
+        ],
       },
       scaling: {
         minimumInstances: props.instanceCount,


### PR DESCRIPTION
## What does this change?

#118 added permissions – but we're missing S3 access to fetch the permissions cache in CODE and PROD, [hence these logs.](https://logs.gutools.co.uk/s/editorial-tools/goto/627b41f0-0bc2-11ee-872e-07cde0a14815)

This PR adds access via the CDK.

## How to test

CODE should currently deny you permission to edit rules, regardless of whether they're set, as the box cannot load them. Deploy to CODE, granting yourself permission to add rules. You should be able to edit rules once the box refreshes its permissions – within a 1 minute window.

- [x] Tested in CODE