### PR TITLE
Better user experience when editing rules of different types

### DIFF
--- a/apps/rule-manager/client/src/ts/components/RuleContent.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleContent.tsx
@@ -1,6 +1,6 @@
-import {EuiFieldText, EuiFlexItem, EuiFormRow, EuiRadioGroup} from "@elastic/eui"
+import {EuiFieldText, EuiFlexItem, EuiFormLabel, EuiFormRow, EuiRadioGroup, EuiSpacer, EuiTextArea} from "@elastic/eui"
 import {css} from "@emotion/react";
-import React, {useState} from "react"
+import React from "react"
 import {RuleFormSection} from "./RuleFormSection";
 import {LineBreak} from "./LineBreak";
 import {FormError, PartiallyUpdateRuleData} from "./RuleForm";
@@ -29,17 +29,31 @@ export const RuleContent = ({ruleData, partiallyUpdateRuleData, errors, showErro
             label: "LanguageTool",
         },
     ]
-    const [ruleTypeSelected, setRuleTypeSelected] = useState(ruleTypeOptions[0].id);
+    const TextField = ruleData.ruleType === "languageToolXML" ? EuiTextArea : EuiFieldText;
 
     return <RuleFormSection title="RULE CONTENT">
         <LineBreak/>
         <EuiFlexItem>
+          <EuiFormLabel>Rule type</EuiFormLabel>
+            <EuiRadioGroup
+                options={ruleTypeOptions}
+                idSelected={ruleData.ruleType}
+                onChange={(ruleType) => {
+                    partiallyUpdateRuleData({ruleType: ruleType as RuleType});
+                }}
+                css={css`
+                        display: flex;
+                        gap: 1rem;
+                        align-items: flex-end;
+                    `}
+            />
+            <EuiSpacer size="s" />
             <EuiFormRow
                 label={<Label text='Pattern' required={true}/>}
                 isInvalid={showErrors && !ruleData.pattern}
                 fullWidth={true}
             >
-                <EuiFieldText
+                <TextField
                     value={ruleData.pattern || ""}
                     onChange={(_ => partiallyUpdateRuleData({pattern: _.target.value}))}
                     required={true}
@@ -65,21 +79,6 @@ export const RuleContent = ({ruleData, partiallyUpdateRuleData, errors, showErro
                               onChange={(_ => partiallyUpdateRuleData({description: _.target.value}))}
                               fullWidth={true} />
             </EuiFormRow>
-            <EuiRadioGroup
-                options={ruleTypeOptions}
-                idSelected={ruleTypeSelected}
-                onChange={(ruleType) => {
-                    setRuleTypeSelected(ruleType as RuleType);
-                    partiallyUpdateRuleData({ruleType: ruleType as RuleType});
-                }}
-                css={css`
-                        flex-direction: row;
-                        display: flex;
-                        gap: 1rem;
-                        align-items: flex-end;
-                        margin-top: 8px;
-                    `}
-            />
         </EuiFlexItem>
     </RuleFormSection>
 }

--- a/apps/rule-manager/client/src/ts/components/RuleContent.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleContent.tsx
@@ -12,10 +12,9 @@ type RuleTypeOption = {
   label: string,
 }
 
-export const RuleContent = ({ruleData, partiallyUpdateRuleData, errors, showErrors}: {
+export const RuleContent = ({ruleData, partiallyUpdateRuleData, showErrors}: {
         ruleData: DraftRule,
         partiallyUpdateRuleData: PartiallyUpdateRuleData,
-        errors: FormError[],
         showErrors: boolean
     }) => {
 

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -168,7 +168,7 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
     return <EuiForm component="form">
         {isLoading && <SpinnerOverlay><SpinnerOuter><SpinnerContainer><EuiLoadingSpinner /></SpinnerContainer></SpinnerOuter></SpinnerOverlay>}
         {<EuiFlexGroup  direction="column">
-            <RuleContent ruleData={ruleFormData} partiallyUpdateRuleData={partiallyUpdateRuleData} errors={formErrors} showErrors={showErrors}/>
+            <RuleContent ruleData={ruleFormData} partiallyUpdateRuleData={partiallyUpdateRuleData} showErrors={showErrors}/>
             <RuleMetadata tags={tags} ruleData={ruleFormData} partiallyUpdateRuleData={partiallyUpdateRuleData} />
             {rule && <RuleHistory ruleHistory={rule.live} />}
             {


### PR DESCRIPTION
## What does this change?

A few tweaks when editing rules of different types:

- the rule type is now respected, changing when the rule data changes
- the input changes from a text to textarea when editing XML rules, to reflect their multiline content

![rule-type](https://github.com/guardian/typerighter/assets/7767575/605754d8-95fe-4d62-a74d-889ce9d3ad7d)

I've also moved the radio buttons nearer the pattern input, as the two fields are very related – one affects the other's presentation.

## How to test

Have a play inspecting and editing rules of different types. Do the changes make sense?