### PR TITLE
Batch edit rules (server-side)

### DIFF
--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -4,7 +4,7 @@ import com.gu.pandomainauth.PublicSettings
 import com.gu.permissions.PermissionDefinition
 import com.gu.typerighter.lib.PandaAuthentication
 import com.gu.typerighter.rules.BucketRuleResource
-import play.api.libs.json.Json
+import play.api.libs.json.{JsSuccess, JsValue, Json, Reads}
 import db.DbRuleDraft
 import model.{CreateRuleForm, PublishRuleForm, UpdateRuleForm}
 import play.api.mvc._
@@ -119,6 +119,76 @@ class RulesController(
               }
             }
           )
+    }
+  }
+
+  def batchUpdate() = ApiAuthAction { implicit request =>
+    hasPermission(request.user, PermissionDefinition("manage_rules", "typerighter")) match {
+      case false => Unauthorized("You don't have permission to edit rules")
+      case true =>
+        val jsonBody = request.body.asJson
+        jsonBody match {
+          case Some(json) =>
+            val validatedRequest = json.validate[BatchUpdateRequest]
+            validatedRequest.fold(
+              errors => {
+                val errorMessages = errors.flatMap { case (path, validationErrors) =>
+                  validationErrors.map(error => s"${path.toString}: ${error.message}")
+                }
+                BadRequest(
+                  Json.obj(
+                    "errors"
+                      -> errorMessages
+                  )
+                )
+              },
+              batchUpdateRequest => {
+                val ids = batchUpdateRequest.ids
+                val updatedRuleForm = UpdateRuleForm(
+                  category = batchUpdateRequest.fields.category,
+                  tags = batchUpdateRequest.fields.tags
+                )
+                val filledForm = UpdateRuleForm.form.fill(updatedRuleForm)
+
+                filledForm
+                  .fold(
+                    formWithErrors => {
+                      val errors = formWithErrors.errors
+                      BadRequest(Json.toJson(errors))
+                    },
+                    formRule => {
+                      DbRuleDraft.batchUpdateFromFormRule(formRule, ids, request.user.email) match {
+                        case Success(dbRules) => Ok(Json.toJson(dbRules))
+                        case Failure(error)   => InternalServerError(error.getMessage())
+                      }
+                    }
+                  )
+              }
+            )
+          case None => BadRequest("No JSON body found")
+        }
+    }
+  }
+
+  case class BatchUpdateRequest(ids: List[Int], fields: BatchUpdateFields)
+
+  case class BatchUpdateFields(category: Option[String], tags: Option[String])
+
+  object BatchUpdateRequest {
+    implicit val batchUpdateFieldsReads: Reads[BatchUpdateFields] = Reads { json =>
+      val category = (json \ "category").asOpt[String]
+      val tags = (json \ "tags").asOpt[String]
+
+      val batchUpdateFields = BatchUpdateFields(category, tags)
+
+      JsSuccess(batchUpdateFields)
+    }
+    implicit val batchUpdateRequestReads: Reads[BatchUpdateRequest] = Reads { json =>
+      val ids = (json \ "ids").as[List[Int]]
+      val fieldsJson = (json \ "fields").as[JsValue]
+      val fields = fieldsJson.asOpt[BatchUpdateFields].getOrElse(BatchUpdateFields(None, None))
+
+      JsSuccess(BatchUpdateRequest(ids, fields))
     }
   }
 }

--- a/apps/rule-manager/app/model/BatchUpdateRuleForm.scala
+++ b/apps/rule-manager/app/model/BatchUpdateRuleForm.scala
@@ -1,0 +1,20 @@
+package model
+
+import play.api.data._
+import play.api.data.Forms._
+
+object BatchUpdateRuleForm {
+  val form = Form(
+    mapping(
+      "ids" -> list(number),
+      "fields" -> mapping(
+        "category" -> text,
+        "tags" -> text
+      )(BatchUpdateFields.apply)(BatchUpdateFields.unapply)
+    )(BatchUpdateRuleForm.apply)(BatchUpdateRuleForm.unapply)
+  )
+}
+
+case class BatchUpdateRuleForm(ids: List[Int], fields:BatchUpdateFields)
+case class BatchUpdateFields(category: String, tags: String)
+

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -17,6 +17,8 @@ GET     /rules                      controllers.RulesController.list()
 +nocsrf
 POST    /rules                      controllers.RulesController.create()
 +nocsrf
+POST    /rules/batch                controllers.RulesController.batchUpdate()
++nocsrf
 GET     /rules/:id                  controllers.RulesController.get(id: Int)
 +nocsrf
 POST    /rules/:id                  controllers.RulesController.update(id: Int)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR introduces a new endpoint  `/rules/batch` for batch editing, and adds `batchUpdate` method to authenticate and validate (via `BatchUpdateRuleForm`) the request. Lastly `DbRuleDraft.batchUpdateFromFormRule()` updates the corresponding rules in the database. I have also added a test.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Run this locally (or on CODE but #342 would need to be merged to fix CODE permissions). Create multiple new rules and and send a POST request to  `/rules/batch` with their IDs and new categories and/or tags to update e.g.
```
{
 "ids":[800,801,802], 
 "fields": {
    "category": "Check this",
    "tags": "General,SG"
  }
}
```
Check that the relevant fields have been updated for these rules.
