### PR TITLE
t4g.micro -> t4g.small

### DIFF
--- a/cdk/lib/index.ts
+++ b/cdk/lib/index.ts
@@ -94,7 +94,7 @@ export class Typerighter extends GuStack {
 
     const ruleManagerApp = new GuPlayApp(this, {
       app: ruleManagerAppName,
-      instanceType: new InstanceType("t4g.micro"),
+      instanceType: new InstanceType("t4g.small"),
       userData: `#!/bin/bash -ev
         aws --quiet --region ${this.region} s3 cp s3://composer-dist/${this.stack}/${this.stage}/typerighter-rule-manager/typerighter-rule-manager.deb /tmp/package.deb
         dpkg -i /tmp/package.deb`,


### PR DESCRIPTION
## What does this change?

We've had problems with boxes becoming unresponsive and cycling (no logs, hanging SSH sessions.) On inspection, the running program was taking up a significant amount of memory on the `micro` instance, which we think might be the cause:

<img width="1002" alt="Screenshot 2023-07-05 at 17 46 37" src="https://github.com/guardian/typerighter/assets/7767575/ec0f88c2-acb4-439b-a92e-93d941c2a90f">

This PR bumps the instance size for the manager from `micro` to `small`. Since deploying to CODE, I've been unable to replicate the problem, and there's more free memory on the box:

<img width="842" alt="Screenshot 2023-07-05 at 18 17 28" src="https://github.com/guardian/typerighter/assets/7767575/d5f80efb-2fea-4165-89fc-d3eec09feaab">

## How to test

Tested by deploying to CODE. Since then, we haven't had a box cycle – I've given the test box a rinse with apachebench and I can't make it fall over, which is a promising sign (you'll need to replace the cookie with something current):

```
ab -n 100 -c 10 -H 'accept: */*' -H 'accept-language: en-GB,en-US;q=0.9,en;q=0.8' -H 'accept-language: en-GB,en-US;q=0.9,en;q=0.8' -H 'cookie: _ga=GA1.3.545298348.1685975974; _gid=GA1.3.1852050354.1688377328; consentUUID=3cda161a-1282-4683-b81c-3fe8e68de5f5_21; consentDate=2023-07-05T09:26:05.167Z; features.override=dev-mode%3Dtrue; gutoolsAuth-assym=<add your panda cookie here>' -H 'sec-fetch-site: same-origin' -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36' 'https://manager.typerighter.code.dev-gutools.co.uk/rules'
```