### PR TITLE
Rejig rule table

### DIFF
--- a/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
@@ -25,7 +25,7 @@ export const CategorySelector = ({currentCategory, partiallyUpdateRuleData}: {
     }, [selectedCategory])
 
     return (
-        <EuiFormRow label='Category' fullWidth={true}>
+        <EuiFormRow label='Source' fullWidth={true}>
             <EuiComboBox
                 options={categories}
                 singleSelection={singleSelectionOptions}

--- a/apps/rule-manager/client/src/ts/components/RuleContent.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleContent.tsx
@@ -39,7 +39,17 @@ export const RuleContent = ({ruleData, ruleFormData, isLoading, errors, partiall
       additionalInfo={ruleData && <RuleDataLastUpdated ruleData={ruleData} isLoading={isLoading} hasErrors={!!errors} />}>
         <LineBreak/>
         <EuiFlexItem>
-          <EuiFormLabel>Rule type</EuiFormLabel>
+            <EuiFormRow
+                label="Description"
+                helpText="What will the users see in Composer?"
+                fullWidth={true}
+            >
+                <EuiFieldText value={ruleFormData.description || ""}
+                              onChange={(_ => partiallyUpdateRuleData({description: _.target.value}))}
+                              fullWidth={true}/>
+            </EuiFormRow>
+            <EuiSpacer size="m" />
+            <EuiFormLabel>Rule type</EuiFormLabel>
             <EuiRadioGroup
                 options={ruleTypeOptions}
                 idSelected={ruleFormData.ruleType}
@@ -73,15 +83,6 @@ export const RuleContent = ({ruleData, ruleFormData, isLoading, errors, partiall
             >
                 <EuiFieldText value={ruleFormData.replacement || ""}
                               onChange={(_ => partiallyUpdateRuleData({replacement: _.target.value}))}
-                              fullWidth={true} />
-            </EuiFormRow>
-            <EuiFormRow
-                label="Description"
-                helpText="What will the users see in Composer?"
-                fullWidth={true}
-            >
-                <EuiFieldText value={ruleFormData.description || ""}
-                              onChange={(_ => partiallyUpdateRuleData({description: _.target.value}))}
                               fullWidth={true} />
             </EuiFormRow>
         </EuiFlexItem>

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -55,7 +55,7 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
         onUpdate: (id: number) => void
     }) => {
     const [showErrors, setShowErrors] = useState(false);
-    const { isLoading, errors, rule, isPublishing, publishRule, updateRule, createRule, validateRule, publishValidationErrors, resetPublishValidationErrors, archiveRule, unarchiveRule, unpublishRule, ruleState } = useRule(ruleId);
+    const { isLoading, errors, rule, isPublishing, publishRule, updateRule, createRule, validateRule, publishValidationErrors, resetPublishValidationErrors, archiveRule, unarchiveRule, unpublishRule, ruleStatus } = useRule(ruleId);
     const [ruleFormData, setRuleFormData] = useState(rule?.draft ?? baseForm)
     const debouncedFormData = useDebouncedValue(ruleFormData, 1000);
     const [formErrors, setFormErrors] = useState<FormError[]>([]);
@@ -118,7 +118,7 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
     }
 
     const publishRuleHandler = async (reason: string) => {
-      const isDraftOrLive = (ruleState === 'draft' || ruleState === 'live')
+      const isDraftOrLive = (ruleStatus === 'draft' || ruleStatus === 'live')
       if (!ruleId || !isDraftOrLive) {
         return;
       }
@@ -146,7 +146,7 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
     }
 
     const archiveRuleHandler = async () => {
-        if (!ruleId || ruleState !== 'draft') {
+        if (!ruleId || ruleStatus !== 'draft') {
           return;
         }
 
@@ -155,7 +155,7 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
     }
 
     const unarchiveRuleHandler = async () => {
-        if (!ruleId || ruleState !== 'archived') {
+        if (!ruleId || ruleStatus !== 'archived') {
             return;
         }
 
@@ -164,7 +164,7 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
     }
 
     const unpublishRuleHandler = async () => {
-        if (!ruleId || ruleState !== 'live') {
+        if (!ruleId || ruleStatus !== 'live') {
             return;
         }
 
@@ -173,7 +173,7 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
     }
 
     const hasUnsavedChanges = ruleFormData !== rule?.draft;
-    const canEditRuleContent = ruleState === 'draft' || ruleState === 'live';
+    const canEditRuleContent = ruleStatus === 'draft' || ruleStatus === 'live';
 
     return <EuiForm component="form">
         {<EuiFlexGroup gutterSize="m" direction="column">
@@ -203,7 +203,7 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
                     </EuiFlexItem>
             }
             {
-                ruleState === 'archived' &&
+                ruleStatus === 'archived' &&
                     <EuiFlexItem>
                         <EuiButton onClick={unarchiveRuleHandler} color={"danger"} disabled={!ruleId || isLoading}>
                             Unarchive Rule
@@ -211,7 +211,7 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
                     </EuiFlexItem>
             }
             {
-                ruleState === 'draft' &&
+                ruleStatus === 'draft' &&
                     <EuiFlexItem>
                         <EuiButton onClick={archiveRuleHandler} color={"danger"} disabled={!ruleId || isLoading}>
                             Archive Rule
@@ -219,7 +219,7 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
                     </EuiFlexItem>
             }
             {
-                ruleState === 'live' &&
+                ruleStatus === 'live' &&
                     <EuiFlexItem>
                         <EuiButton onClick={unpublishRuleHandler} color={"danger"} disabled={!ruleId || isLoading}>
                             Unpublish Rule

--- a/apps/rule-manager/client/src/ts/components/RuleStatus.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleStatus.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {RuleData} from "./hooks/useRule";
 import {RuleFormSection} from "./RuleFormSection";
 import {capitalize} from "lodash";
-import {getRuleState, getRuleStateColour, hasUnpublishedChanges} from "../utils/rule";
+import {getRuleStatus, getRuleStatusColour, hasUnpublishedChanges} from "../utils/rule";
 import {EuiButton, EuiHealth, EuiText, EuiTextColor} from "@elastic/eui";
 import {css} from "@emotion/react";
 import {euiTextTruncate} from "@elastic/eui/src/global_styling/mixins/_typography";
@@ -16,13 +16,13 @@ const UnpublishedChangesContainer = styled.div`display: flex; align-items: cente
 export const RuleStatus = ({ruleData}: {
   ruleData: RuleData | undefined
 }) => {
-  const state = capitalize(getRuleState(ruleData?.draft));
+  const state = capitalize(getRuleStatus(ruleData?.draft));
   return <RuleFormSection title="RULE STATUS" additionalInfo={
     !!ruleData && hasUnpublishedChanges(ruleData) && "Has unpublished changes"}>
     <LineBreak/>
     <RuleStatusContainer>
       <AnotherContainer>
-        <EuiHealth textSize="m" color={getRuleStateColour(ruleData?.draft)} />
+        <EuiHealth textSize="m" color={getRuleStatusColour(ruleData?.draft)} />
         <EuiText css={css`${euiTextTruncate()}`}>{state}</EuiText>
       </AnotherContainer>
 

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -25,7 +25,7 @@ import {hasCreateEditPermissions} from './helpers/hasCreateEditPermissions';
 import styled from '@emotion/styled';
 import {FeatureSwitchesContext} from "./context/featureSwitches";
 import {DraftRule} from "./hooks/useRule";
-import {getRuleState, getRuleStateColour} from "../utils/rule";
+import {getRuleStatus, getRuleStatusColour} from "../utils/rule";
 import {capitalize} from "lodash";
 import {euiTextTruncate} from "@elastic/eui/src/global_styling/mixins/_typography";
 import {TagMap, useTags} from "./hooks/useTags";
@@ -60,47 +60,50 @@ const createColumns = (tags: TagMap, editRule: (ruleId: number) => void): Array<
   const hasEditPermissions = useCreateEditPermissions();
   return [
     {
-      field: 'replacement',
-      name: 'Replacement',
-      width: '14.2%'
-    },
-    {
       field: 'description',
       name: 'Description',
-      textOnly: true,
       truncateText: true,
+      render: (value: string) => !!value ? value : '–',
       width: '21.4%'
     },
     {
       field: 'pattern',
-      name: 'Match',
+      name: 'Pattern',
       truncateText: true,
+      render: (value: string) => !!value ? value : '–',
       width: '21.4%'
     },
     {
+      field: 'replacement',
+      name: 'Replacement',
+      render: (value: string) => !!value ? value : '–',
+      width: '14.2%'
+    },
+    {
       field: 'category',
-      name: 'Rule source',
+      name: 'Source',
+      render: (value: string) => !!value ? value : '–',
       width: '14.2%'
     },
     {
       field: 'tags',
       name: 'Tags',
-      render: (value: number[]) => value ?
+      render: (value: number[]) => value && value.length > 0 ?
         <TagWrapContainer>{value.map(tagId =>
           <span style={{width: '100%'}} key={tagId}>
             <EuiBadge>{tags[tagId.toString()]?.name ?? "Unknown tag"}</EuiBadge>
           </span>
-        )}</TagWrapContainer> : <></>,
+        )}</TagWrapContainer> : <>–</>,
       width: '13.2%'
     },
     {
-      name: 'State',
+      name: 'Status',
       width: '8.1%',
       render: (rule: DraftRule) => {
-        const state = capitalize(getRuleState(rule));
+        const status = capitalize(getRuleStatus(rule));
         return <>
-          <EuiHealth color={getRuleStateColour(rule)} />
-          <EuiText css={css`${euiTextTruncate()}`}>{state}</EuiText>
+          <EuiHealth color={getRuleStatusColour(rule)} />
+          <EuiText css={css`${euiTextTruncate()}`}>{status}</EuiText>
         </>
       }
     },
@@ -249,8 +252,8 @@ const RulesTable = () => {
         {rules &&
           <EuiInMemoryTable
             rowProps={getRowProps}
-	css={css`.euiTableRow.euiTableRow-isSelected { background-color: rgba(0, 119, 204, 0.1); }`}
-        loading={isLoading}
+	        css={css`.euiTableRow.euiTableRow-isSelected { background-color: rgba(0, 119, 204, 0.1); }`}
+            loading={isLoading}
             tableCaption="Demo of EuiInMemoryTable"
             items={rules}
             itemId="id"

--- a/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
@@ -2,7 +2,7 @@ import {useEffect, useState} from "react";
 import {ErrorIResponse, responseHandler} from "../../utils/api";
 import { errorToString } from "../../utils/error";
 import { FormError } from "../RuleForm";
-import {getRuleState, RuleState} from "../../utils/rule";
+import {getRuleStatus, RuleStatus} from "../../utils/rule";
 
 export type RuleType = 'regex' | 'languageToolXML';
 
@@ -43,7 +43,7 @@ export function useRule(ruleId: number | undefined) {
   const [publishValidationErrors, setPublishValidationErrors] = useState<FormError[] | undefined>(undefined);
   const [errors, setErrors] = useState<string | undefined>(undefined);
   const [ruleData, setRuleData] = useState<RuleData | undefined>(undefined);
-  const [ruleState, setRuleState] = useState<RuleState>("draft")
+  const [ruleStatus, setRuleStatus] = useState<RuleStatus>("draft")
 
   const setRuleDataAndClearErrors = (ruleData: RuleData) => {
     setRuleData(ruleData);
@@ -239,8 +239,8 @@ export function useRule(ruleId: number | undefined) {
   }, [ruleId])
 
   useEffect(() => {
-    setRuleState(getRuleState(ruleData?.draft));
+    setRuleStatus(getRuleStatus(ruleData?.draft));
   }, [ruleData])
 
-  return { fetchRule, updateRule, createRule, isLoading, errors, rule: ruleData, publishRule, isPublishing, validateRule, isValidating, publishValidationErrors, resetPublishValidationErrors, archiveRule, unarchiveRule, unpublishRule, ruleState }
+  return { fetchRule, updateRule, createRule, isLoading, errors, rule: ruleData, publishRule, isPublishing, validateRule, isValidating, publishValidationErrors, resetPublishValidationErrors, archiveRule, unarchiveRule, unpublishRule, ruleStatus }
 }

--- a/apps/rule-manager/client/src/ts/utils/rule.ts
+++ b/apps/rule-manager/client/src/ts/utils/rule.ts
@@ -1,9 +1,9 @@
 import {DraftRule, RuleData} from "../components/hooks/useRule";
 import {IconColor} from "@elastic/eui/src/components/icon";
 
-export type RuleState = "live" | "archived" | "draft" | "error";
+export type RuleStatus = "live" | "archived" | "draft" | "error";
 
-export const getRuleState = (rule: DraftRule | undefined): RuleState => {
+export const getRuleStatus = (rule: DraftRule | undefined): RuleStatus => {
   if(!rule) {
     return "draft";
   }
@@ -23,10 +23,10 @@ export const getRuleState = (rule: DraftRule | undefined): RuleState => {
   return "draft"
 }
 
-export const getRuleStateColour = (rule: DraftRule | undefined): IconColor =>
-  rule ? stateToColourMap[getRuleState(rule)] : stateToColourMap.draft;
+export const getRuleStatusColour = (rule: DraftRule | undefined): IconColor =>
+  rule ? statusToColourMap[getRuleStatus(rule)] : statusToColourMap.draft;
 
-const stateToColourMap: {[state in RuleState]: IconColor} = {
+const statusToColourMap: {[status in RuleStatus]: IconColor} = {
   error: "danger",
   live: "success",
   archived: "danger",


### PR DESCRIPTION
## What does this change?

_Apologies for the one commit - Git wreaked havoc on my commit history, and I haven't the heart to go back over my commits and rebase._

![image](https://github.com/guardian/typerighter/assets/40991816/e1e65dc1-47f8-4338-b03b-c1c3d00171ef)

This PR tweaks the order of the fields -> "Description", "Pattern", "Replacement" in the form, and in the table. We feel the order should be like this because:

- Description best describes a rule, and is always present
- Match is always present, and reading left to right from ‘match’ to ‘replacement’ makes sense
- Replacement is not always present

We have also renamed some fields, and added some handling for empty fields (here we now display 'em dash': –)

## How to test

Is the form and table more consistent? Do the changes make sense?


