### PR TITLE
Rearchitect rule states and transitions

### DIFF
--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -130,13 +130,7 @@ class RulesController(
       case true =>
         RuleManager.unpublishRule(id, request.user.email, bucketRuleResource) match {
           case Left(e: Throwable) => InternalServerError(e.getMessage)
-          case Right((draftRule, liveRule)) =>
-            Ok(
-              Json.obj(
-                "draft" -> Json.toJson(draftRule),
-                "live" -> Json.toJson(liveRule)
-              )
-            )
+          case Right(allRuleData) => Ok(Json.toJson(allRuleData))
         }
     }
   }

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -141,12 +141,7 @@ class RulesController(
       case true =>
         RuleManager.archiveRule(id, request.user.email) match {
           case Left(e: Throwable) => InternalServerError(e.getMessage)
-          case Right(draftRule) =>
-            Ok(
-              Json.obj(
-                "draft" -> Json.toJson(draftRule)
-              )
-            )
+          case Right(allRuleData) => Ok(Json.toJson(allRuleData))
         }
     }
   }
@@ -157,12 +152,7 @@ class RulesController(
       case true =>
         RuleManager.unarchiveRule(id, request.user.email) match {
           case Left(e: Throwable) => InternalServerError(e.getMessage)
-          case Right(draftRule) =>
-            Ok(
-              Json.obj(
-                "draft" -> Json.toJson(draftRule)
-              )
-            )
+          case Right(allRuleData) => Ok(Json.toJson(allRuleData))
         }
     }
   }

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -130,9 +130,10 @@ class RulesController(
       case true =>
         RuleManager.unpublishRule(id, request.user.email) match {
           case Left(e: Throwable) => InternalServerError(e.getMessage)
-          case Right(liveRule) =>
+          case Right((draftRule, liveRule)) =>
             Ok(
               Json.obj(
+                "draft" -> Json.toJson(draftRule),
                 "live" -> Json.toJson(liveRule)
               )
             )

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -155,4 +155,20 @@ class RulesController(
         }
     }
   }
