### PR TITLE
Autosave on rule edit

### DIFF
--- a/apps/rule-manager/client/src/ts/components/LastUpdated.tsx
+++ b/apps/rule-manager/client/src/ts/components/LastUpdated.tsx
@@ -1,0 +1,18 @@
+import { formatDistance } from "date-fns";
+import { usePeriodicRefresh } from "./hooks/usePeriodicRefresh";
+
+/**
+ * Return the
+ * @param lastUpdated
+ * @returns
+ */
+export const LastUpdated: React.FC<{ lastUpdated: string }> = ({
+  lastUpdated,
+}) => {
+  usePeriodicRefresh(10000);
+  return (
+    <>{`Updated ${formatDistance(new Date(), new Date(lastUpdated), {
+      includeSeconds: true,
+    })} ago`}</>
+  );
+};

--- a/apps/rule-manager/client/src/ts/components/LastUpdated.tsx
+++ b/apps/rule-manager/client/src/ts/components/LastUpdated.tsx
@@ -1,11 +1,6 @@
 import { formatDistance } from "date-fns";
 import { usePeriodicRefresh } from "./hooks/usePeriodicRefresh";
 
-/**
- * Return the
- * @param lastUpdated
- * @returns
- */
 export const LastUpdated: React.FC<{ lastUpdated: string }> = ({
   lastUpdated,
 }) => {

--- a/apps/rule-manager/client/src/ts/components/RuleContent.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleContent.tsx
@@ -3,9 +3,10 @@ import {css} from "@emotion/react";
 import React from "react"
 import {RuleFormSection} from "./RuleFormSection";
 import {LineBreak} from "./LineBreak";
-import {FormError, PartiallyUpdateRuleData} from "./RuleForm";
+import {PartiallyUpdateRuleData} from "./RuleForm";
 import {Label} from "./Label";
 import {DraftRule, RuleType} from "./hooks/useRule";
+import { LastUpdated } from "./LastUpdated";
 
 type RuleTypeOption = {
   id: RuleType,
@@ -30,7 +31,10 @@ export const RuleContent = ({ruleData, partiallyUpdateRuleData, showErrors}: {
     ]
     const TextField = ruleData.ruleType === "languageToolXML" ? EuiTextArea : EuiFieldText;
 
-    return <RuleFormSection title="RULE CONTENT">
+    return <RuleFormSection title="RULE CONTENT" additionalInfo={
+      ruleData.updatedAt &&
+      <LastUpdated lastUpdated={ruleData.updatedAt} />
+    }>
         <LineBreak/>
         <EuiFlexItem>
           <EuiFormLabel>Rule type</EuiFormLabel>

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -17,6 +17,7 @@ import styled from "@emotion/styled";
 import {capitalize} from "lodash";
 import { ReasonModal } from "./modals/Reason";
 import {TagMap} from "./hooks/useTags";
+import { useDebouncedValue } from "./hooks/useDebounce";
 
 export type PartiallyUpdateRuleData = (partialReplacement: Partial<DraftRule>) => void;
 
@@ -42,6 +43,7 @@ const SpinnerContainer = styled.div`
 `;
 
 const emptyPatternFieldError = {key: 'pattern', message: 'A pattern is required'}
+const formDebounceMs = 1000;
 
 export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
         tags: TagMap,
@@ -50,9 +52,10 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
         onUpdate: (id: number) => void
     }) => {
     const [showErrors, setShowErrors] = useState(false);
-    const { isLoading, errors, rule, isPublishing, publishRule, fetchRule, updateRule, createRule, validateRule, publishValidationErrors, resetPublishValidationErrors, archiveRule, unarchiveRule, unpublishRule, ruleState } = useRule(ruleId);
+    const { isLoading, errors, rule, isPublishing, publishRule, updateRule, createRule, validateRule, publishValidationErrors, resetPublishValidationErrors, archiveRule, unarchiveRule, unpublishRule, ruleState } = useRule(ruleId);
     const [ruleFormData, setRuleFormData] = useState(rule?.draft ?? baseForm)
-    const [ formErrors, setFormErrors ] = useState<FormError[]>([]);
+    const debouncedFormData = useDebouncedValue(ruleFormData, 1000);
+    const [formErrors, setFormErrors] = useState<FormError[]>([]);
     const [isReasonModalVisible, setIsReasonModalVisible] = useState(false);
 
     const partiallyUpdateRuleData: PartiallyUpdateRuleData = (partialReplacement) => {
@@ -83,22 +86,25 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
         }
     }, [errors])
 
