### PR TITLE
Surface 'unpublished changes' status in table

### DIFF
--- a/apps/rule-manager/client/src/ts/components/RuleStatus.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleStatus.tsx
@@ -3,7 +3,7 @@ import {RuleData} from "./hooks/useRule";
 import {RuleFormSection} from "./RuleFormSection";
 import {capitalize} from "lodash";
 import {getRuleStatus, getRuleStatusColour, hasUnpublishedChanges} from "../utils/rule";
-import {EuiButton, EuiHealth, EuiText, EuiTextColor} from "@elastic/eui";
+import {EuiFlexGroup, EuiHealth, EuiIcon, EuiText} from "@elastic/eui";
 import {css} from "@emotion/react";
 import {euiTextTruncate} from "@elastic/eui/src/global_styling/mixins/_typography";
 import styled from "@emotion/styled";
@@ -18,14 +18,13 @@ export const RuleStatus = ({ruleData}: {
 }) => {
   const state = capitalize(getRuleStatus(ruleData?.draft));
   return <RuleFormSection title="RULE STATUS" additionalInfo={
-    !!ruleData && hasUnpublishedChanges(ruleData) && "Has unpublished changes"}>
+    !!ruleData && hasUnpublishedChanges(ruleData) && <EuiFlexGroup gutterSize="s">Has unpublished changes<EuiIcon type="warning" /></EuiFlexGroup>}>
     <LineBreak/>
     <RuleStatusContainer>
       <AnotherContainer>
         <EuiHealth textSize="m" color={getRuleStatusColour(ruleData?.draft)} />
         <EuiText css={css`${euiTextTruncate()}`}>{state}</EuiText>
       </AnotherContainer>
-
     </RuleStatusContainer>
   </RuleFormSection>
 }

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -14,8 +14,7 @@ import {
   EuiHealth,
   EuiTableSelectionType,
   EuiBadge,
-  EuiText,
-  EuiTableRow
+  EuiText
 } from '@elastic/eui';
 import {useRules} from "./hooks/useRules";
 import {css} from "@emotion/react";
@@ -100,11 +99,15 @@ const createColumns = (tags: TagMap, editRule: (ruleId: number) => void): Array<
       name: 'Status',
       width: '8.1%',
       render: (rule: DraftRule) => {
-        const status = capitalize(getRuleStatus(rule));
-        return <>
-          <EuiHealth color={getRuleStatusColour(rule)} />
-          <EuiText css={css`${euiTextTruncate()}`}>{status}</EuiText>
-        </>
+        const state = capitalize(getRuleStatus(rule));
+        return <EuiFlexGroup alignItems="center" gutterSize="xs">
+          <EuiFlexGroup alignItems="center" justifyContent="flexStart" gutterSize="none">
+            <EuiHealth color={getRuleStatusColour(rule)} />
+            <EuiText css={css`${euiTextTruncate()}`}>{state}</EuiText>
+          </EuiFlexGroup>
+          {rule.hasUnpublishedChanges &&
+            <EuiToolTip content="This rule has unpublished changes"><EuiIcon type="warning" /></EuiToolTip>}
+        </EuiFlexGroup>
       }
     },
     {

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -100,13 +100,11 @@ const createColumns = (tags: TagMap, editRule: (ruleId: number) => void): Array<
       width: '8.1%',
       render: (rule: DraftRule) => {
         const state = capitalize(getRuleStatus(rule));
-        return <EuiFlexGroup alignItems="center" gutterSize="xs">
-          <EuiFlexGroup alignItems="center" justifyContent="flexStart" gutterSize="none">
-            <EuiHealth color={getRuleStatusColour(rule)} />
-            <EuiText css={css`${euiTextTruncate()}`}>{state}</EuiText>
-          </EuiFlexGroup>
+        return <EuiFlexGroup alignItems="center" justifyContent="flexStart" gutterSize="none">
+          <EuiHealth color={getRuleStatusColour(rule)} />
+          <EuiText css={css`${euiTextTruncate()}`}>{state}</EuiText>
           {rule.hasUnpublishedChanges &&
-            <EuiToolTip content="This rule has unpublished changes"><EuiIcon type="warning" /></EuiToolTip>}
+            <>&nbsp;&nbsp;<EuiToolTip content="This rule has unpublished changes"><EuiIcon type="warning" /></EuiToolTip></>}
         </EuiFlexGroup>
       }
     },

--- a/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
@@ -23,7 +23,8 @@ export type BaseRule = {
   updatedAt: string,
   id?: number,
   isArchived: boolean,
-  isPublished: boolean
+  isPublished: boolean,
+  hasUnpublishedChanges: boolean
 }
 
 export type DraftRule = BaseRule

--- a/apps/rule-manager/test/db/DraftRulesSpec.scala
+++ b/apps/rule-manager/test/db/DraftRulesSpec.scala
@@ -28,6 +28,29 @@ class DraftRulesSpec extends RuleFixture with Matchers with DBTest {
     foundAndPublished.isPublished should be(true)
   }
 
+  it should "find by primary keys and return unpublished changes status - false, unpublished" in {
+    implicit session =>
+      val found = DbRuleDraft.find(1).get
+      found.hasUnpublishedChanges should be(false)
+  }
+
+  it should "find by primary keys and return unpublished changes status - false, published" in {
+    implicit session =>
+      val found = DbRuleDraft.find(1).get
+      DbRuleLive.create(found.toLive("reason"), "user")
+      val foundAndPublished = DbRuleDraft.find(1).get
+      foundAndPublished.hasUnpublishedChanges should be(false)
+  }
+
+  it should "find by primary keys and return unpublished changes status - true" in {
+    implicit session =>
+      val found = DbRuleDraft.find(1).get
+      DbRuleLive.create(found.toLive("reason"), "user")
+      val foundAndPublished =
+        DbRuleDraft.save(found.copy(description = Some("updated")), "test.user").get
+      foundAndPublished.hasUnpublishedChanges should be(true)
+  }
+
   it should "find all records and return published status" in { implicit session =>
     val toBePublished = DbRuleDraft
       .create(ruleType = "regex", pattern = Some("2"), user = "test.user", ignore = false)

--- a/apps/rule-manager/test/db/RuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/RuleManagerSpec.scala
@@ -371,7 +371,7 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
       val secondLiveRule =
         RuleManager.publishRule(ruleToPublish.id.get, user, reason, bucketRuleResource).toOption.get
 
-      secondLiveRule.draft shouldMatchTo revisedRuleToPublish
+      secondLiveRule.draft shouldMatchTo revisedRuleToPublish.copy(hasUnpublishedChanges = false)
       secondLiveRule.live shouldMatchTo List(
         secondLiveRule.live(0),
         firstLiveRule.live(0).copy(isActive = false)


### PR DESCRIPTION
## What does this change?

Surface the 'unpublished changes' status in the rules table, as well as the rule form:
- Adds an icon to both to make the meaning of the symbol clear
- There's a tooltip on hover to explain what the icon is.

<img width="1707" alt="Screenshot 2023-07-05 at 12 51 02" src="https://github.com/guardian/typerighter/assets/7767575/b72378df-8d85-4de5-b3e6-c577e0db36cc">

One thing to note – at the moment, the icon won't appear in the table until the rules table refreshes. 

We don't refresh the rule table on every update in real-time mode, as it's currently 8MB of JSON, and we don't want to be fetching and parsing that every few seconds. There's a question as to how we keep in sync which probably involves optimistically updating the rule list on update. We could implement that in this PR if we felt that behaviour was a blocker.

## How to test

- Automated tests should pass
- Have a play. Does the new icon appear as expected in the table?
