### PR TITLE
Pass loading state to tag selector, rather than inferring loading via empty list

### DIFF
--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -48,8 +48,9 @@ export const SpinnerContainer = styled.div`
 const formDebounceMs = 1000;
 export const emptyPatternFieldError = {key: 'pattern', message: 'A pattern is required'}
 
-export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
+export const RuleForm = ({tags, ruleId, onClose, onUpdate, isTagMapLoading}: {
         tags: TagMap,
+        isTagMapLoading: boolean,
         ruleId: number | undefined,
         onClose: () => void,
         onUpdate: (id: number) => void
@@ -57,7 +58,7 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
     const [showErrors, setShowErrors] = useState(false);
     const { isLoading, errors, rule, isPublishing, publishRule, updateRule, createRule, validateRule, publishValidationErrors, resetPublishValidationErrors, archiveRule, unarchiveRule, unpublishRule, ruleStatus } = useRule(ruleId);
     const [ruleFormData, setRuleFormData] = useState(rule?.draft ?? baseForm)
-    const debouncedFormData = useDebouncedValue(ruleFormData, 1000);
+    const debouncedFormData = useDebouncedValue(ruleFormData, formDebounceMs);
     const [formErrors, setFormErrors] = useState<FormError[]>([]);
     const [isReasonModalVisible, setIsReasonModalVisible] = useState(false);
 
@@ -184,7 +185,7 @@ export const RuleForm = ({tags, ruleId, onClose, onUpdate}: {
                 <RuleFormSection title="RULE METADATA">
                   <LineBreak/>
                   <CategorySelector currentCategory={ruleFormData.category} partiallyUpdateRuleData={partiallyUpdateRuleData} />
-                  <TagsSelector tags={tags} selectedTagIds={ruleFormData.tags} partiallyUpdateRuleData={partiallyUpdateRuleData} />
+                  <TagsSelector tags={tags} isLoading={isTagMapLoading} selectedTagIds={ruleFormData.tags} partiallyUpdateRuleData={partiallyUpdateRuleData} />
                 </RuleFormSection>
                 {rule && <RuleHistory ruleHistory={rule.live} />}
               </EuiFlexGroup>

--- a/apps/rule-manager/client/src/ts/components/RuleFormBatchEdit.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleFormBatchEdit.tsx
@@ -18,8 +18,9 @@ import {LineBreak} from "./LineBreak";
 import {CategorySelector} from "./CategorySelector";
 import {TagsSelector} from "./TagsSelector";
 
-export const RuleFormBatchEdit = ({tags, ruleIds, onClose, onUpdate}: {
+export const RuleFormBatchEdit = ({tags, ruleIds, onClose, onUpdate, isTagMapLoading}: {
     tags: TagMap,
+    isTagMapLoading: boolean,
     ruleIds: number[],
     onClose: () => void,
     onUpdate: () => void
@@ -70,7 +71,7 @@ export const RuleFormBatchEdit = ({tags, ruleIds, onClose, onUpdate}: {
             <RuleFormSection title="RULE METADATA">
               <LineBreak/>
               <CategorySelector currentCategory={ruleFormData[0]?.category} partiallyUpdateRuleData={partiallyUpdateRuleData} />
-              <TagsSelector tags={tags} selectedTagIds={uniqueTagIds} partiallyUpdateRuleData={partiallyUpdateRuleData} />
+              <TagsSelector tags={tags} isLoading={isTagMapLoading} selectedTagIds={uniqueTagIds} partiallyUpdateRuleData={partiallyUpdateRuleData} />
             </RuleFormSection>
             <EuiFlexGroup gutterSize="m">
                 <EuiFlexItem>

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -151,7 +151,7 @@ const EditRuleButton = styled.button<EditRuleButtonProps>(props => ({
 }))
 
 const RulesTable = () => {
-  const {tags, fetchTags} = useTags();
+  const {tags, fetchTags, isLoading: isTagMapLoading } = useTags();
   const {rules, isLoading, error, refreshRules, isRefreshing, setError, fetchRules} = useRules();
   const [formMode, setFormMode] = useState<'closed' | 'create' | 'edit'>('closed');
   const [currentRuleId, setCurrentRuleId] = useState<number | undefined>(undefined)
@@ -277,6 +277,7 @@ const RulesTable = () => {
             {selectedRules.length > 1
                 ? <RuleFormBatchEdit
                     tags={tags}
+                    isTagMapLoading={isTagMapLoading}
                     onClose={() => {
                       setFormMode('closed');
                       fetchRules()
@@ -288,6 +289,7 @@ const RulesTable = () => {
                   />
                 : <RuleForm
                     tags={tags}
+                    isTagMapLoading={isTagMapLoading}
                     onClose={() => {
                       setFormMode('closed');
                       fetchRules();

--- a/apps/rule-manager/client/src/ts/components/TagsSelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsSelector.tsx
@@ -6,12 +6,13 @@ import {PartiallyUpdateRuleData} from "./RuleForm";
 
 type TagOption = { label: string, value?: number }
 
-export const TagsSelector = ({tags, selectedTagIds, partiallyUpdateRuleData}: {
+export const TagsSelector = ({tags, selectedTagIds, partiallyUpdateRuleData, isLoading}: {
     tags: TagMap,
     selectedTagIds: number[],
+    isLoading: boolean,
     partiallyUpdateRuleData: PartiallyUpdateRuleData,
 }) => {
-    if (Object.keys(tags).length === 0) {
+    if (isLoading) {
       return <EuiFormRow label='Tags' fullWidth={true}><EuiLoadingSpinner/></EuiFormRow>
     }
 


### PR DESCRIPTION
## What does this change?

Passes loading state to tag selector, rather than inferring loading via empty list, which corrects a bug where when the tool is first loaded without rules or tags, the tag field is populated by a loading indicator (rather than an empty selector.)

## How to test

Run the manager locally with a clean DB. Create a rule. The tags selector should be present, but empty:

<img width="563" alt="Screenshot 2023-07-05 at 13 01 27" src="https://github.com/guardian/typerighter/assets/7767575/1453a740-094b-49f1-ab2a-2d6e0c5cfc43">