-    // We need the errors at the form level, so that we can prevent save etc. when there are errors
-    // We need to be able to change the errors depending on which fields are invalid
-    // We need to be able to show errors on a field by field basis
+    /**
+     * Automatically save the form data when it changes. Debounces saves.
+     */
+    useEffect(() => {
+      if (debouncedFormData === rule?.draft) {
+        return;
+      }
 
-    const saveRuleHandler = async () => {
-      if(formErrors.length > 0 || errors && errors.length > 0) {
+      if (formErrors.length > 0 || errors && errors.length > 0) {
           setShowErrors(true);
           return;
       }
 
-      const response = await (ruleId ? updateRule(ruleFormData) : createRule(ruleFormData));
-
-      if (response.status === "ok" && response.data.id) {
-        onUpdate(response.data.id);
-      }
-    };
+      (ruleId ? updateRule(ruleFormData) : createRule(ruleFormData)).then(response => {
+        if (response.status === "ok" && response.data.id) {
+          onUpdate(response.data.id);
+        }
+      });
+    }, [debouncedFormData]);
 
     const maybePublishRuleHandler = () => {
       if (rule?.live.length) {

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -164,6 +164,7 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
     }
 
     const hasUnsavedChanges = ruleFormData !== rule?.draft;
+    const canEditRuleContent = ruleState === 'draft' || ruleState === 'live';
 
     return <EuiForm component="form">
         {isLoading && <SpinnerOverlay><SpinnerOuter><SpinnerContainer><EuiLoadingSpinner /></SpinnerContainer></SpinnerOuter></SpinnerOverlay>}
@@ -171,8 +172,9 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
             <RuleContent ruleData={ruleFormData} partiallyUpdateRuleData={partiallyUpdateRuleData} showErrors={showErrors}/>
             <RuleMetadata tags={tags} ruleData={ruleFormData} partiallyUpdateRuleData={partiallyUpdateRuleData} />
             {rule && <RuleHistory ruleHistory={rule.live} />}
+            <EuiFlexGroup gutterSize="m">
             {
-                ruleState === 'draft' || ruleState === 'live' ? <EuiFlexGroup gutterSize="m">
+                canEditRuleContent &&
                     <EuiFlexItem>
                         <EuiButton onClick={() => {
                             const shouldClose = hasUnsavedChanges
@@ -185,40 +187,42 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
                             setRuleFormData(baseForm);
                         }}>Close</EuiButton>
                     </EuiFlexItem>
+            }
+            {
+                ruleState === 'archived' &&
                     <EuiFlexItem>
-                        <EuiButton fill={true} isDisabled={!hasUnsavedChanges} isLoading={isLoading}
-                                   onClick={saveRuleHandler}>{ruleId ? "Update Rule" : "Save Rule"}</EuiButton>
+                        <EuiButton onClick={unarchiveRuleHandler} color={"danger"} disabled={!ruleId || isLoading}>
+                            Unarchive Rule
+                        </EuiButton>
                     </EuiFlexItem>
+            }
+            {
+                ruleState === 'draft' &&
+                    <EuiFlexItem>
+                        <EuiButton onClick={archiveRuleHandler} color={"danger"} disabled={!ruleId || isLoading}>
+                            Archive Rule
+                        </EuiButton>
+                    </EuiFlexItem>
+            }
+            {
+                ruleState === 'live' &&
+                    <EuiFlexItem>
+                        <EuiButton onClick={unpublishRuleHandler} color={"danger"} disabled={!ruleId || isLoading}>
+                            Unpublish Rule
+                        </EuiButton>
+                    </EuiFlexItem>
+            }
+            {
+                canEditRuleContent &&
                     <EuiFlexItem>
                         <PublishTooltip>
                             <EuiButton fill={true} disabled={!ruleId || isLoading || !!publishValidationErrors}
-                                       isLoading={isPublishing}
-                                       onClick={maybePublishRuleHandler}>{"Publish"}</EuiButton>
+                                        isLoading={isPublishing}
+                                        onClick={maybePublishRuleHandler}>{"Publish"}</EuiButton>
                         </PublishTooltip>
                     </EuiFlexItem>
-                </EuiFlexGroup> : null
             }
-            {
-                ruleState === 'archived' ? <EuiFlexItem grow={0}>
-                    <EuiButton onClick={unarchiveRuleHandler} color={"danger"} disabled={!ruleId || isLoading}>
-                        Unarchive Rule
-                    </EuiButton>
-                </EuiFlexItem> : null
-            }
-            {
-                ruleState === 'draft' ? <EuiFlexItem grow={0}>
-                    <EuiButton onClick={archiveRuleHandler} color={"danger"} disabled={!ruleId || isLoading}>
-                        Archive Rule
-                    </EuiButton>
-                </EuiFlexItem> : null
-            }
-            {
-                ruleState === 'live' ? <EuiFlexItem grow={0}>
-                    <EuiButton onClick={unpublishRuleHandler} color={"danger"} disabled={!ruleId || isLoading}>
-                        Unpublish Rule
-                    </EuiButton>
-                </EuiFlexItem> : null
-            }
+            </EuiFlexGroup>
             {showErrors ? <EuiCallOut title="Please resolve the following errors:" color="danger" iconType="error">
                 {formErrors.map((error, index) => <EuiText key={index}>{`${error.message}`}</EuiText>)}
             </EuiCallOut> : null}

--- a/apps/rule-manager/client/src/ts/components/RuleFormSection.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleFormSection.tsx
@@ -1,8 +1,20 @@
-import { EuiFlexItem } from "@elastic/eui"
+import { EuiFlexItem, EuiTextColor } from "@elastic/eui"
 import { css } from "@emotion/react"
+import styled from "@emotion/styled"
 import React from "react"
 
-export const RuleFormSection = ({title, children} : {title?: string, children: JSX.Element | JSX.Element[]}) => {
+const SectionHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const Title = styled.h2`
+  font-family: 'Guardian Agate Sans';
+  color: #1A1C21;
+  font-weight: 700;
+`
+
+export const RuleFormSection = ({title, additionalInfo, children} : {title?: string, additionalInfo?: React.ReactNode, children: JSX.Element | JSX.Element[]}) => {
     return <EuiFlexItem css={css`
             background-color: #D3DAE6;
             padding-top: 12px;
@@ -11,13 +23,10 @@ export const RuleFormSection = ({title, children} : {title?: string, children: J
             padding-right: 12px;
             border-radius: 4px;
         `}>
-        {
-            title ? <h2 style={{
-                fontFamily: 'Guardian Agate Sans',
-                color: '#1A1C21',
-                fontWeight: '700',
-            }}>{title}</h2> : null
-        }
+        <SectionHeader>
+            {title && <Title>{title}</Title>}
+            {additionalInfo && <EuiTextColor color="subdued">{additionalInfo}</EuiTextColor>}
+        </SectionHeader>
         {children}
     </EuiFlexItem>
 }

--- a/apps/rule-manager/client/src/ts/components/hooks/useDebounce.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useDebounce.ts
@@ -1,0 +1,16 @@
+import React, { useState, useEffect } from 'react';
+
+/**
+ * Debounce changes to the given value, returning the debounced value.
+ */
+export const useDebouncedValue = <T>(value: T, timeoutMs: number): T => {
+    const [state, setState] = useState(value);
+
+    useEffect(() => {
+        const handler = setTimeout(() => setState(value), timeoutMs);
+
+        return () => clearTimeout(handler);
+    }, [value, timeoutMs]);
+
+    return state;
+}

--- a/apps/rule-manager/client/src/ts/components/hooks/usePeriodicRefresh.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/usePeriodicRefresh.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 /**
- * Force a re-render for the given period.
+ * Force a re-render every given interval.
  */
 export const usePeriodicRefresh = (periodInMs: number) => {
   const [_, setTime] = useState(Date.now());

--- a/apps/rule-manager/client/src/ts/components/hooks/usePeriodicRefresh.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/usePeriodicRefresh.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Force a re-render for the given period.
+ */
+export const usePeriodicRefresh = (periodInMs: number) => {
+  const [_, setTime] = useState(Date.now());
+
+  useEffect(() => {
+    const interval = setInterval(() => setTime(Date.now()), periodInMs);
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+};


### PR DESCRIPTION
## What does this change?

Adds autosave on rule edit for every field. Adds 'updated at' text that's refreshed on update, and periodically rerendered to ensure it doesn't get stale.

![real-time-updates](https://github.com/guardian/typerighter/assets/7767575/78428d42-d6f5-4027-8da6-a945534b5b42)

Removes the 'update' button, which is no longer needed.

## How to test

Have a go at editing a rule. It should update as expected after a short delay, and the updated time should change as expected, even when not editing (currently it refreshes every 10 seconds, which felt about right, not too distracting!)
