### PR TITLE
Hide refresh button and make message scary

### DIFF
--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -206,11 +206,15 @@ const RulesTable = () => {
           <h1>Current rules</h1>
         </EuiTitle>
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiButton size="s" fill={true} color={"primary"} onClick={handleRefreshRules} isLoading={isRefreshing}>
-          Refresh{isRefreshing ? "ing" : ""} rules
-        </EuiButton>
-      </EuiFlexItem>
+      {
+        getFeatureSwitchValue("enable-destructive-reload") ?
+          <EuiFlexItem grow={false}>
+            <EuiButton size="s" fill={true} color={"danger"} onClick={handleRefreshRules} isLoading={isRefreshing}>
+              <strong>Destroy all rules in the manager and reload from the original Google Sheet</strong>
+            </EuiButton>
+          </EuiFlexItem> : 
+          null
+      }
     </EuiFlexGroup>
     <EuiFlexGrid>
       {error &&

--- a/apps/rule-manager/client/src/ts/components/context/featureSwitches.tsx
+++ b/apps/rule-manager/client/src/ts/components/context/featureSwitches.tsx
@@ -13,6 +13,11 @@ const allFeatureSwitches = [
     id: "create-and-edit",
     default: false,
   },
+  {
+    name: "Enable destructive reload from rules sheet",
+    id: "enable-destructive-reload",
+    default: false,
+  },
 ] as const;
 
 type FeatureSwitchIds = (typeof allFeatureSwitches)[number]["id"];


### PR DESCRIPTION
## What does this change?

This hides the 'Refresh rules' button behind a feature switch, adding a scary new message with a scary red background ☠️

Collectively these two changes should make it very unlikely anyone will click the button accidentally.

We'll remove the button altogether once the tool is being used universally instead of the sheet.

## How to test

1. Run the manager locally according to the instructions in the readme.
2. Enabled the 'Enable destructive reload from rules sheet' feature switch in the top right dropdown menu
3. Can you refresh the rules via the scary button?

## Images

![image](https://github.com/guardian/typerighter/assets/34686302/6e581cf7-0f20-4f83-a257-ee5e2afc8d10)
