### PR TITLE
Add DB instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,17 @@ For intellij there is a guide to set up automated linting on save [here](https:/
 ## Automatic Linting
 
 The project contains a pre-commit hook which will automatically run the linter on all staged files. To enable this, run `./script/setup-hooks` from the root of the project.
+
+## Developer how-tos
+
+### Connecting to the rule-manager database in CODE or PROD
+
+Sometimes it's useful to connect to the databases running in AWS to inspect the data locally.
+
+We can use `ssm-scala` to create an SSH tunnel that exposes the remote database on a local port. For example, to connect to the CODE database, we can run:
+
+```bash
+ssm ssh -x -t typerighter-rule-manager,CODE -p composer --rds-tunnel 5000:rule-manager-db,CODE
+```
+
+You should then be able to connect the database on `localhost:5000`. You'll need to use the username and password specified in [AWS parameter store](https://eu-west-1.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-1&tab=Table) at `/${STAGE}/flexible/typerighter-rule-manager/db.default.username` and `db.default.password`.

--- a/README.md
+++ b/README.md
@@ -100,4 +100,4 @@ ssm ssh -x -t typerighter-rule-manager,CODE -p composer --rds-tunnel 5000:rule-m
 
 You should then be able to connect the database on `localhost:5000`. You'll need to use the username and password specified in [AWS parameter store](https://eu-west-1.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-1&tab=Table) at `/${STAGE}/flexible/typerighter-rule-manager/db.default.username` and `db.default.password`.
 
-Don't forget to kill the connection once you're done! Here's a handy one-liner `kill $(lsof -ti {PORT_NUMBER})`
+Don't forget to kill the connection once you're done! Here's a handy one-liner: `kill $(lsof -ti {PORT_NUMBER})`

--- a/README.md
+++ b/README.md
@@ -99,3 +99,5 @@ ssm ssh -x -t typerighter-rule-manager,CODE -p composer --rds-tunnel 5000:rule-m
 ```
 
 You should then be able to connect the database on `localhost:5000`. You'll need to use the username and password specified in [AWS parameter store](https://eu-west-1.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-1&tab=Table) at `/${STAGE}/flexible/typerighter-rule-manager/db.default.username` and `db.default.password`.
+
+Don't forget to kill the connection once you're done! Here's a handy one-liner `kill $(lsof -ti {PORT_NUMBER})`


### PR DESCRIPTION
## What does this change?

Adds instructions for connecting to a remote DB to the README.

(I've added a few links and params for convenience, but it's nothing that we don't already encode in CDK!)

## How to test

Useful? Anything to add?