### PR TITLE
Allow users to archive a rule

### DIFF
--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -121,4 +121,21 @@ class RulesController(
           )
     }
   }
+
+  def archive(id: Int): Action[AnyContent] = ApiAuthAction { implicit request =>
+    hasPermission(request.user, PermissionDefinition("manage_rules", "typerighter")) match {
+      case false => Unauthorized("You don't have permission to archive rules")
+      case true =>
+        RuleManager.archiveRule(id, request.user.email) match {
+          case Left(e: Throwable) => InternalServerError(e.getMessage)
+          case Right((draftRule, liveRule)) =>
+            Ok(
+              Json.obj(
+                "draft" -> Json.toJson(draftRule),
+                "live" -> Json.toJson(liveRule)
+              )
+            )
+        }
+    }
+  }
 }

--- a/apps/rule-manager/app/db/DbRuleLive.scala
+++ b/apps/rule-manager/app/db/DbRuleLive.scala
@@ -64,9 +64,21 @@ object DbRuleLive extends SQLSyntaxSupport[DbRuleLive] {
     }.map(DbRuleLive.fromResultName(r.resultName)).single().apply()
   }
 
+  def findLatestRevision(externalId: String)(implicit
+      session: DBSession = autoSession
+  ): Option[DbRuleLive] = {
+    withSQL {
+      select
+        .from(DbRuleLive as r)
+        .where
+        .eq(r.externalId, externalId)
+        .orderBy(r.revisionId.desc)
+    }.map(DbRuleLive.fromResultName(r.resultName)).single().apply()
+  }
+
   /** Find live rules by `externalId`. Because there may be many inactive live rules with the same
     * id, unlike the `find` method for draft rules, this method returns a list. To return a single
-    * rule, use `findRevision`.
+    * rule, use `findRevision` or `findLatestActiveRevision`.
     */
   def find(
       externalId: String
@@ -97,6 +109,25 @@ object DbRuleLive extends SQLSyntaxSupport[DbRuleLive] {
       .map(DbRuleLive.fromResultName(r.resultName))
       .list()
       .apply()
+  }
+
+  def setInactive(externalId: String, user: String)(implicit
+      session: DBSession = autoSession
+  ): Option[DbRuleLive] = {
+    withSQL {
+      update(DbRuleLive)
+        .set(
+          column.isActive -> false,
+          column.updatedBy -> user,
+          column.updatedAt -> OffsetDateTime.now
+        )
+        .where
+        .eq(column.externalId, externalId)
+        .and
+        .eq(column.isActive, true)
+    }.update().apply()
+
+    findLatestRevision(externalId)
   }
 
   /** Create a new live rule. This rule will supercede the previous active live rule.

--- a/apps/rule-manager/app/service/RuleManager.scala
+++ b/apps/rule-manager/app/service/RuleManager.scala
@@ -230,4 +230,31 @@ object RuleManager extends Loggable {
       )
     }
   }
+
+  def archiveRule(
+      id: Int,
+      user: String
+  ): Either[Exception, (Option[DbRuleDraft], Option[DbRuleLive])] = {
+    try {
+      val maybeDraftRule = DbRuleDraft.find(id)
+
+      val maybeUpdatedLiveRule = for {
+        draftRule <- maybeDraftRule
+        externalId <- draftRule.externalId
+        liveRule <- DbRuleLive.findLatestRevision(externalId)
+        if liveRule.isActive
+        updatedLiveRule <- DbRuleLive.setInactive(externalId, user)
+      } yield updatedLiveRule
+
+      val maybeUpdatedDraftRule = for {
+        draftRule <- maybeDraftRule
+        archivedDraftRule = draftRule.copy(isArchived = true)
+        updatedDraftRule <- DbRuleDraft.save(archivedDraftRule, user).toOption
+      } yield updatedDraftRule
+
+      Right(maybeUpdatedDraftRule, maybeUpdatedLiveRule)
+    } catch {
+      case e: Exception => Left(e)
+    }
+  }
 }

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -15,6 +15,7 @@ import { updateRule } from "./api/updateRule";
 import {DraftRule, RuleType, useRule} from "./hooks/useRule";
 import {RuleHistory} from "./RuleHistory";
 import styled from "@emotion/styled";
+import {archiveRule} from "./api/archiveRule";
 
 export type PartiallyUpdateRuleData = (partialReplacement: Partial<DraftRule>) => void;
 
@@ -97,23 +98,46 @@ export const RuleForm = ({ruleId, onClose}: {
             })
     }
 
+    const archiveRuleHandler = () => {
+        if(formErrors.length > 0) {
+            setShowErrors(true);
+            return;
+        }
+
+        archiveRule(ruleFormData.id)
+            .then(data => {
+                if (data.status === 'ok'){
+                    setRuleFormData(baseForm);
+                    onClose();
+                } else {
+                    setFormErrors([...formErrors, {id: `${data.status} error`, value: `${data.errorMessage} - try again or contact the Editorial Tools team.`}])
+                }
+            })
+    }
+
     return <EuiForm component="form">
         {isLoading && <SpinnerOverlay><SpinnerOuter><SpinnerContainer><EuiLoadingSpinner /></SpinnerContainer></SpinnerOuter></SpinnerOverlay>}
         {<EuiFlexGroup  direction="column">
             <RuleContent ruleData={ruleFormData} partiallyUpdateRuleData={partiallyUpdateRuleData} errors={formErrors} showErrors={showErrors}/>
             <RuleMetadata ruleData={ruleFormData} partiallyUpdateRuleData={partiallyUpdateRuleData} />
             {rule && <RuleHistory ruleHistory={rule.live} />}
-            <EuiFlexGroup>
-                <EuiFlexItem>
+            <EuiFlexGroup gutterSize="m">
+                <EuiFlexItem grow={0}>
                     <EuiButton onClick={() => {
                         onClose();
                         setRuleFormData(baseForm);
                     }}>{ruleId ? "Discard Changes" : "Discard Rule"}</EuiButton>
                 </EuiFlexItem>
-                <EuiFlexItem>
+                <EuiFlexItem grow={0}>
                     <EuiButton fill={true} onClick={saveRuleHandler}>{ruleId ? "Update Rule" : "Save Rule"}</EuiButton>
                 </EuiFlexItem>
             </EuiFlexGroup>
+            {
+                !ruleFormData.isArchived ? <EuiFlexItem grow={0}>
+                    <EuiButton onClick={archiveRuleHandler} color={"danger"}>Archive Rule</EuiButton>
+                </EuiFlexItem> : null
+            }
+
             {showErrors ? <EuiCallOut title="Please resolve the following errors:" color="danger" iconType="error">
                 {formErrors.map((error, index) => <EuiText key={index}>{`${error.value}`}</EuiText>)}
             </EuiCallOut> : null}

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -11,7 +11,9 @@ import {
   EuiButtonIcon,
   EuiFlexGrid,
   EuiIcon,
-  EuiToolTip, EuiSpacer,
+  EuiToolTip,
+  EuiSpacer,
+  EuiHealth,
   EuiTableSelectionType
 } from '@elastic/eui';
 import {useRules} from "./hooks/useRules";
@@ -77,9 +79,18 @@ const createColumns = (editRule: (ruleId: number) => void): Array<EuiBasicTableC
       name: 'Description'
     },
     {
-      field: 'isPublished',
-      name: 'Status',
-      render: value =>  value ? "Live" : "Draft"
+      name: 'State',
+      render: rule =>  {
+        if(rule.isPublished) {
+          return <><EuiHealth color="success"/>Live</>;
+        }
+
+        if(rule.isArchived) {
+          return <><EuiHealth color="danger"/>Archived</>;
+        }
+
+        return <><EuiHealth color="#DA8B45"/>Draft</>;
+      }
     },
     {
       name: <EuiIcon type="pencil"/>,
@@ -91,7 +102,7 @@ const createColumns = (editRule: (ruleId: number) => void): Array<EuiBasicTableC
         onClick: (rule) => {
           editRule(Number(rule.id))
         },
-        enabled: (item) => hasEditPermissions,
+        enabled: () => hasEditPermissions,
         'data-test-subj': 'action-edit',
       }]
     }

--- a/apps/rule-manager/client/src/ts/components/api/archiveRule.ts
+++ b/apps/rule-manager/client/src/ts/components/api/archiveRule.ts
@@ -1,0 +1,7 @@
+import { responseHandler } from "./parseResponse";
+
+export const archiveRule = async (ruleId: number) => (
+    fetch(`${location}rules/${ruleId}/archive`, {
+        method: 'POST',
+    }).then(responseHandler)
+);

--- a/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
@@ -17,8 +17,9 @@ export type BaseRule = {
   createdBy: string,
   createdAt: string,
   updatedBy: string,
-  updatedAt: string
-  id?: number
+  updatedAt: string,
+  id?: number,
+  isArchived: boolean
 }
 
 export type DraftRule = BaseRule

--- a/apps/rule-manager/client/src/ts/components/icons/index.ts
+++ b/apps/rule-manager/client/src/ts/components/icons/index.ts
@@ -18,6 +18,7 @@ import { icon as pencil } from "@elastic/eui/es/components/icon/assets/pencil";
 import { icon as returnKey } from "@elastic/eui/es/components/icon/assets/return_key";
 import { icon as warning } from "@elastic/eui/es/components/icon/assets/warning";
 import { icon as pageSelect } from "@elastic/eui/es/components/icon/assets/pageSelect";
+import { icon as dot } from "@elastic/eui/es/components/icon/assets/dot";
 
 type IconComponentNameType = ValuesType<typeof ICON_TYPES>;
 type IconComponentCacheType = Partial<Record<IconComponentNameType, unknown>>;
@@ -39,7 +40,8 @@ const cachedIcons: IconComponentCacheType = {
     pencil,
     returnKey,
     warning,
-    pageSelect
+    pageSelect,
+    dot
 };
 
 appendIconComponentCache(cachedIcons);

--- a/apps/rule-manager/conf/evolutions/default/10.sql
+++ b/apps/rule-manager/conf/evolutions/default/10.sql
@@ -1,0 +1,7 @@
+-- !Ups
+
+ALTER TABLE rules_draft ADD COLUMN is_archived BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- !Downs
+
+ALTER TABLE rules_draft DROP COLUMN is_archived;

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -22,6 +22,8 @@ GET     /rules/:id                  controllers.RulesController.get(id: Int)
 POST    /rules/:id                  controllers.RulesController.update(id: Int)
 +nocsrf
 POST    /rules/:id/publish          controllers.RulesController.publish(id: Int)
++nocsrf
+POST    /rules/:id/archive          controllers.RulesController.archive(id: Int)
 
 # Tags
 +nocsrf

--- a/apps/rule-manager/test/db/LiveRulesSpec.scala
+++ b/apps/rule-manager/test/db/LiveRulesSpec.scala
@@ -10,7 +10,7 @@ class LiveRulesSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback w
 
   override def fixture(implicit session: DBSession) = {
     sql"ALTER SEQUENCE rules_id_seq RESTART WITH 1".update().apply()
-    sql"insert into rules_live (rule_type, pattern, replacement, category, tags, description, notes, external_id, force_red_rule, advisory_rule, created_by, updated_by, rule_order) values (${"regex"}, ${"pattern"}, ${"replacement"}, ${"category"}, ${"someTags"}, ${"description"}, ${"notes"}, ${"googleSheetId"}, false, false, 'test.user', 'test.user', 1)"
+    sql"insert into rules_live (rule_type, pattern, replacement, category, tags, description, notes, external_id, force_red_rule, advisory_rule, created_by, updated_by, is_active, rule_order) values (${"regex"}, ${"pattern"}, ${"replacement"}, ${"category"}, ${"someTags"}, ${"description"}, ${"notes"}, ${"googleSheetId"}, false, false, 'test.user', 'test.user', true, 1)"
       .update()
       .apply()
   }


### PR DESCRIPTION
## What does this change?

Adds an archive button. When a rule is archived, we set the rule as archived in the draft table. If there's a corresponding active rule in the live table, we set that rule as inactive.

https://github.com/guardian/typerighter/assets/40991816/e2f4cc99-3740-4960-b152-9e36275a44b6

It is worth nothing that we are mutating live rules here (previously each new version of a rule has been inserted as a new row). We think is okay, as we are modifying the 'is_active' column, rather than the rule contents.

The UX is a first pass - awaiting final design.

## How to test

- The automated tests should pass.
- Try archiving draft and live rules using the archive button (prior to https://github.com/guardian/typerighter/pull/335, you may need to make rules live using Postman / Postgres). The status in the Rules table should change correspondingly.

In future passes we hope to add the ability to filter out archived rules, the ability to unarchive a rule, and the ability to see the archive action in the publication history (this last part might be a little complex given we do not model archiving on the live rule itself).