+
+  def unarchive(id: Int): Action[AnyContent] = ApiAuthAction { implicit request =>
+    hasPermission(request.user, PermissionDefinition("manage_rules", "typerighter")) match {
+      case false => Unauthorized("You don't have permission to unarchive rules")
+      case true =>
+        RuleManager.unarchiveRule(id, request.user.email) match {
+          case Left(e: Throwable) => InternalServerError(e.getMessage)
+          case Right(draftRule) =>
+            Ok(
+              Json.obj(
+                "draft" -> Json.toJson(draftRule)
+              )
+            )
+        }
+    }
+  }
 }

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -128,7 +128,7 @@ class RulesController(
     hasPermission(request.user, PermissionDefinition("manage_rules", "typerighter")) match {
       case false => Unauthorized("You don't have permission to unpublish rules")
       case true =>
-        RuleManager.unpublishRule(id, request.user.email) match {
+        RuleManager.unpublishRule(id, request.user.email, bucketRuleResource) match {
           case Left(e: Throwable) => InternalServerError(e.getMessage)
           case Right((draftRule, liveRule)) =>
             Ok(

--- a/apps/rule-manager/app/db/DbRuleLive.scala
+++ b/apps/rule-manager/app/db/DbRuleLive.scala
@@ -73,6 +73,7 @@ object DbRuleLive extends SQLSyntaxSupport[DbRuleLive] {
         .where
         .eq(r.externalId, externalId)
         .orderBy(r.revisionId.desc)
+        .limit(1)
     }.map(DbRuleLive.fromResultName(r.resultName)).single().apply()
   }
 

--- a/apps/rule-manager/app/db/DbRuleLive.scala
+++ b/apps/rule-manager/app/db/DbRuleLive.scala
@@ -78,7 +78,7 @@ object DbRuleLive extends SQLSyntaxSupport[DbRuleLive] {
 
   /** Find live rules by `externalId`. Because there may be many inactive live rules with the same
     * id, unlike the `find` method for draft rules, this method returns a list. To return a single
-    * rule, use `findRevision` or `findLatestActiveRevision`.
+    * rule, use `findRevision` or `findLatestRevision`.
     */
   def find(
       externalId: String

--- a/apps/rule-manager/app/service/RuleManager.scala
+++ b/apps/rule-manager/app/service/RuleManager.scala
@@ -267,10 +267,10 @@ object RuleManager extends Loggable {
     }
   }
 
-  def archiveRule(
+  def unpublishRule(
       id: Int,
       user: String
-  ): Either[Exception, (Option[DbRuleDraft], Option[DbRuleLive])] = {
+  ): Either[Exception, Option[DbRuleLive]] = {
     try {
       val maybeDraftRule = DbRuleDraft.find(id)
 
@@ -282,13 +282,26 @@ object RuleManager extends Loggable {
         updatedLiveRule <- DbRuleLive.setInactive(externalId, user)
       } yield updatedLiveRule
 
+      Right(maybeUpdatedLiveRule)
+    } catch {
+      case e: Exception => Left(e)
+    }
+  }
+
+  def archiveRule(
+      id: Int,
+      user: String
+  ): Either[Exception, Option[DbRuleDraft]] = {
+    try {
+      val maybeDraftRule = DbRuleDraft.find(id)
+
       val maybeUpdatedDraftRule = for {
         draftRule <- maybeDraftRule
         archivedDraftRule = draftRule.copy(isArchived = true)
         updatedDraftRule <- DbRuleDraft.save(archivedDraftRule, user).toOption
       } yield updatedDraftRule
 
-      Right(maybeUpdatedDraftRule, maybeUpdatedLiveRule)
+      Right(maybeUpdatedDraftRule)
     } catch {
       case e: Exception => Left(e)
     }

--- a/apps/rule-manager/app/service/RuleManager.scala
+++ b/apps/rule-manager/app/service/RuleManager.scala
@@ -176,6 +176,18 @@ object RuleManager extends Loggable {
             )
           )
         )
+      _ <- draftRule match {
+        case _ if draftRule.isArchived =>
+          Left(
+            Seq(
+              FormError(
+                "Rule is archived",
+                "Only unarchived rules can be published"
+              )
+            )
+          )
+        case _ => Right(())
+      }
       liveRule = draftRule.toLive(reason)
       externalId <- liveRule.externalId.toRight(Seq(FormError("External id", "required")))
       _ <- liveDbRuleToCheckerRule(liveRule)

--- a/apps/rule-manager/app/service/RuleManager.scala
+++ b/apps/rule-manager/app/service/RuleManager.scala
@@ -307,4 +307,24 @@ object RuleManager extends Loggable {
       case e: Exception => Left(e)
     }
   }
+
+  def unarchiveRule(
+      id: Int,
+      user: String
+  ): Either[Exception, Option[DbRuleDraft]] = {
+    try {
+      val maybeDraftRule = DbRuleDraft.find(id)
+
+      val maybeUpdatedDraftRule = for {
+        draftRule <- maybeDraftRule
+        if draftRule.isArchived
+        archivedDraftRule = draftRule.copy(isArchived = false)
+        updatedDraftRule <- DbRuleDraft.save(archivedDraftRule, user).toOption
+      } yield updatedDraftRule
+
+      Right(maybeUpdatedDraftRule)
+    } catch {
+      case e: Exception => Left(e)
+    }
+  }
 }

--- a/apps/rule-manager/app/service/RuleManager.scala
+++ b/apps/rule-manager/app/service/RuleManager.scala
@@ -297,6 +297,7 @@ object RuleManager extends Loggable {
 
       val maybeUpdatedDraftRule = for {
         draftRule <- maybeDraftRule
+        if !draftRule.isArchived
         archivedDraftRule = draftRule.copy(isArchived = true)
         updatedDraftRule <- DbRuleDraft.save(archivedDraftRule, user).toOption
       } yield updatedDraftRule

--- a/apps/rule-manager/app/service/RuleManager.scala
+++ b/apps/rule-manager/app/service/RuleManager.scala
@@ -307,18 +307,17 @@ object RuleManager extends Loggable {
   def archiveRule(
       id: Int,
       user: String
-  ): Either[Exception, Option[DbRuleDraft]] = {
+  ): Either[Exception, Option[AllRuleData]] = {
     try {
-      val maybeDraftRule = DbRuleDraft.find(id)
-
-      val maybeUpdatedDraftRule = for {
-        draftRule <- maybeDraftRule
+      val maybeAllRuleData = for {
+        draftRule <- DbRuleDraft.find(id)
         if !draftRule.isArchived
         archivedDraftRule = draftRule.copy(isArchived = true)
-        updatedDraftRule <- DbRuleDraft.save(archivedDraftRule, user).toOption
-      } yield updatedDraftRule
+        _ <- DbRuleDraft.save(archivedDraftRule, user).toOption
+        allRuleData <- getAllRuleData(id)
+      } yield allRuleData
 
-      Right(maybeUpdatedDraftRule)
+      Right(maybeAllRuleData)
     } catch {
       case e: Exception => Left(e)
     }
@@ -327,18 +326,17 @@ object RuleManager extends Loggable {
   def unarchiveRule(
       id: Int,
       user: String
-  ): Either[Exception, Option[DbRuleDraft]] = {
+  ): Either[Exception, Option[AllRuleData]] = {
     try {
-      val maybeDraftRule = DbRuleDraft.find(id)
-
-      val maybeUpdatedDraftRule = for {
-        draftRule <- maybeDraftRule
+      val maybeAllRuleData = for {
+        draftRule <- DbRuleDraft.find(id)
         if draftRule.isArchived
         archivedDraftRule = draftRule.copy(isArchived = false)
-        updatedDraftRule <- DbRuleDraft.save(archivedDraftRule, user).toOption
-      } yield updatedDraftRule
+        _ <- DbRuleDraft.save(archivedDraftRule, user).toOption
+        allRuleData <- getAllRuleData(id)
+      } yield allRuleData
 
-      Right(maybeUpdatedDraftRule)
+      Right(maybeAllRuleData)
     } catch {
       case e: Exception => Left(e)
     }

--- a/apps/rule-manager/app/service/RuleManager.scala
+++ b/apps/rule-manager/app/service/RuleManager.scala
@@ -269,7 +269,8 @@ object RuleManager extends Loggable {
 
   def unpublishRule(
       id: Int,
-      user: String
+      user: String,
+      bucketRuleResource: BucketRuleResource
   ): Either[Exception, (Option[DbRuleDraft], Option[DbRuleLive])] = {
     try {
       val maybeDraftRule = DbRuleDraft.find(id)
@@ -280,6 +281,7 @@ object RuleManager extends Loggable {
         liveRule <- DbRuleLive.findLatestRevision(externalId)
         if liveRule.isActive
         updatedLiveRule <- DbRuleLive.setInactive(externalId, user)
+        _ <- publishLiveRules(bucketRuleResource).toOption
       } yield updatedLiveRule
 
       // The draft rule needs to be updated to reflect the fact that it is no longer published

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -49,7 +49,7 @@ export const RuleForm = ({ruleId, onClose, onUpdate}: {
         onUpdate: (id: number) => void
     }) => {
     const [showErrors, setShowErrors] = useState(false);
-    const { isLoading, errors, rule, isPublishing, publishRule, fetchRule, updateRule, createRule, validateRule, publishValidationErrors, resetPublishValidationErrors, archiveRule } = useRule(ruleId);
+    const { isLoading, errors, rule, isPublishing, publishRule, fetchRule, updateRule, createRule, validateRule, publishValidationErrors, resetPublishValidationErrors, archiveRule, ruleState } = useRule(ruleId);
     const [ruleFormData, setRuleFormData] = useState(rule?.draft ?? baseForm)
     const [ formErrors, setFormErrors ] = useState<FormError[]>([]);
     const [isReasonModalVisible, setIsReasonModalVisible] = useState(false);
@@ -157,31 +157,38 @@ export const RuleForm = ({ruleId, onClose, onUpdate}: {
             <RuleContent ruleData={ruleFormData} partiallyUpdateRuleData={partiallyUpdateRuleData} errors={formErrors} showErrors={showErrors}/>
             <RuleMetadata ruleData={ruleFormData} partiallyUpdateRuleData={partiallyUpdateRuleData} />
             {rule && <RuleHistory ruleHistory={rule.live} />}
-            <EuiFlexGroup gutterSize="m">
-                <EuiFlexItem>
-                    <EuiButton onClick={() => {
-                        const shouldClose = hasUnsavedChanges
-                          ? window.confirm("Your rule has unsaved changes. Are you sure you want to discard them?")
-                          : true;
-                        if (!shouldClose) {
-                          return;
-                        }
-                        onClose();
-                        setRuleFormData(baseForm);
-                    }}>Close</EuiButton>
-                </EuiFlexItem>
-                <EuiFlexItem>
-                    <EuiButton fill={true} isDisabled={!hasUnsavedChanges} isLoading={isLoading} onClick={saveRuleHandler}>{ruleId ? "Update Rule" : "Save Rule"}</EuiButton>
-                </EuiFlexItem>
-                <EuiFlexItem>
-                  <PublishTooltip>
-                    <EuiButton fill={true} disabled={!ruleId || isLoading || !!publishValidationErrors} isLoading={isPublishing} onClick={maybePublishRuleHandler}>{"Publish"}</EuiButton>
-                  </PublishTooltip>
-                </EuiFlexItem>
-            </EuiFlexGroup>
             {
-                !ruleFormData.isArchived ? <EuiFlexItem grow={0}>
-                    <EuiButton onClick={archiveRuleHandler} color={"danger"}>Archive Rule</EuiButton>
+                ruleState === 'draft' || ruleState === 'live' ? <EuiFlexGroup gutterSize="m">
+                    <EuiFlexItem>
+                        <EuiButton onClick={() => {
+                            const shouldClose = hasUnsavedChanges
+                                ? window.confirm("Your rule has unsaved changes. Are you sure you want to discard them?")
+                                : true;
+                            if (!shouldClose) {
+                                return;
+                            }
+                            onClose();
+                            setRuleFormData(baseForm);
+                        }}>Close</EuiButton>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                        <EuiButton fill={true} isDisabled={!hasUnsavedChanges} isLoading={isLoading}
+                                   onClick={saveRuleHandler}>{ruleId ? "Update Rule" : "Save Rule"}</EuiButton>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                        <PublishTooltip>
+                            <EuiButton fill={true} disabled={!ruleId || isLoading || !!publishValidationErrors}
+                                       isLoading={isPublishing}
+                                       onClick={maybePublishRuleHandler}>{"Publish"}</EuiButton>
+                        </PublishTooltip>
+                    </EuiFlexItem>
+                </EuiFlexGroup> : null
+            }
+            {
+                ruleState === 'draft' ? <EuiFlexItem grow={0}>
+                    <EuiButton onClick={archiveRuleHandler} color={"danger"} disabled={!ruleId || isLoading}>
+                        Archive Rule
+                    </EuiButton>
                 </EuiFlexItem> : null
             }
             {showErrors ? <EuiCallOut title="Please resolve the following errors:" color="danger" iconType="error">

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -108,14 +108,15 @@ export const RuleForm = ({ruleId, onClose, onUpdate}: {
     }
 
     const publishRuleHandler = async (reason: string) => {
-      if (!ruleId) {
+      const isDraftOrLive = (ruleState === 'draft' || ruleState === 'live')
+      if (!ruleId || !isDraftOrLive) {
         return;
       }
       await publishRule(ruleId, reason);
       await fetchRule(ruleId);
       if (isReasonModalVisible) {
         setIsReasonModalVisible(false);
-      };
+      }
       onUpdate(ruleId);
     }
 
@@ -136,7 +137,7 @@ export const RuleForm = ({ruleId, onClose, onUpdate}: {
     }
 
     const archiveRuleHandler = () => {
-        if (!ruleFormData?.id) {
+        if (!ruleFormData?.id || ruleState !== 'draft') {
           return;
         }
 
@@ -149,7 +150,7 @@ export const RuleForm = ({ruleId, onClose, onUpdate}: {
     }
 
     const unarchiveRuleHandler = () => {
-        if (!ruleFormData?.id) {
+        if (!ruleFormData?.id || ruleState !== 'archived') {
             return;
         }
 
@@ -162,7 +163,7 @@ export const RuleForm = ({ruleId, onClose, onUpdate}: {
     }
 
     const unpublishRuleHandler = () => {
-        if (!ruleFormData?.id) {
+        if (!ruleFormData?.id || ruleState !== 'live') {
             return;
         }
 

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -49,7 +49,7 @@ export const RuleForm = ({ruleId, onClose, onUpdate}: {
         onUpdate: (id: number) => void
     }) => {
     const [showErrors, setShowErrors] = useState(false);
-    const { isLoading, errors, rule, isPublishing, publishRule, fetchRule, updateRule, createRule, validateRule, publishValidationErrors, resetPublishValidationErrors, archiveRule, unpublishRule, ruleState } = useRule(ruleId);
+    const { isLoading, errors, rule, isPublishing, publishRule, fetchRule, updateRule, createRule, validateRule, publishValidationErrors, resetPublishValidationErrors, archiveRule, unarchiveRule, unpublishRule, ruleState } = useRule(ruleId);
     const [ruleFormData, setRuleFormData] = useState(rule?.draft ?? baseForm)
     const [ formErrors, setFormErrors ] = useState<FormError[]>([]);
     const [isReasonModalVisible, setIsReasonModalVisible] = useState(false);
@@ -148,6 +148,19 @@ export const RuleForm = ({ruleId, onClose, onUpdate}: {
         })
     }
 
+    const unarchiveRuleHandler = () => {
+        if (!ruleFormData?.id) {
+            return;
+        }
+
+        unarchiveRule(ruleFormData.id).then(data => {
+            if (data.status === 'ok'){
+                setRuleFormData(baseForm);
+                onClose();
+            }
+        })
+    }
+
     const unpublishRuleHandler = () => {
         if (!ruleFormData?.id) {
             return;
@@ -196,6 +209,13 @@ export const RuleForm = ({ruleId, onClose, onUpdate}: {
                         </PublishTooltip>
                     </EuiFlexItem>
                 </EuiFlexGroup> : null
+            }
+            {
+                ruleState === 'archived' ? <EuiFlexItem grow={0}>
+                    <EuiButton onClick={unarchiveRuleHandler} color={"danger"} disabled={!ruleId || isLoading}>
+                        Unarchive Rule
+                    </EuiButton>
+                </EuiFlexItem> : null
             }
             {
                 ruleState === 'draft' ? <EuiFlexItem grow={0}>

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -11,12 +11,14 @@ import {
 import React, {ReactElement, useEffect, useState} from "react"
 import { RuleContent } from "./RuleContent";
 import { RuleMetadata } from "./RuleMetadata";
-import {DraftRule, RuleType, useRule} from "./hooks/useRule";
+import {DraftRule, RuleDataFromServer, RuleType, useRule} from "./hooks/useRule";
 import {RuleHistory} from "./RuleHistory";
 import styled from "@emotion/styled";
 import {capitalize} from "lodash";
 
 import { ReasonModal } from "./modals/Reason";
+import {transformApiFormData} from "../utils/api";
+import {errorToString} from "../utils/error";
 
 export type PartiallyUpdateRuleData = (partialReplacement: Partial<DraftRule>) => void;
 
@@ -113,7 +115,6 @@ export const RuleForm = ({ruleId, onClose, onUpdate}: {
         return;
       }
       await publishRule(ruleId, reason);
-      await fetchRule(ruleId);
       if (isReasonModalVisible) {
         setIsReasonModalVisible(false);
       }
@@ -137,33 +138,30 @@ export const RuleForm = ({ruleId, onClose, onUpdate}: {
     }
 
     const archiveRuleHandler = async () => {
-        if (!ruleFormData?.id || ruleState !== 'draft') {
+        if (!ruleId || ruleState !== 'draft') {
           return;
         }
 
-        await archiveRule(ruleFormData.id);
-        await fetchRule(ruleFormData.id);
-        onUpdate(ruleFormData.id);
+        await archiveRule(ruleId);
+        onUpdate(ruleId);
     }
 
     const unarchiveRuleHandler = async () => {
-        if (!ruleFormData?.id || ruleState !== 'archived') {
+        if (!ruleId || ruleState !== 'archived') {
             return;
         }
 
-        await unarchiveRule(ruleFormData.id);
-        await fetchRule(ruleFormData.id);
-        onUpdate(ruleFormData.id);
+        await unarchiveRule(ruleId);
+        onUpdate(ruleId);
     }
 
     const unpublishRuleHandler = async () => {
-        if (!ruleFormData?.id || ruleState !== 'live') {
+        if (!ruleId || ruleState !== 'live') {
             return;
         }
 
-        await unpublishRule(ruleFormData.id);
-        await fetchRule(ruleFormData.id);
-        onUpdate(ruleFormData.id);
+        await unpublishRule(ruleId);
+        onUpdate(ruleId);
     }
 
     const hasUnsavedChanges = ruleFormData !== rule?.draft;

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -49,7 +49,7 @@ export const RuleForm = ({ruleId, onClose, onUpdate}: {
         onUpdate: (id: number) => void
     }) => {
     const [showErrors, setShowErrors] = useState(false);
-    const { isLoading, errors, rule, isPublishing, publishRule, fetchRule, updateRule, createRule, validateRule, publishValidationErrors, resetPublishValidationErrors, archiveRule, ruleState } = useRule(ruleId);
+    const { isLoading, errors, rule, isPublishing, publishRule, fetchRule, updateRule, createRule, validateRule, publishValidationErrors, resetPublishValidationErrors, archiveRule, unpublishRule, ruleState } = useRule(ruleId);
     const [ruleFormData, setRuleFormData] = useState(rule?.draft ?? baseForm)
     const [ formErrors, setFormErrors ] = useState<FormError[]>([]);
     const [isReasonModalVisible, setIsReasonModalVisible] = useState(false);
@@ -148,6 +148,19 @@ export const RuleForm = ({ruleId, onClose, onUpdate}: {
         })
     }
 
+    const unpublishRuleHandler = () => {
+        if (!ruleFormData?.id) {
+            return;
+        }
+
+        unpublishRule(ruleFormData.id).then(data => {
+            if (data.status === 'ok'){
+                setRuleFormData(baseForm);
+                onClose();
+            }
+        })
+    }
+
     const hasUnsavedChanges = ruleFormData !== rule?.draft;
 
 
@@ -188,6 +201,13 @@ export const RuleForm = ({ruleId, onClose, onUpdate}: {
                 ruleState === 'draft' ? <EuiFlexItem grow={0}>
                     <EuiButton onClick={archiveRuleHandler} color={"danger"} disabled={!ruleId || isLoading}>
                         Archive Rule
+                    </EuiButton>
+                </EuiFlexItem> : null
+            }
+            {
+                ruleState === 'live' ? <EuiFlexItem grow={0}>
+                    <EuiButton onClick={unpublishRuleHandler} color={"danger"} disabled={!ruleId || isLoading}>
+                        Unpublish Rule
                     </EuiButton>
                 </EuiFlexItem> : null
             }

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -136,43 +136,34 @@ export const RuleForm = ({ruleId, onClose, onUpdate}: {
         </EuiToolTip>
     }
 
-    const archiveRuleHandler = () => {
+    const archiveRuleHandler = async () => {
         if (!ruleFormData?.id || ruleState !== 'draft') {
           return;
         }
 
-        archiveRule(ruleFormData.id).then(data => {
-            if (data.status === 'ok'){
-                setRuleFormData(baseForm);
-                onClose();
-            }
-        })
+        await archiveRule(ruleFormData.id);
+        await fetchRule(ruleFormData.id);
+        onUpdate(ruleFormData.id);
     }
 
-    const unarchiveRuleHandler = () => {
+    const unarchiveRuleHandler = async () => {
         if (!ruleFormData?.id || ruleState !== 'archived') {
             return;
         }
 
-        unarchiveRule(ruleFormData.id).then(data => {
-            if (data.status === 'ok'){
-                setRuleFormData(baseForm);
-                onClose();
-            }
-        })
+        await unarchiveRule(ruleFormData.id);
+        await fetchRule(ruleFormData.id);
+        onUpdate(ruleFormData.id);
     }
 
-    const unpublishRuleHandler = () => {
+    const unpublishRuleHandler = async () => {
         if (!ruleFormData?.id || ruleState !== 'live') {
             return;
         }
 
-        unpublishRule(ruleFormData.id).then(data => {
-            if (data.status === 'ok'){
-                setRuleFormData(baseForm);
-                onClose();
-            }
-        })
+        await unpublishRule(ruleFormData.id);
+        await fetchRule(ruleFormData.id);
+        onUpdate(ruleFormData.id);
     }
 
     const hasUnsavedChanges = ruleFormData !== rule?.draft;

--- a/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
@@ -105,37 +105,73 @@ export function useRule(ruleId: number | undefined) {
   const archiveRule = async (ruleId: number) => {
     setIsLoading(true);
 
-    const result = await fetch(`${location}rules/${ruleId}/archive`, {
-      method: 'POST',
-    }).then(responseHandler)
+    try {
+      const response = await fetch(`${location}rules/${ruleId}/archive`, {
+        method: 'POST',
+      });
 
-    setIsLoading(false);
+      if (!response.ok) {
+        throw new Error(`Failed to archive rule: ${response.status} ${response.statusText}`);
+      }
 
-    return result;
+      const rules: RuleDataFromServer = await response.json();
+      setRule({
+        draft: transformApiFormData(rules.draft),
+        live: rules.live.map(transformApiFormData)
+      });
+    } catch (error) {
+      setErrors(errorToString(error));
+    } finally {
+      setIsLoading(false);
+    }
   }
 
   const unarchiveRule = async (ruleId: number) => {
     setIsLoading(true);
 
-    const result = await fetch(`${location}rules/${ruleId}/unarchive`, {
-      method: 'POST',
-    }).then(responseHandler)
+    try {
+      const response = await fetch(`${location}rules/${ruleId}/unarchive`, {
+        method: 'POST',
+      });
 
-    setIsLoading(false);
+      if (!response.ok) {
+        throw new Error(`Failed to unarchive rule: ${response.status} ${response.statusText}`);
+      }
 
-    return result;
+      const rules: RuleDataFromServer = await response.json();
+      setRule({
+        draft: transformApiFormData(rules.draft),
+        live: rules.live.map(transformApiFormData)
+      });
+    } catch (error) {
+      setErrors(errorToString(error));
+    } finally {
+      setIsLoading(false);
+    }
   }
 
   const unpublishRule = async (ruleId: number) => {
     setIsLoading(true);
 
-    const result = await fetch(`${location}rules/${ruleId}/unpublish`, {
-      method: 'POST',
-    }).then(responseHandler)
+    try {
+      const response = await fetch(`${location}rules/${ruleId}/unpublish`, {
+        method: 'POST',
+      });
 
-    setIsLoading(false);
+      if (!response.ok) {
+        throw new Error(`Failed to unpublish rule: ${response.status} ${response.statusText}`);
+      }
 
-    return result;
+      const rules: RuleDataFromServer = await response.json();
+      setRule({
+        draft: transformApiFormData(rules.draft),
+        live: rules.live.map(transformApiFormData)
+      });
+    } catch (error) {
+      setErrors(errorToString(error));
+    } finally {
+      setIsLoading(false);
+    }
   }
 
   const validateRule = async (ruleId: number) => {

--- a/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
@@ -114,6 +114,18 @@ export function useRule(ruleId: number | undefined) {
     return result;
   }
 
+  const unpublishRule = async (ruleId: number) => {
+    setIsLoading(true);
+
+    const result = await fetch(`${location}rules/${ruleId}/unpublish`, {
+      method: 'POST',
+    }).then(responseHandler)
+
+    setIsLoading(false);
+
+    return result;
+  }
+
   const validateRule = async (ruleId: number) => {
     setIsValidating(false);
 
@@ -198,5 +210,5 @@ export function useRule(ruleId: number | undefined) {
     setRuleState(getRuleState(rule?.draft));
   }, [rule])
 
-  return { fetchRule, updateRule, createRule, isLoading, errors, rule, publishRule, isPublishing, validateRule, isValidating, publishValidationErrors, resetPublishValidationErrors, archiveRule, ruleState }
+  return { fetchRule, updateRule, createRule, isLoading, errors, rule, publishRule, isPublishing, validateRule, isValidating, publishValidationErrors, resetPublishValidationErrors, archiveRule, unpublishRule, ruleState }
 }

--- a/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
@@ -114,6 +114,18 @@ export function useRule(ruleId: number | undefined) {
     return result;
   }
 
+  const unarchiveRule = async (ruleId: number) => {
+    setIsLoading(true);
+
+    const result = await fetch(`${location}rules/${ruleId}/unarchive`, {
+      method: 'POST',
+    }).then(responseHandler)
+
+    setIsLoading(false);
+
+    return result;
+  }
+
   const unpublishRule = async (ruleId: number) => {
     setIsLoading(true);
 
@@ -210,5 +222,5 @@ export function useRule(ruleId: number | undefined) {
     setRuleState(getRuleState(rule?.draft));
   }, [rule])
 
-  return { fetchRule, updateRule, createRule, isLoading, errors, rule, publishRule, isPublishing, validateRule, isValidating, publishValidationErrors, resetPublishValidationErrors, archiveRule, unpublishRule, ruleState }
+  return { fetchRule, updateRule, createRule, isLoading, errors, rule, publishRule, isPublishing, validateRule, isValidating, publishValidationErrors, resetPublishValidationErrors, archiveRule, unarchiveRule, unpublishRule, ruleState }
 }

--- a/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
@@ -2,6 +2,7 @@ import {useEffect, useState} from "react";
 import {ErrorIResponse, responseHandler, transformApiFormData, transformRuleFormData} from "../../utils/api";
 import { errorToString } from "../../utils/error";
 import { FormError } from "../RuleForm";
+import {getRuleState, RuleState} from "../../utils/rule";
 
 export type RuleType = 'regex' | 'languageToolXML';
 
@@ -53,6 +54,7 @@ export function useRule(ruleId: number | undefined) {
   const [publishValidationErrors, setPublishValidationErrors] = useState<FormError[] | undefined>(undefined);
   const [errors, setErrors] = useState<string | undefined>(undefined);
   const [rule, setRule] = useState<RuleData | undefined>(undefined);
+  const [ruleState, setRuleState] = useState<RuleState>("draft")
 
   const fetchRule = async (ruleId: number) => {
     setIsLoading(true);
@@ -192,5 +194,9 @@ export function useRule(ruleId: number | undefined) {
     }
   }, [ruleId])
 
-  return { fetchRule, updateRule, createRule, isLoading, errors, rule, publishRule, isPublishing, validateRule, isValidating, publishValidationErrors, resetPublishValidationErrors, archiveRule }
+  useEffect(() => {
+    setRuleState(getRuleState(rule?.draft));
+  }, [rule])
+
+  return { fetchRule, updateRule, createRule, isLoading, errors, rule, publishRule, isPublishing, validateRule, isValidating, publishValidationErrors, resetPublishValidationErrors, archiveRule, ruleState }
 }

--- a/apps/rule-manager/client/src/ts/utils/rule.ts
+++ b/apps/rule-manager/client/src/ts/utils/rule.ts
@@ -29,6 +29,6 @@ export const getRuleStateColour = (rule: DraftRule): IconColor =>
 const stateToColourMap: {[state in RuleState]: IconColor} = {
   error: "danger",
   live: "success",
-  archived: "subdued",
+  archived: "danger",
   draft: "#DA8B45"
 }

--- a/apps/rule-manager/client/src/ts/utils/rule.ts
+++ b/apps/rule-manager/client/src/ts/utils/rule.ts
@@ -1,9 +1,17 @@
 import {DraftRule} from "../components/hooks/useRule";
 import {IconColor} from "@elastic/eui/src/components/icon";
 
-type RuleState = "live" | "archived" | "draft";
+export type RuleState = "live" | "archived" | "draft" | "error";
 
-export const getRuleState = (rule: DraftRule): RuleState => {
+export const getRuleState = (rule: DraftRule | undefined): RuleState => {
+  if(!rule) {
+    return "draft";
+  }
+
+  if(rule.isPublished && rule.isArchived) {
+    return "error";
+  }
+
   if(rule.isPublished) {
     return "live";
   }
@@ -19,7 +27,8 @@ export const getRuleStateColour = (rule: DraftRule): IconColor =>
   stateToColourMap[getRuleState(rule)];
 
 const stateToColourMap: {[state in RuleState]: IconColor} = {
+  error: "danger",
   live: "success",
-  archived: "danger",
+  archived: "subdued",
   draft: "#DA8B45"
 }

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -28,6 +28,8 @@ GET     /rules/:id/publish          controllers.RulesController.canPublish(id: I
 POST    /rules/:id/unpublish        controllers.RulesController.unpublish(id: Int)
 +nocsrf
 POST    /rules/:id/archive          controllers.RulesController.archive(id: Int)
++nocsrf
+POST    /rules/:id/unarchive        controllers.RulesController.unarchive(id: Int)
 
 # Tags
 +nocsrf

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -23,7 +23,9 @@ POST    /rules/:id                  controllers.RulesController.update(id: Int)
 +nocsrf
 POST    /rules/:id/publish          controllers.RulesController.publish(id: Int)
 +nocsrf
-GET    /rules/:id/publish           controllers.RulesController.canPublish(id: Int)
+GET     /rules/:id/publish          controllers.RulesController.canPublish(id: Int)
++nocsrf
+POST    /rules/:id/unpublish        controllers.RulesController.unpublish(id: Int)
 +nocsrf
 POST    /rules/:id/archive          controllers.RulesController.archive(id: Int)
 

--- a/apps/rule-manager/test/db/RuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/RuleManagerSpec.scala
@@ -285,7 +285,7 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
     allLiveRules(1).isActive shouldBe true
   }
 
-  "publishRule" should "should not be able to publish the same revision of a rule" in { () =>
+  "publishRule" should "not be able to publish the same revision of a rule" in { () =>
     val ruleToPublish = createPublishableRule
 
     RuleManager.publishRule(ruleToPublish.id.get, user, reason, bucketRuleResource)
@@ -298,7 +298,7 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
     }
   }
 
-  "parseDraftRuleForPublication" should "should give validation errors when the rule is incomplete" in {
+  "parseDraftRuleForPublication" should "give validation errors when the rule is incomplete" in {
     () =>
       val ruleToPublish = DbRuleDraft
         .create(
@@ -313,7 +313,7 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
       }
   }
 
-  "parseDraftRuleForPublication" should "should give validation errors when a live rule of that revision id already exists" in {
+  "parseDraftRuleForPublication" should "give validation errors when a live rule of that revision id already exists" in {
     () =>
       val ruleToPublish = createPublishableRule
       RuleManager.publishRule(ruleToPublish.id.get, user, reason, bucketRuleResource)

--- a/apps/rule-manager/test/db/RuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/RuleManagerSpec.scala
@@ -384,8 +384,8 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
     RuleManager.archiveRule(invalidId, user) match {
       case Left(e) =>
         fail(s"Unexpected error on archiving id: $invalidId: ${e.getMessage}")
-      case Right(maybeDraftRule) =>
-        maybeDraftRule shouldBe None
+      case Right(maybeAllRuleData) =>
+        maybeAllRuleData shouldBe None
     }
   }
 
@@ -397,8 +397,8 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
     RuleManager.archiveRule(ruleToArchive.id.get, user) match {
       case Left(e) =>
         fail(s"Unexpected error on archiving id: $ruleToArchive.id.get: ${e.getMessage}")
-      case Right(maybeDraftRule) =>
-        maybeDraftRule shouldBe None
+      case Right(maybeAllRuleData) =>
+        maybeAllRuleData shouldBe None
     }
   }
 
@@ -408,13 +408,14 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
     RuleManager.archiveRule(ruleToArchive.id.get, user) match {
       case Left(e) =>
         fail(s"Unexpected error on archiving id: ${ruleToArchive.id.get}: ${e.getMessage}")
-      case Right(maybeDraftRule) =>
-        val draftRule = maybeDraftRule.get
-        draftRule.revisionId shouldMatchTo (ruleToArchive.revisionId + 1)
-        draftRule.isArchived shouldBe true
-        draftRule.isPublished shouldBe false
-        draftRule.updatedBy shouldBe user
-        draftRule.updatedAt shouldBe >(ruleToArchive.updatedAt)
+      case Right(maybeAllRuleData) =>
+        val updatedDraftRule = maybeAllRuleData.get.draft
+        updatedDraftRule.isArchived shouldBe true
+        updatedDraftRule.revisionId shouldMatchTo (ruleToArchive.revisionId + 1)
+        updatedDraftRule.isArchived shouldBe true
+        updatedDraftRule.isPublished shouldBe false
+        updatedDraftRule.updatedBy shouldBe user
+        updatedDraftRule.updatedAt shouldBe >(ruleToArchive.updatedAt)
     }
   }
 
@@ -424,8 +425,8 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
     RuleManager.unarchiveRule(invalidId, user) match {
       case Left(e) =>
         fail(s"Unexpected error on unarchiving id: $invalidId: ${e.getMessage}")
-      case Right(maybeDraftRule) =>
-        maybeDraftRule shouldBe None
+      case Right(maybeAllRuleData) =>
+        maybeAllRuleData shouldBe None
     }
   }
 
@@ -435,8 +436,8 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
     RuleManager.unarchiveRule(ruleToArchive.id.get, user) match {
       case Left(e) =>
         fail(s"Unexpected error on unarchiving id: $ruleToArchive.id.get: ${e.getMessage}")
-      case Right(maybeDraftRule) =>
-        maybeDraftRule shouldBe None
+      case Right(maybeAllRuleData) =>
+        maybeAllRuleData shouldBe None
     }
   }
 
@@ -446,23 +447,22 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
       val maybeRuleToUnarchive = RuleManager.archiveRule(ruleToArchive.id.get, user) match {
         case Left(e) =>
           fail(s"Unexpected error on archiving id: ${ruleToArchive.id.get}: ${e.getMessage}")
-        case Right(maybeDraftRule) => maybeDraftRule
+        case Right(maybeAllRuleData) => maybeAllRuleData
       }
 
       maybeRuleToUnarchive shouldBe defined
-
-      val ruleToUnarchive = maybeRuleToUnarchive.get
+      val ruleToUnarchive = maybeRuleToUnarchive.get.draft
 
       RuleManager.unarchiveRule(ruleToUnarchive.id.get, user) match {
         case Left(e) =>
           fail(s"Unexpected error on unarchiving id: ${ruleToArchive.id.get}: ${e.getMessage}")
-        case Right(maybeDraftRule) =>
-          val draftRule = maybeDraftRule.get
-          draftRule.revisionId shouldMatchTo (ruleToUnarchive.revisionId + 1)
-          draftRule.isArchived shouldBe false
-          draftRule.isPublished shouldBe false
-          draftRule.updatedBy shouldBe user
-          draftRule.updatedAt shouldBe >(ruleToUnarchive.updatedAt)
+        case Right(maybeAllRuleData) =>
+          val updatedDraftRule = maybeAllRuleData.get.draft
+          updatedDraftRule.revisionId shouldMatchTo (ruleToUnarchive.revisionId + 1)
+          updatedDraftRule.isArchived shouldBe false
+          updatedDraftRule.isPublished shouldBe false
+          updatedDraftRule.updatedBy shouldBe user
+          updatedDraftRule.updatedAt shouldBe >(ruleToUnarchive.updatedAt)
       }
   }
 

--- a/apps/rule-manager/test/db/RuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/RuleManagerSpec.scala
@@ -353,7 +353,7 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
       )
   }
 
-  "archiveRule" should "not do nothing if the rule does not exist in draft" in { () =>
+  "archiveRule" should "do nothing if the rule does not exist in draft" in { () =>
     val invalidId = 100
 
     RuleManager.archiveRule(invalidId, user) match {
@@ -364,7 +364,18 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
     }
   }
 
-  "archiveRule" should "archive the rule if it exists in draft" in { () =>
+  "archiveRule" should "do nothing if the rule is already archived" in { () =>
+    val ruleToArchive = createPublishableRule
+
+    RuleManager.archiveRule(ruleToArchive.id.get, user) match {
+      case Left(e) =>
+        fail(s"Unexpected error on archiving id: $ruleToArchive.id.get: ${e.getMessage}")
+      case Right(maybeDraftRule) =>
+        maybeDraftRule shouldBe None
+    }
+  }
+
+  "archiveRule" should "archive the rule if it (a) exists in draft and (b) is unarchived" in { () =>
     val ruleToArchive = createPublishableRule
 
     RuleManager.archiveRule(ruleToArchive.id.get, user) match {
@@ -391,7 +402,7 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
     }
   }
 
-  "unpublishRule" should "should do nothing if the rule does not exist in live" in { () =>
+  "unpublishRule" should "do nothing if the rule does not exist in draft" in { () =>
     val invalidId = 100
 
     RuleManager.unpublishRule(invalidId, user) match {
@@ -402,7 +413,18 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
     }
   }
 
-  "unpublishRule" should "should do nothing to the live rule if it is inactive" in { () =>
+  "unpublishRule" should "do nothing if the rule does not exist in live" in { () =>
+    val ruleToArchive = createPublishableRule
+
+    RuleManager.unpublishRule(ruleToArchive.id.get, user) match {
+      case Left(e) =>
+        fail(s"Unexpected error on unpublishing id: $ruleToArchive.id.get: ${e.getMessage}")
+      case Right(maybeLiveRule) =>
+        maybeLiveRule shouldBe None
+    }
+  }
+
+  "unpublishRule" should "do nothing to the live rule if it is already inactive" in { () =>
     val ruleToUnpublish = createPublishableRule
 
     RuleManager.publishRule(ruleToUnpublish.id.get, user, reason, bucketRuleResource)

--- a/apps/rule-manager/test/db/RuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/RuleManagerSpec.scala
@@ -472,9 +472,8 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
     RuleManager.unpublishRule(invalidId, user, bucketRuleResource) match {
       case Left(e) =>
         fail(s"Unexpected error on unpublishing id: $invalidId: ${e.getMessage}")
-      case Right((maybeDraftRule, maybeLiveRule)) =>
-        maybeDraftRule shouldBe None
-        maybeLiveRule shouldBe None
+      case Right(allRuleData) =>
+        allRuleData shouldBe None
     }
   }
 
@@ -484,9 +483,8 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
     RuleManager.unpublishRule(ruleToArchive.id.get, user, bucketRuleResource) match {
       case Left(e) =>
         fail(s"Unexpected error on unpublishing id: $ruleToArchive.id.get: ${e.getMessage}")
-      case Right((maybeDraftRule, maybeLiveRule)) =>
-        maybeDraftRule shouldBe None
-        maybeLiveRule shouldBe None
+      case Right(allRuleData) =>
+        allRuleData shouldBe None
     }
   }
 
@@ -506,9 +504,8 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
       RuleManager.unpublishRule(ruleToUnpublish.id.get, user, bucketRuleResource) match {
         case Left(e) =>
           fail(s"Unexpected error on unpublishing id: ${ruleToUnpublish.id.get}: ${e.getMessage}")
-        case Right((maybeDraftRule, maybeLiveRule)) =>
-          maybeDraftRule shouldBe None
-          maybeLiveRule shouldBe None
+        case Right(allRuleData) =>
+          allRuleData shouldBe None
       }
   }
 
@@ -521,17 +518,17 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
       RuleManager.unpublishRule(ruleToUnpublish.id.get, user, bucketRuleResource) match {
         case Left(e) =>
           fail(s"Unexpected error on unpublishing id: ${ruleToUnpublish.id.get}: ${e.getMessage}")
-        case Right((maybeDraftRule, maybeLiveRule)) =>
-          maybeLiveRule shouldBe defined
-          val liveRule = maybeLiveRule.get
-          liveRule.isActive shouldBe false
-          liveRule.updatedBy shouldBe user
-          liveRule.updatedAt shouldBe >(ruleToUnpublish.updatedAt)
+        case Right(allRuleData) =>
+          allRuleData match {
+            case None => fail("Expected rule data to be returned")
+            case Some(allRuleData) =>
+              allRuleData.draft.isPublished shouldBe false
+              allRuleData.draft.revisionId shouldBe >(ruleToUnpublish.revisionId)
 
-          maybeDraftRule shouldBe defined
-          val draftRule = maybeDraftRule.get
-          draftRule.isPublished shouldBe false
-          draftRule.revisionId shouldBe >(ruleToUnpublish.revisionId)
+              allRuleData.live.head.isActive shouldBe false
+              allRuleData.live.head.updatedBy shouldBe user
+              allRuleData.live.head.updatedAt shouldBe >(ruleToUnpublish.updatedAt)
+          }
       }
   }
 }

--- a/apps/rule-manager/test/db/RuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/RuleManagerSpec.scala
@@ -444,7 +444,7 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
   "unpublishRule" should "do nothing if the rule does not exist in draft" in { () =>
     val invalidId = 100
 
-    RuleManager.unpublishRule(invalidId, user) match {
+    RuleManager.unpublishRule(invalidId, user, bucketRuleResource) match {
       case Left(e) =>
         fail(s"Unexpected error on unpublishing id: $invalidId: ${e.getMessage}")
       case Right((maybeDraftRule, maybeLiveRule)) =>
@@ -456,7 +456,7 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
   "unpublishRule" should "do nothing if the rule does not exist in live" in { () =>
     val ruleToArchive = createPublishableRule
 
-    RuleManager.unpublishRule(ruleToArchive.id.get, user) match {
+    RuleManager.unpublishRule(ruleToArchive.id.get, user, bucketRuleResource) match {
       case Left(e) =>
         fail(s"Unexpected error on unpublishing id: $ruleToArchive.id.get: ${e.getMessage}")
       case Right((maybeDraftRule, maybeLiveRule)) =>
@@ -478,7 +478,7 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
       externalId <- liveRule.externalId
       _ <- DbRuleLive.setInactive(externalId, user)
     }
-      RuleManager.unpublishRule(ruleToUnpublish.id.get, user) match {
+      RuleManager.unpublishRule(ruleToUnpublish.id.get, user, bucketRuleResource) match {
         case Left(e) =>
           fail(s"Unexpected error on unpublishing id: ${ruleToUnpublish.id.get}: ${e.getMessage}")
         case Right((maybeDraftRule, maybeLiveRule)) =>
@@ -493,7 +493,7 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
 
       RuleManager.publishRule(ruleToUnpublish.id.get, user, reason, bucketRuleResource)
 
-      RuleManager.unpublishRule(ruleToUnpublish.id.get, user) match {
+      RuleManager.unpublishRule(ruleToUnpublish.id.get, user, bucketRuleResource) match {
         case Left(e) =>
           fail(s"Unexpected error on unpublishing id: ${ruleToUnpublish.id.get}: ${e.getMessage}")
         case Right((maybeDraftRule, maybeLiveRule)) =>


### PR DESCRIPTION
## What does this change?

Rules can now move along the following states: `Archived` <-> `Draft` <-> `Live`

They can only move one state along at a time. For example, previously a user could archive from live. Now they must first unpublish a rule to draft, and then archive the draft rule.

The possible states and transitions can be summarised as follows:

| Rule State | Valid Transitions |
| --- | --- |
| Archived | Unarchive (-> Draft) |
| Draft | Archive (-> Archived), Publish (-> Live) |
| Live | Unpublish (-> Draft) |

This PR refactors our two existing state functions, Publish and Archive, to reflect the above, and adds two new state functions, Unarchive and Unpublish. 

We validate state transitions on the client and server, and show different actions to the user depending on the rule state (e.g. if the rule is archived, we only show the `Unarchive` button, and do not surface the `Publish` button).

## How to test

Run the new and updated tests - they should pass.

Play around with the various state buttons - you should be able to move a rule into different states without any errors.

## How can we measure success?

A (relatively) simple publication system ready before launch, that allows users to manage rules throughout their life cycle.