### PR TITLE
Return 200 from GET publish endpoint

### DIFF
--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -143,8 +143,8 @@ class RulesController(
 
   def canPublish(id: Int) = ApiAuthAction {
     RuleManager.parseDraftRuleForPublication(id, "validate") match {
-      case Right(_)     => Ok
-      case Left(errors) => BadRequest(Json.toJson(errors))
+      case Right(_)     => Ok(Json.toJson(Nil))
+      case Left(errors) => Ok(Json.toJson(errors))
     }
   }
 

--- a/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
@@ -117,9 +117,11 @@ export function useRule(ruleId: number | undefined) {
 
     try {
       const response = await fetch(`${location}rules/${ruleId}/publish`);
-      if (response.status === 400) {
+      if (response.status === 200) {
         const validationErrors: FormError[] = await response.json();
-        return setPublishValidationErrors(validationErrors);
+        return validationErrors.length > 0
+            ? setPublishValidationErrors(validationErrors)
+            : setPublishValidationErrors(undefined);
       }
       setPublishValidationErrors(undefined);
     } catch (error) {


### PR DESCRIPTION
## What does this change?

A small change to avoid polluting the console and log stack -> the GET /publish endpoint now returns a 200 rather than a 400.

## How to test

Errors from the endpoint populate the form as before. The network tab now shows only 200s for validation requests.