### PR TITLE
Add Tags table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules
 /RUNNING_PID
 .DS_Store
 .bsp
+.vscode

--- a/apps/rule-manager/app/controllers/TagsController.scala
+++ b/apps/rule-manager/app/controllers/TagsController.scala
@@ -22,7 +22,15 @@ class TagsController(
     with FormHelpers {
 
   def list = ApiAuthAction {
-    Ok(Json.toJson(Tags.findAll()))
+    val tagsWithRuleCounts = Tags.findAllWithRuleCounts()
+
+    val json = tagsWithRuleCounts.map(tagWithRuleCount => Json.obj(
+      "id" -> tagWithRuleCount.id.get,
+      "name" -> tagWithRuleCount.name,
+      "ruleCount" -> tagWithRuleCount.ruleCount
+    ))
+
+    Ok(Json.toJson(json))
   }
 
   def get(id: Int) = ApiAuthAction {

--- a/apps/rule-manager/app/controllers/TagsController.scala
+++ b/apps/rule-manager/app/controllers/TagsController.scala
@@ -47,6 +47,8 @@ class TagsController(
     Tags.find(id) match {
       case None => NotFound("Tag not found matching ID")
       case Some(tag) =>
+        RuleTagDraft.destroyForTag(tag.id.get)
+        RuleTagLive.destroyForTag(tag.id.get)
         Tags.destroy(tag)
         Ok(s"Tag with id ${tag.id.get} deleted.")
     }

--- a/apps/rule-manager/app/controllers/TagsController.scala
+++ b/apps/rule-manager/app/controllers/TagsController.scala
@@ -24,11 +24,13 @@ class TagsController(
   def listWithRuleCounts = ApiAuthAction {
     val tagsWithRuleCounts = Tags.findAllWithRuleCounts()
 
-    val json = tagsWithRuleCounts.map(tagWithRuleCount => Json.obj(
-      "id" -> tagWithRuleCount.id.get,
-      "name" -> tagWithRuleCount.name,
-      "ruleCount" -> tagWithRuleCount.ruleCount
-    ))
+    val json = tagsWithRuleCounts.map(tagWithRuleCount =>
+      Json.obj(
+        "id" -> tagWithRuleCount.id.get,
+        "name" -> tagWithRuleCount.name,
+        "ruleCount" -> tagWithRuleCount.ruleCount
+      )
+    )
 
     Ok(Json.toJson(json))
   }

--- a/apps/rule-manager/app/controllers/TagsController.scala
+++ b/apps/rule-manager/app/controllers/TagsController.scala
@@ -9,7 +9,7 @@ import play.api.mvc._
 import utils.{DbException, FormHelpers, NotFoundException, PermissionsHandler, RuleManagerConfig}
 
 import scala.util.{Failure, Success}
-import db.Tags
+import db.{RuleTagDraft, RuleTagLive, Tags}
 import db.Tags.format
 
 class TagsController(
@@ -31,6 +31,16 @@ class TagsController(
       case Some(tag) =>
         Ok(Json.toJson(tag))
     }
+  }
+
+  def getRuleCountForAllTags() = ApiAuthAction {
+    val liveTagCounts = RuleTagLive.countRulesForAllTags()
+    val draftTagCounts = RuleTagDraft.countRulesForAllTags()
+    val liveAndDraftTagCounts = Map(
+      "live" -> liveTagCounts,
+      "draft" -> draftTagCounts
+    )
+    Ok(Json.toJson(liveAndDraftTagCounts))
   }
 
   def delete(id: Int) = ApiAuthAction {

--- a/apps/rule-manager/app/controllers/TagsController.scala
+++ b/apps/rule-manager/app/controllers/TagsController.scala
@@ -37,8 +37,8 @@ class TagsController(
     val liveTagCounts = RuleTagLive.countRulesForAllTags()
     val draftTagCounts = RuleTagDraft.countRulesForAllTags()
     val liveAndDraftTagCounts = Map(
-      "live" -> liveTagCounts,
-      "draft" -> draftTagCounts
+      "live" -> liveTagCounts.map(tuple => Map("tagId" -> tuple._1, "ruleCount" -> tuple._2)),
+      "draft" -> draftTagCounts.map(tuple => Map("tagId" -> tuple._1, "ruleCount" -> tuple._2))
     )
     Ok(Json.toJson(liveAndDraftTagCounts))
   }

--- a/apps/rule-manager/app/controllers/TagsController.scala
+++ b/apps/rule-manager/app/controllers/TagsController.scala
@@ -21,7 +21,7 @@ class TagsController(
     with PermissionsHandler
     with FormHelpers {
 
-  def list = ApiAuthAction {
+  def listWithRuleCounts = ApiAuthAction {
     val tagsWithRuleCounts = Tags.findAllWithRuleCounts()
 
     val json = tagsWithRuleCounts.map(tagWithRuleCount => Json.obj(
@@ -39,16 +39,6 @@ class TagsController(
       case Some(tag) =>
         Ok(Json.toJson(tag))
     }
-  }
-
-  def getRuleCountForAllTags() = ApiAuthAction {
-    val liveTagCounts = RuleTagLive.countRulesForAllTags()
-    val draftTagCounts = RuleTagDraft.countRulesForAllTags()
-    val liveAndDraftTagCounts = Map(
-      "live" -> liveTagCounts.map(tuple => Map("tagId" -> tuple._1, "ruleCount" -> tuple._2)),
-      "draft" -> draftTagCounts.map(tuple => Map("tagId" -> tuple._1, "ruleCount" -> tuple._2))
-    )
-    Ok(Json.toJson(liveAndDraftTagCounts))
   }
 
   def delete(id: Int) = ApiAuthAction {

--- a/apps/rule-manager/app/db/RuleTagDraft.scala
+++ b/apps/rule-manager/app/db/RuleTagDraft.scala
@@ -37,17 +37,10 @@ object RuleTagDraft extends SQLSyntaxSupport[RuleTagDraft] {
       select.from(this as rt).where.eq(rt.tagId, tagId)
     }.map(this.fromResultName(rt.resultName)).list().apply().map(rt => rt.ruleId)
   }
-
-  def countRulesByTag(tagId: Int)(implicit session: DBSession = autoSession): List[Int] = {
+  def countRulesForAllTags()(implicit session: DBSession = autoSession): List[(Int, Int)] = {
     withSQL {
-      select(count(distinct(rt.ruleId))).from(this as rt).where.eq(rt.tagId, tagId)
-    }.map(this.fromResultName(rt.resultName)).list().apply().map(rt => rt.ruleId)
-  }
-
-  def countRulesForAllTags()(implicit session: DBSession = autoSession): List[Int] = {
-    withSQL {
-      select(rt.tagId, count(distinct(rt.ruleId)) as RuleCount).from(this as rt).groupBy(rt.tagId)
-    }.map(this.fromResultName(rt.resultName)).list().apply().map(rt => (rt.ruleId, rt.count))
+      select(rt.tagId, sqls"COUNT(DISTINCT($rt.ruleId})) as rule_count").from(this as rt).groupBy(rt.tagId)
+    }.map(rs => (rs.int("tagId"), rs.int("rule_count"))).list().apply()
   }
 
   def findAll()(implicit session: DBSession = autoSession): List[RuleTagDraft] = {

--- a/apps/rule-manager/app/db/RuleTagDraft.scala
+++ b/apps/rule-manager/app/db/RuleTagDraft.scala
@@ -38,7 +38,9 @@ object RuleTagDraft extends SQLSyntaxSupport[RuleTagDraft] {
   }
   def countRulesForAllTags()(implicit session: DBSession = autoSession): List[(Int, Int)] = {
     withSQL {
-      select(rt.tagId, sqls"COUNT(DISTINCT(${rt.ruleId})) as rule_count").from(this as rt).groupBy(rt.tagId)
+      select(rt.tagId, sqls"COUNT(DISTINCT(${rt.ruleId})) as rule_count")
+        .from(this as rt)
+        .groupBy(rt.tagId)
     }.map(rs => (rs.int("tag_id"), rs.int("rule_count"))).list().apply()
   }
 

--- a/apps/rule-manager/app/db/RuleTagDraft.scala
+++ b/apps/rule-manager/app/db/RuleTagDraft.scala
@@ -37,14 +37,6 @@ object RuleTagDraft extends SQLSyntaxSupport[RuleTagDraft] {
     }.map(this.fromResultName(rt.resultName)).list().apply().map(rt => rt.ruleId)
   }
 
-  def countRulesForAllTags()(implicit session: DBSession = autoSession): List[(Int, Int)] = {
-    withSQL {
-      select(rt.tagId, sqls"COUNT(DISTINCT(${rt.ruleId})) as rule_count")
-        .from(this as rt)
-        .groupBy(rt.tagId)
-    }.map(rs => (rs.int("tag_id"), rs.int("rule_count"))).list().apply()
-  }
-
   def findAll()(implicit session: DBSession = autoSession): List[RuleTagDraft] = {
     withSQL(select.from(this as rt).orderBy(rt.ruleId))
       .map(this.fromResultName(rt.resultName))

--- a/apps/rule-manager/app/db/RuleTagDraft.scala
+++ b/apps/rule-manager/app/db/RuleTagDraft.scala
@@ -1,6 +1,7 @@
 package db
 
 import scalikejdbc._
+import scalikejdbc.interpolation.SQLSyntax.{count, distinct}
 
 import scala.util.{Failure, Success, Try}
 
@@ -35,6 +36,18 @@ object RuleTagDraft extends SQLSyntaxSupport[RuleTagDraft] {
     withSQL {
       select.from(this as rt).where.eq(rt.tagId, tagId)
     }.map(this.fromResultName(rt.resultName)).list().apply().map(rt => rt.ruleId)
+  }
+
+  def countRulesByTag(tagId: Int)(implicit session: DBSession = autoSession): List[Int] = {
+    withSQL {
+      select(count(distinct(rt.ruleId))).from(this as rt).where.eq(rt.tagId, tagId)
+    }.map(this.fromResultName(rt.resultName)).list().apply().map(rt => rt.ruleId)
+  }
+
+  def countRulesForAllTags()(implicit session: DBSession = autoSession): List[Int] = {
+    withSQL {
+      select(rt.tagId, count(distinct(rt.ruleId)) as RuleCount).from(this as rt).groupBy(rt.tagId)
+    }.map(this.fromResultName(rt.resultName)).list().apply().map(rt => (rt.ruleId, rt.count))
   }
 
   def findAll()(implicit session: DBSession = autoSession): List[RuleTagDraft] = {

--- a/apps/rule-manager/app/db/RuleTagDraft.scala
+++ b/apps/rule-manager/app/db/RuleTagDraft.scala
@@ -36,6 +36,7 @@ object RuleTagDraft extends SQLSyntaxSupport[RuleTagDraft] {
       select.from(this as rt).where.eq(rt.tagId, tagId)
     }.map(this.fromResultName(rt.resultName)).list().apply().map(rt => rt.ruleId)
   }
+
   def countRulesForAllTags()(implicit session: DBSession = autoSession): List[(Int, Int)] = {
     withSQL {
       select(rt.tagId, sqls"COUNT(DISTINCT(${rt.ruleId})) as rule_count")

--- a/apps/rule-manager/app/db/RuleTagDraft.scala
+++ b/apps/rule-manager/app/db/RuleTagDraft.scala
@@ -1,7 +1,6 @@
 package db
 
 import scalikejdbc._
-import scalikejdbc.interpolation.SQLSyntax.{count, distinct}
 
 import scala.util.{Failure, Success, Try}
 
@@ -39,8 +38,8 @@ object RuleTagDraft extends SQLSyntaxSupport[RuleTagDraft] {
   }
   def countRulesForAllTags()(implicit session: DBSession = autoSession): List[(Int, Int)] = {
     withSQL {
-      select(rt.tagId, sqls"COUNT(DISTINCT($rt.ruleId})) as rule_count").from(this as rt).groupBy(rt.tagId)
-    }.map(rs => (rs.int("tagId"), rs.int("rule_count"))).list().apply()
+      select(rt.tagId, sqls"COUNT(DISTINCT(${rt.ruleId})) as rule_count").from(this as rt).groupBy(rt.tagId)
+    }.map(rs => (rs.int("tag_id"), rs.int("rule_count"))).list().apply()
   }
 
   def findAll()(implicit session: DBSession = autoSession): List[RuleTagDraft] = {

--- a/apps/rule-manager/app/db/RuleTagDraft.scala
+++ b/apps/rule-manager/app/db/RuleTagDraft.scala
@@ -110,6 +110,15 @@ object RuleTagDraft extends SQLSyntaxSupport[RuleTagDraft] {
     }.update().apply()
   }
 
+  def destroyForTag(tagId: Int)(implicit session: DBSession = autoSession): Int = {
+    withSQL {
+      delete
+        .from(this)
+        .where
+        .eq(column.tagId, tagId)
+    }.update().apply()
+  }
+
   def destroyAll()(implicit session: DBSession = autoSession): Int = {
     withSQL {
       delete.from(this)

--- a/apps/rule-manager/app/db/RuleTagLive.scala
+++ b/apps/rule-manager/app/db/RuleTagLive.scala
@@ -56,14 +56,6 @@ object RuleTagLive extends SQLSyntaxSupport[RuleTagLive] {
       .map(rt => (rt.ruleExternalId, rt.ruleRevisionId))
   }
 
-  def countRulesForAllTags()(implicit session: DBSession = autoSession): List[(Int, Int)] = {
-    withSQL {
-      select(rt.tagId, sqls"COUNT(DISTINCT(${rt.ruleExternalId})) as rule_count")
-        .from(this as rt)
-        .groupBy(rt.tagId)
-    }.map(rs => (rs.int("tag_id"), rs.int("rule_count"))).list().apply()
-  }
-
   def findAll()(implicit session: DBSession = autoSession): List[RuleTagLive] = {
     withSQL(select.from(this as rt).orderBy(rt.ruleExternalId))
       .map(this.fromResultName(rt.resultName))

--- a/apps/rule-manager/app/db/RuleTagLive.scala
+++ b/apps/rule-manager/app/db/RuleTagLive.scala
@@ -56,6 +56,12 @@ object RuleTagLive extends SQLSyntaxSupport[RuleTagLive] {
       .map(rt => (rt.ruleExternalId, rt.ruleRevisionId))
   }
 
+  def countRulesForAllTags()(implicit session: DBSession = autoSession): List[(Int, Int)] = {
+    withSQL {
+      select(rt.tagId, sqls"COUNT(DISTINCT(${rt.ruleExternalId})) as rule_count").from(this as rt).groupBy(rt.tagId)
+    }.map(rs => (rs.int("tag_id"), rs.int("rule_count"))).list().apply()
+  }
+
   def findAll()(implicit session: DBSession = autoSession): List[RuleTagLive] = {
     withSQL(select.from(this as rt).orderBy(rt.ruleExternalId))
       .map(this.fromResultName(rt.resultName))

--- a/apps/rule-manager/app/db/RuleTagLive.scala
+++ b/apps/rule-manager/app/db/RuleTagLive.scala
@@ -133,4 +133,13 @@ object RuleTagLive extends SQLSyntaxSupport[RuleTagLive] {
       delete.from(this)
     }.update().apply()
   }
+
+  def destroyForTag(tagId: Int)(implicit session: DBSession = autoSession): Int = {
+    withSQL {
+      delete
+        .from(this)
+        .where
+        .eq(column.tagId, tagId)
+    }.update().apply()
+  }
 }

--- a/apps/rule-manager/app/db/RuleTagLive.scala
+++ b/apps/rule-manager/app/db/RuleTagLive.scala
@@ -58,7 +58,9 @@ object RuleTagLive extends SQLSyntaxSupport[RuleTagLive] {
 
   def countRulesForAllTags()(implicit session: DBSession = autoSession): List[(Int, Int)] = {
     withSQL {
-      select(rt.tagId, sqls"COUNT(DISTINCT(${rt.ruleExternalId})) as rule_count").from(this as rt).groupBy(rt.tagId)
+      select(rt.tagId, sqls"COUNT(DISTINCT(${rt.ruleExternalId})) as rule_count")
+        .from(this as rt)
+        .groupBy(rt.tagId)
     }.map(rs => (rs.int("tag_id"), rs.int("rule_count"))).list().apply()
   }
 

--- a/apps/rule-manager/app/db/Tags.scala
+++ b/apps/rule-manager/app/db/Tags.scala
@@ -12,10 +12,10 @@ case class Tag(
     name: String
 )
 case class TagWithRuleCount(
-   id: Option[Int],
-   name: String,
-   ruleCount: Int
- )
+    id: Option[Int],
+    name: String,
+    ruleCount: Int
+)
 object Tags extends SQLSyntaxSupport[Tag] {
   implicit val format: Format[Tag] = Json.format[Tag]
 
@@ -43,7 +43,7 @@ object Tags extends SQLSyntaxSupport[Tag] {
   }
 
   def findAllWithRuleCounts()(implicit session: DBSession = autoSession): List[TagWithRuleCount] = {
-    withSQL{
+    withSQL {
       select(t.id, t.name, sqls"COUNT(DISTINCT(${rtd.ruleId})) as rule_count")
         .from(Tags as t)
         .leftJoin(RuleTagDraft as rtd)

--- a/apps/rule-manager/app/db/Tags.scala
+++ b/apps/rule-manager/app/db/Tags.scala
@@ -11,6 +11,11 @@ case class Tag(
     id: Option[Int],
     name: String
 )
+case class TagWithRuleCount(
+   id: Option[Int],
+   name: String,
+   ruleCount: Int
+ )
 object Tags extends SQLSyntaxSupport[Tag] {
   implicit val format: Format[Tag] = Json.format[Tag]
 
@@ -19,6 +24,7 @@ object Tags extends SQLSyntaxSupport[Tag] {
   override val columns = Seq("id", "name")
 
   val t = Tags.syntax("t")
+  val rtd = RuleTagDraft.syntax("rtd")
 
   def fromResultName(r: ResultName[Tag])(rs: WrappedResultSet): Tag =
     autoConstruct(rs, r)
@@ -32,6 +38,19 @@ object Tags extends SQLSyntaxSupport[Tag] {
   def findAll()(implicit session: DBSession = autoSession): List[Tag] = {
     withSQL(select.from(Tags as t).orderBy(t.id))
       .map(Tags.fromResultName(t.resultName))
+      .list()
+      .apply()
+  }
+
+  def findAllWithRuleCounts()(implicit session: DBSession = autoSession): List[TagWithRuleCount] = {
+    withSQL{
+      select(t.id, t.name, sqls"COUNT(DISTINCT(${rtd.ruleId})) as rule_count")
+        .from(Tags as t)
+        .leftJoin(RuleTagDraft as rtd)
+        .on(t.id, rtd.tagId)
+        .groupBy(t.id)
+        .orderBy(t.id)
+    }.map(rs => (TagWithRuleCount(Some(rs.int("id")), rs.string("name"), rs.int("rule_count"))))
       .list()
       .apply()
   }

--- a/apps/rule-manager/client/package-lock.json
+++ b/apps/rule-manager/client/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@elastic/datemath": "^5.0.3",
-        "@elastic/eui": "^77.2.0",
+        "@elastic/eui": "^83.1.0",
         "@emotion/cache": "^11.10.5",
         "@emotion/css": "^11.10.6",
         "@emotion/react": "^11.10.6",
@@ -32,7 +32,7 @@
         "jest": "^29.5.0",
         "sass": "^1.60.0",
         "ts-jest": "^29.1.0",
-        "typescript": "^5.1.3",
+        "typescript": "^4.5.3",
         "utility-types": "^3.10.0",
         "vite": "^4.2.0",
         "vite-plugin-checker": "^0.6.0"
@@ -559,12 +559,12 @@
       }
     },
     "node_modules/@elastic/eui": {
-      "version": "77.2.0",
-      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-77.2.0.tgz",
-      "integrity": "sha512-6j3jqXdRmLGQ530GtdMrXyqi7rVd/XCMhymgO+FJiamf3dw5NF1LsXiOTn2+lTa/Tn3v2sJMVsr+SL+0h2Cd+A==",
+      "version": "83.1.0",
+      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-83.1.0.tgz",
+      "integrity": "sha512-l6ERa836K/U9dccZ4xkyf2tmTO54DeElhGXmNdq02CATbXNQ3YGnoAn99+HvA82oXF3zCSpy+pg5tLx6Ag1zaw==",
       "dependencies": {
         "@types/chroma-js": "^2.0.0",
-        "@types/lodash": "^4.14.160",
+        "@types/lodash": "^4.14.194",
         "@types/numeral": "^0.0.28",
         "@types/react-beautiful-dnd": "^13.1.2",
         "@types/react-input-autosize": "^2.2.1",
@@ -585,6 +585,7 @@
         "react-focus-on": "^3.7.0",
         "react-input-autosize": "^3.0.0",
         "react-is": "^17.0.2",
+        "react-remove-scroll-bar": "^2.3.4",
         "react-virtualized-auto-sizer": "^1.0.6",
         "react-window": "^1.8.6",
         "refractor": "^3.5.0",
@@ -602,6 +603,9 @@
         "url-parse": "^1.5.10",
         "uuid": "^8.3.0",
         "vfile": "^4.2.0"
+      },
+      "engines": {
+        "node": "16.x || 18.x || >=20.0"
       },
       "peerDependencies": {
         "@elastic/datemath": "^5.0.2",
@@ -7427,15 +7431,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unherit": {
@@ -8632,12 +8636,12 @@
       }
     },
     "@elastic/eui": {
-      "version": "77.2.0",
-      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-77.2.0.tgz",
-      "integrity": "sha512-6j3jqXdRmLGQ530GtdMrXyqi7rVd/XCMhymgO+FJiamf3dw5NF1LsXiOTn2+lTa/Tn3v2sJMVsr+SL+0h2Cd+A==",
+      "version": "83.1.0",
+      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-83.1.0.tgz",
+      "integrity": "sha512-l6ERa836K/U9dccZ4xkyf2tmTO54DeElhGXmNdq02CATbXNQ3YGnoAn99+HvA82oXF3zCSpy+pg5tLx6Ag1zaw==",
       "requires": {
         "@types/chroma-js": "^2.0.0",
-        "@types/lodash": "^4.14.160",
+        "@types/lodash": "^4.14.194",
         "@types/numeral": "^0.0.28",
         "@types/react-beautiful-dnd": "^13.1.2",
         "@types/react-input-autosize": "^2.2.1",
@@ -8658,6 +8662,7 @@
         "react-focus-on": "^3.7.0",
         "react-input-autosize": "^3.0.0",
         "react-is": "^17.0.2",
+        "react-remove-scroll-bar": "^2.3.4",
         "react-virtualized-auto-sizer": "^1.0.6",
         "react-window": "^1.8.6",
         "refractor": "^3.5.0",
@@ -13590,9 +13595,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw=="
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
     },
     "unherit": {
       "version": "1.1.3",

--- a/apps/rule-manager/client/package-lock.json
+++ b/apps/rule-manager/client/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@elastic/datemath": "^5.0.3",
-        "@elastic/eui": "^83.1.0",
+        "@elastic/eui": "^84.0.0",
         "@emotion/cache": "^11.10.5",
         "@emotion/css": "^11.10.6",
         "@emotion/react": "^11.10.6",
@@ -559,9 +559,9 @@
       }
     },
     "node_modules/@elastic/eui": {
-      "version": "83.1.0",
-      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-83.1.0.tgz",
-      "integrity": "sha512-l6ERa836K/U9dccZ4xkyf2tmTO54DeElhGXmNdq02CATbXNQ3YGnoAn99+HvA82oXF3zCSpy+pg5tLx6Ag1zaw==",
+      "version": "84.0.0",
+      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-84.0.0.tgz",
+      "integrity": "sha512-hgDWyXwlhpbNzQgIvGLppqSRMEVt2zMlXIxMzvlV6PYPJUh1K9f5pOyXtNyouFgYZG2bkltvG3cUrMLeBbgUkg==",
       "dependencies": {
         "@types/chroma-js": "^2.0.0",
         "@types/lodash": "^4.14.194",
@@ -582,7 +582,7 @@
         "react-beautiful-dnd": "^13.1.0",
         "react-dropzone": "^11.5.3",
         "react-element-to-jsx-string": "^14.3.4",
-        "react-focus-on": "^3.7.0",
+        "react-focus-on": "^3.9.1",
         "react-input-autosize": "^3.0.0",
         "react-is": "^17.0.2",
         "react-remove-scroll-bar": "^2.3.4",
@@ -2493,9 +2493,9 @@
       }
     },
     "node_modules/aria-hidden/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/attr-accept": {
       "version": "2.2.2",
@@ -3412,9 +3412,9 @@
       }
     },
     "node_modules/focus-lock/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/fs-extra": {
       "version": "11.1.1",
@@ -6434,17 +6434,6 @@
         "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/react-clientside-effect": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
-      "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13"
-      },
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react-dom": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -6488,36 +6477,14 @@
         "react-dom": "^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1"
       }
     },
-    "node_modules/react-focus-lock": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
-      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.11.6",
-        "prop-types": "^15.6.2",
-        "react-clientside-effect": "^1.2.6",
-        "use-callback-ref": "^1.3.0",
-        "use-sidecar": "^1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-focus-on": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.8.0.tgz",
-      "integrity": "sha512-xuH4jUPeRZ4oE0a85d7pA8pPhotb4U2iWK1CBATP/Xao/WEFHUZxxi5+ffWovjjUT7k53mXDm53TE2pvjLccsw==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.9.1.tgz",
+      "integrity": "sha512-IYo2j4mgNpZEJNv+/XzZs3S3xhJbR+AFop092h4OMW7sbFpIMVWxp/Z61V/gfpsgOi7VnoSFXP2bfOWWkjjtOw==",
       "dependencies": {
         "aria-hidden": "^1.2.2",
-        "react-focus-lock": "^2.9.2",
-        "react-remove-scroll": "^2.5.5",
+        "react-focus-lock": "^2.9.4",
+        "react-remove-scroll": "^2.5.6",
         "react-style-singleton": "^2.2.0",
         "tslib": "^2.3.1",
         "use-callback-ref": "^1.3.0",
@@ -6536,10 +6503,130 @@
         }
       }
     },
+    "node_modules/react-focus-on/node_modules/react-focus-lock": {
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.5.tgz",
+      "integrity": "sha512-h6vrdgUbsH2HeD5I7I3Cx1PPrmwGuKYICS+kB9m+32X/9xHRrAbxgvaBpG7BFBN9h3tO+C3qX1QAVESmi4CiIA==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^0.11.6",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.6",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-focus-on/node_modules/react-focus-lock/node_modules/react-clientside-effect": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
+      "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-focus-on/node_modules/react-remove-scroll": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.6.tgz",
+      "integrity": "sha512-bO856ad1uDYLefgArk559IzUNeQ6SWH4QnrevIUjH+GczV56giDfl3h0Idptf2oIKxQmd1p9BN25jleKodTALg==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.4",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-focus-on/node_modules/react-style-singleton": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-focus-on/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+    },
+    "node_modules/react-focus-on/node_modules/use-callback-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-focus-on/node_modules/use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-input-autosize": {
       "version": "3.0.0",
@@ -6581,30 +6668,6 @@
         }
       }
     },
-    "node_modules/react-remove-scroll": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
-      "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
-      "dependencies": {
-        "react-remove-scroll-bar": "^2.3.3",
-        "react-style-singleton": "^2.2.1",
-        "tslib": "^2.1.0",
-        "use-callback-ref": "^1.3.0",
-        "use-sidecar": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-remove-scroll-bar": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
@@ -6626,15 +6689,32 @@
         }
       }
     },
-    "node_modules/react-remove-scroll-bar/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    "node_modules/react-remove-scroll-bar/node_modules/react-style-singleton": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
-    "node_modules/react-remove-scroll/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    "node_modules/react-remove-scroll-bar/node_modules/tslib": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/react-router": {
       "version": "6.14.0",
@@ -6665,33 +6745,6 @@
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
-    },
-    "node_modules/react-style-singleton": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
-      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
-      "dependencies": {
-        "get-nonce": "^1.0.0",
-        "invariant": "^2.2.4",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-style-singleton/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/react-virtualized-auto-sizer": {
       "version": "1.0.14",
@@ -7607,31 +7660,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "node_modules/use-callback-ref": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
-      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-callback-ref/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-    },
     "node_modules/use-memo-one": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
@@ -7639,32 +7667,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
-    },
-    "node_modules/use-sidecar": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
-      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
-      "dependencies": {
-        "detect-node-es": "^1.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-sidecar/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/utility-types": {
       "version": "3.10.0",
@@ -8636,9 +8638,9 @@
       }
     },
     "@elastic/eui": {
-      "version": "83.1.0",
-      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-83.1.0.tgz",
-      "integrity": "sha512-l6ERa836K/U9dccZ4xkyf2tmTO54DeElhGXmNdq02CATbXNQ3YGnoAn99+HvA82oXF3zCSpy+pg5tLx6Ag1zaw==",
+      "version": "84.0.0",
+      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-84.0.0.tgz",
+      "integrity": "sha512-hgDWyXwlhpbNzQgIvGLppqSRMEVt2zMlXIxMzvlV6PYPJUh1K9f5pOyXtNyouFgYZG2bkltvG3cUrMLeBbgUkg==",
       "requires": {
         "@types/chroma-js": "^2.0.0",
         "@types/lodash": "^4.14.194",
@@ -8659,7 +8661,7 @@
         "react-beautiful-dnd": "^13.1.0",
         "react-dropzone": "^11.5.3",
         "react-element-to-jsx-string": "^14.3.4",
-        "react-focus-on": "^3.7.0",
+        "react-focus-on": "^3.9.1",
         "react-input-autosize": "^3.0.0",
         "react-is": "^17.0.2",
         "react-remove-scroll-bar": "^2.3.4",
@@ -10029,9 +10031,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
         }
       }
     },
@@ -10701,9 +10703,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
         }
       }
     },
@@ -12909,14 +12911,6 @@
         "use-memo-one": "^1.1.1"
       }
     },
-    "react-clientside-effect": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
-      "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
-      "requires": {
-        "@babel/runtime": "^7.12.13"
-      }
-    },
     "react-dom": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -12947,37 +12941,86 @@
         "react-is": "17.0.2"
       }
     },
-    "react-focus-lock": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
-      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.11.6",
-        "prop-types": "^15.6.2",
-        "react-clientside-effect": "^1.2.6",
-        "use-callback-ref": "^1.3.0",
-        "use-sidecar": "^1.1.2"
-      }
-    },
     "react-focus-on": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.8.0.tgz",
-      "integrity": "sha512-xuH4jUPeRZ4oE0a85d7pA8pPhotb4U2iWK1CBATP/Xao/WEFHUZxxi5+ffWovjjUT7k53mXDm53TE2pvjLccsw==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.9.1.tgz",
+      "integrity": "sha512-IYo2j4mgNpZEJNv+/XzZs3S3xhJbR+AFop092h4OMW7sbFpIMVWxp/Z61V/gfpsgOi7VnoSFXP2bfOWWkjjtOw==",
       "requires": {
         "aria-hidden": "^1.2.2",
-        "react-focus-lock": "^2.9.2",
-        "react-remove-scroll": "^2.5.5",
+        "react-focus-lock": "^2.9.4",
+        "react-remove-scroll": "^2.5.6",
         "react-style-singleton": "^2.2.0",
         "tslib": "^2.3.1",
         "use-callback-ref": "^1.3.0",
         "use-sidecar": "^1.1.2"
       },
       "dependencies": {
+        "react-focus-lock": {
+          "version": "2.9.5",
+          "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.5.tgz",
+          "integrity": "sha512-h6vrdgUbsH2HeD5I7I3Cx1PPrmwGuKYICS+kB9m+32X/9xHRrAbxgvaBpG7BFBN9h3tO+C3qX1QAVESmi4CiIA==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "focus-lock": "^0.11.6",
+            "prop-types": "^15.6.2",
+            "react-clientside-effect": "^1.2.6",
+            "use-callback-ref": "^1.3.0",
+            "use-sidecar": "^1.1.2"
+          },
+          "dependencies": {
+            "react-clientside-effect": {
+              "version": "1.2.6",
+              "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
+              "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+              "requires": {
+                "@babel/runtime": "^7.12.13"
+              }
+            }
+          }
+        },
+        "react-remove-scroll": {
+          "version": "2.5.6",
+          "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.6.tgz",
+          "integrity": "sha512-bO856ad1uDYLefgArk559IzUNeQ6SWH4QnrevIUjH+GczV56giDfl3h0Idptf2oIKxQmd1p9BN25jleKodTALg==",
+          "requires": {
+            "react-remove-scroll-bar": "^2.3.4",
+            "react-style-singleton": "^2.2.1",
+            "tslib": "^2.1.0",
+            "use-callback-ref": "^1.3.0",
+            "use-sidecar": "^1.1.2"
+          }
+        },
+        "react-style-singleton": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+          "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+          "requires": {
+            "get-nonce": "^1.0.0",
+            "invariant": "^2.2.4",
+            "tslib": "^2.0.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+        },
+        "use-callback-ref": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+          "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "use-sidecar": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+          "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+          "requires": {
+            "detect-node-es": "^1.1.0",
+            "tslib": "^2.0.0"
+          }
         }
       }
     },
@@ -13007,25 +13050,6 @@
         "react-is": "^17.0.2"
       }
     },
-    "react-remove-scroll": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
-      "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
-      "requires": {
-        "react-remove-scroll-bar": "^2.3.3",
-        "react-style-singleton": "^2.2.1",
-        "tslib": "^2.1.0",
-        "use-callback-ref": "^1.3.0",
-        "use-sidecar": "^1.1.2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
     "react-remove-scroll-bar": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
@@ -13035,10 +13059,20 @@
         "tslib": "^2.0.0"
       },
       "dependencies": {
+        "react-style-singleton": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+          "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+          "requires": {
+            "get-nonce": "^1.0.0",
+            "invariant": "^2.2.4",
+            "tslib": "^2.0.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
         }
       }
     },
@@ -13057,23 +13091,6 @@
       "requires": {
         "@remix-run/router": "1.7.0",
         "react-router": "6.14.0"
-      }
-    },
-    "react-style-singleton": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
-      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
-      "requires": {
-        "get-nonce": "^1.0.0",
-        "invariant": "^2.2.4",
-        "tslib": "^2.0.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
       }
     },
     "react-virtualized-auto-sizer": {
@@ -13701,42 +13718,11 @@
         "requires-port": "^1.0.0"
       }
     },
-    "use-callback-ref": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
-      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
-      "requires": {
-        "tslib": "^2.0.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
     "use-memo-one": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
       "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
       "requires": {}
-    },
-    "use-sidecar": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
-      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
-      "requires": {
-        "detect-node-es": "^1.1.0",
-        "tslib": "^2.0.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
     },
     "utility-types": {
       "version": "3.10.0",

--- a/apps/rule-manager/client/package.json
+++ b/apps/rule-manager/client/package.json
@@ -22,14 +22,14 @@
     "jest": "^29.5.0",
     "sass": "^1.60.0",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.1.3",
+    "typescript": "^4.5.3",
     "utility-types": "^3.10.0",
     "vite": "^4.2.0",
     "vite-plugin-checker": "^0.6.0"
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
-    "@elastic/eui": "^77.2.0",
+    "@elastic/eui": "^83.1.0",
     "@emotion/cache": "^11.10.5",
     "@emotion/css": "^11.10.6",
     "@emotion/react": "^11.10.6",

--- a/apps/rule-manager/client/package.json
+++ b/apps/rule-manager/client/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
-    "@elastic/eui": "^83.1.0",
+    "@elastic/eui": "^84.0.0",
     "@emotion/cache": "^11.10.5",
     "@emotion/css": "^11.10.6",
     "@emotion/react": "^11.10.6",

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -4,9 +4,7 @@ import { Tag, useTags } from "./hooks/useTags";
 import React, { useEffect, useState } from "react";
 import styled from "@emotion/styled";
 import { useCreateEditPermissions } from "./RulesTable";
-import { create, set, update } from "lodash";
 import { RuleFormSection } from "./RuleFormSection";
-import { hasCreateEditPermissions } from "./helpers/hasCreateEditPermissions";
 
 
 type DeleteTagButtonProps = {
@@ -32,9 +30,7 @@ export const EditableNameField = ({
     editIsEnabled,
     editTag,
     tag,
-    fetchTags,
-    isLoading,
-  }: { editIsEnabled: boolean, editTag: (tag: Tag) => void, tag: Tag, fetchTags: () => void, isLoading: boolean }) => {
+  }: { editIsEnabled: boolean, editTag: (tag: Tag) => void, tag: Tag, fetchTags: () => void }) => {
     const [tagName, setTagName] = useState(tag.name);
     useEffect(() => {
         setTagName(tag.name)
@@ -78,7 +74,7 @@ const createTagTableColumns = (editTag: (tag: Tag) => void, fetchTags: () => voi
             width: editableNameWidth,
             actions: [{
               name: 'Edit',
-              render: (item, enabled) => <EditableNameField editIsEnabled={enabled} editTag={editTag} tag={item} fetchTags={fetchTags} isLoading={isLoading} key={item.id} />,
+              render: (item, enabled) => <EditableNameField editIsEnabled={enabled} editTag={editTag} tag={item} fetchTags={fetchTags} key={item.id} />,
               enabled: () => hasEditPermissions,
             //   'data-test-subj': 'action-edit',
             }],

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -205,7 +205,6 @@ export const TagsTable = () => {
 
     return (<>
         <EuiFlexGroup>
-            <EuiFlexItem/>
             <EuiFlexItem css={css`width: 32rem;`}>
                 <EuiFlexGroup>
                     <EuiFlexItem grow={false} css={css`padding-bottom: 20px;`}>

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -1,4 +1,4 @@
-import { EuiBasicTableColumn, EuiButton, EuiFieldText, EuiFlexGroup, EuiFlexItem, EuiForm, EuiFormRow, EuiIcon, EuiInMemoryTable, EuiInMemoryTableProps, EuiInlineEditText, EuiSpacer, EuiText, EuiTextColor, EuiTitle, EuiToast, EuiToolTip } from "@elastic/eui"
+import { EuiBasicTableColumn, EuiButton, EuiButtonEmpty, EuiFieldText, EuiFlexGroup, EuiFlexItem, EuiForm, EuiFormRow, EuiIcon, EuiInMemoryTable, EuiInMemoryTableProps, EuiInlineEditText, EuiModal, EuiModalBody, EuiModalHeader, EuiModalHeaderTitle, EuiSpacer, EuiText, EuiTextColor, EuiTitle, EuiToast, EuiToolTip } from "@elastic/eui"
 import { css } from "@emotion/react"
 import { Tag, useTags } from "./hooks/useTags";
 import React, { useEffect, useState } from "react";
@@ -149,29 +149,36 @@ const DeleteTagWarning = ({tag, setTagToDelete, deleteTag}: {tag: Tag, setTagToD
         deleteTag(tag);
         setTagToDelete(null);
     }
-    return <EuiToast
-        title="Confirm Tag delete action"
+    return <EuiModal 
+        onClose={() => {setTagToDelete(null)}} 
+        initialFocus="[name=popswitch]"
         color="danger"
-        iconType="warning"
-        onClose={() => {setTagToDelete(null)}}
-        css={deleteTagWarningCss}
+        // css={deleteTagWarningCss}
     >
-    <p>
-      Are you sure you want to delete the tag '{tag.name}'?
-    <br/>
-      This action is <strong>permanent</strong> and will remove the tag from all associated rules.
-    </p>
-
-    <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
-      <EuiFlexItem grow={false}>
-        <EuiButton onClick={() => deleteAndClosePrompty(tag)}size="s" color="danger">Delete the '{tag.name}' tag</EuiButton>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </EuiToast>
+        <EuiModalHeader>
+            <EuiModalHeaderTitle>Confirm tag deletion</EuiModalHeaderTitle>
+        </EuiModalHeader>
+        <EuiModalBody>
+            <EuiText>
+                Are you sure you want to delete the tag '{tag.name}'?
+                <br/>
+                This action is <strong>permanent</strong> and will remove the tag from all associated rules.
+            </EuiText>
+            <EuiSpacer />
+            <EuiFlexGroup justifyContent="flexEnd">
+                <EuiFlexItem grow={false}>
+                    <EuiButtonEmpty onClick={() => {setTagToDelete(null)}}>Cancel</EuiButtonEmpty>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                    <EuiButton onClick={() => deleteAndClosePrompty(tag)} color="danger">Delete the '{tag.name}' tag</EuiButton>
+                </EuiFlexItem>
+            </EuiFlexGroup>
+        </EuiModalBody>
+    </EuiModal>
 }
 
 const ServerErrorNotification =  ({error}: {error: string}) => {
-   return <EuiToast
+    return <EuiToast
         title="Server Error"
         color="danger"
         iconType="error"

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -161,7 +161,7 @@ const DeleteTagWarning = (
 ) => {
     const deleteAndClosePrompty = (tag: Tag) => { 
         setHideDeletionModal(true);
-        deleteTag(tag).then(resp => {
+        deleteTag(tag).then(() => {
             setTagToDelete(null);
             setHideDeletionModal(false);
         })

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -16,6 +16,8 @@ const createTagTableColumns = () => {
 }
 export const TagsTable = () => {
     const {tags, fetchTags} = useTags();
+
+    const fetchUsages = 
     return (<>
         <EuiFlexGroup>
             <EuiFlexItem/>

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -1,0 +1,43 @@
+import { EuiFlexGroup, EuiFlexItem, EuiInMemoryTable, EuiTitle } from "@elastic/eui"
+import { css } from "@emotion/react"
+import { useTags } from "./hooks/useTags";
+
+const createTagTableColumns = () => {
+    return [
+        {
+            field: 'id',
+            name: 'id'
+        },{
+            field: 'name',
+            name: 'Name'
+        }
+    ]
+}
+export const TagsTable = () => {
+    const {tags, fetchTags} = useTags();
+    return (<>
+        <EuiFlexGroup>
+            <EuiFlexItem/>
+            <EuiFlexItem>
+                <EuiFlexGroup>
+                    <EuiFlexItem grow={false} css={css`padding-bottom: 20px;`}>
+                        <EuiTitle>
+                            <h1>Tags</h1>
+                        </EuiTitle>
+                    </EuiFlexItem>
+                </EuiFlexGroup>
+                <EuiFlexGroup>
+                    <EuiFlexItem>
+                        <EuiInMemoryTable
+                            columns={createTagTableColumns()}
+                            items={Object.values(tags)}
+                            css={css`max-width: 500px`}
+                        >
+                        </EuiInMemoryTable>
+                    </EuiFlexItem>
+                </EuiFlexGroup>
+            </ EuiFlexItem>
+            <EuiFlexItem/>
+        </EuiFlexGroup>
+    </>)
+}

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -18,9 +18,12 @@ const DeleteTagButton = styled.button<DeleteTagButtonProps>(props => ({
 
 const editableNameWidth = '18rem';
 
+const getTagMethodDisabledMessage = (methodName: string) => 
+    `You do not have the correct permissions to ${methodName} a tag. Please contact Central Production if you need to do so.`
+
 const DeleteTag = ({editIsEnabled, tag, openDeleteTagDialogue}: {editIsEnabled: boolean, tag: Tag, openDeleteTagDialogue: (tag: Tag) => void}) => 
     <EuiToolTip
-        content={editIsEnabled ? "" : "You do not have the correct permissions to delete a tag. Please contact Central Production if you need to do so."}>
+        content={editIsEnabled ? "" : getTagMethodDisabledMessage('delete')}>
         <DeleteTagButton editIsEnabled={editIsEnabled} onClick={() => editIsEnabled ? openDeleteTagDialogue(tag) : null}>
             <EuiIcon type="trash" color="danger"/>
         </DeleteTagButton>
@@ -49,7 +52,7 @@ export const EditableNameField = ({
                     }}
                     css={css`width: 100%; color: black`}
                 /> : <EuiToolTip
-                        content={editIsEnabled ? "" : "You do not have the correct permissions to edit a tag. Please contact Central Production if you need to do so."}>
+                        content={editIsEnabled ? "" : getTagMethodDisabledMessage('edit')}>
                         <EuiFlexItem>{tagName}</EuiFlexItem>
                     </EuiToolTip>
             }
@@ -113,17 +116,25 @@ const CreateTagForm = ({createTag, enabled}: {createTag: (tagName: string) => Pr
         <EuiSpacer size="s" />
         <EuiFlexGroup css={css`width: 100%; display: flex; gap: 0.8rem;`}>
             <EuiFlexItem grow={true}>
-                <EuiFieldText 
-                    placeholder="Tag name..." 
-                    value={tagName} 
-                    onChange={(e) => {setClientSideValidationError(null); setTagName(e.target.value || "")}}
-                    css={css`width: 100%; max-width: 100%;`}
-                />
+                <EuiToolTip
+                content={enabled ? "" : getTagMethodDisabledMessage('create')}>
+                    <EuiFieldText 
+                        placeholder="Tag name..." 
+                        value={tagName} 
+                        onChange={(e) => {setClientSideValidationError(null); setTagName(e.target.value || "")}}
+                        css={css`width: 100%; max-width: 100%;`}
+                        disabled={!enabled}
+                    />
+                </EuiToolTip>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-                <EuiButton onClick={() => createTagIfSuitable(tagName)} color={"primary"} fill disabled={!enabled}>
-                    Create Tag
-                </EuiButton>
+                <EuiToolTip
+                content={enabled ? "" : getTagMethodDisabledMessage('create')}>
+                    <EuiButton onClick={() => createTagIfSuitable(tagName)} color={"primary"} fill disabled={!enabled}>
+                        Create Tag
+                    </EuiButton>
+                
+                </EuiToolTip>
             </EuiFlexItem>
         </EuiFlexGroup>
         <EuiFlexGroup >

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -1,6 +1,7 @@
 import { EuiFlexGroup, EuiFlexItem, EuiInMemoryTable, EuiTitle } from "@elastic/eui"
 import { css } from "@emotion/react"
 import { useTags } from "./hooks/useTags";
+import React from "react";
 
 const createTagTableColumns = () => {
     return [

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -40,7 +40,7 @@ export const EditableNameField = ({
     }, [tag])
     return (
       <>
-        <EuiFlexGroup css={css`width: ${editableNameWidth}; padding-left: 1.2rem;`}>
+        <EuiFlexGroup css={css`width: ${editableNameWidth};`}>
             {editIsEnabled ? 
                 <EuiInlineEditText
                     inputAriaLabel="Edit text inline"
@@ -64,23 +64,11 @@ export const EditableNameField = ({
 const createTagTableColumns = (editTag: (tag: Tag) => void, fetchTags: () => void, isLoading: boolean, openDeleteTagDialogue: (tag: Tag) => void, hasEditPermissions: boolean): Array<EuiBasicTableColumn<Tag>> => {
     return [
         {
-            // Bit of a hack to sort alphabetically on load
             field: 'name',
-            width: '0rem',
-            name: 'Name',
-            render: (item, enabled) => null,
-            dataType: 'string',
-            sortable: ({ name }) => name.toLowerCase(),
-        },
-        {
             name: 'Name',
             width: editableNameWidth,
-            actions: [{
-              name: 'Edit',
-              render: (item, enabled) => <EditableNameField editIsEnabled={enabled} editTag={editTag} tag={item} fetchTags={fetchTags} key={item.id} />,
-              enabled: () => hasEditPermissions,
-            //   'data-test-subj': 'action-edit',
-            }],
+            sortable: ({ name }) => name.toLowerCase(),
+            render: (tagName, item) => <EditableNameField editIsEnabled={hasEditPermissions} editTag={editTag} tag={item} fetchTags={fetchTags} key={item.id} />,
           },
         {
             field: 'ruleCount',
@@ -112,39 +100,39 @@ const CreateTagForm = ({createTag, enabled}: {createTag: (tagName: string) => Pr
             setTagName('');
         }
     }
-    return <><EuiFlexGroup css={css`margin-bottom: 1rem; width: 100%;`}><RuleFormSection title="CREATE NEW TAG">
-        <EuiSpacer size="s" />
-        <EuiFlexGroup css={css`width: 100%; display: flex; gap: 0.8rem;`}>
-            <EuiFlexItem grow={true}>
-                <EuiToolTip
-                content={enabled ? "" : getTagMethodDisabledMessage('create')}>
-                    <EuiFieldText 
-                        placeholder="Tag name..." 
-                        value={tagName} 
-                        onChange={(e) => {setClientSideValidationError(null); setTagName(e.target.value || "")}}
-                        css={css`width: 100%; max-width: 100%;`}
-                        disabled={!enabled}
-                    />
-                </EuiToolTip>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-                <EuiToolTip
-                content={enabled ? "" : getTagMethodDisabledMessage('create')}>
-                    <EuiButton onClick={() => createTagIfSuitable(tagName)} color={"primary"} fill disabled={!enabled}>
-                        Create Tag
-                    </EuiButton>
-                
-                </EuiToolTip>
-            </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiFlexGroup >
-            <EuiTextColor color="danger">
-                {clientSideValidationError ? <EuiText css={css`margin-top: 0.5rem;`}>{clientSideValidationError}</EuiText> : null}
-            </EuiTextColor>
-        </EuiFlexGroup>
-    </RuleFormSection>
+    return <EuiFlexGroup css={css`margin-bottom: 1rem; width: 100%;`}>
+        <RuleFormSection title="CREATE NEW TAG">
+            <EuiSpacer size="s" />
+            <EuiFlexGroup css={css`width: 100%; display: flex; gap: 0.8rem;`}>
+                <EuiFlexItem grow={true}>
+                    <EuiToolTip
+                    content={enabled ? "" : getTagMethodDisabledMessage('create')}>
+                        <EuiFieldText 
+                            placeholder="Tag name..." 
+                            value={tagName} 
+                            onChange={(e) => {setClientSideValidationError(null); setTagName(e.target.value || "")}}
+                            css={css`width: 100%; max-width: 100%;`}
+                            disabled={!enabled}
+                        />
+                    </EuiToolTip>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                    <EuiToolTip
+                    content={enabled ? "" : getTagMethodDisabledMessage('create')}>
+                        <EuiButton onClick={() => createTagIfSuitable(tagName)} color={"primary"} fill disabled={!enabled}>
+                            Create Tag
+                        </EuiButton>
+                    
+                    </EuiToolTip>
+                </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiFlexGroup >
+                <EuiTextColor color="danger">
+                    {clientSideValidationError ? <EuiText css={css`margin-top: 0.5rem;`}>{clientSideValidationError}</EuiText> : null}
+                </EuiTextColor>
+            </EuiFlexGroup>
+        </RuleFormSection>
     </EuiFlexGroup>
-    </>
 }
 
 const deleteTagWarningCss = css`
@@ -212,7 +200,7 @@ export const TagsTable = () => {
     return (<>
         <EuiFlexGroup>
             <EuiFlexItem/>
-            <EuiFlexItem>
+            <EuiFlexItem css={css`width: 32rem;`}>
                 <EuiFlexGroup>
                     <EuiFlexItem grow={false} css={css`padding-bottom: 20px;`}>
                         <EuiTitle>

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -103,7 +103,7 @@ const CreateTagForm = ({createTag, enabled}: {createTag: (tagName: string) => Pr
     return <EuiFlexGroup css={css`margin-bottom: 1rem; width: 100%;`}>
         <RuleFormSection title="CREATE NEW TAG">
             <EuiSpacer size="s" />
-            <EuiFlexGroup css={css`width: 100%; display: flex; gap: 0.8rem;`}>
+            <EuiFlexGroup css={css`display: flex; gap: 0.8rem;`}>
                 <EuiFlexItem grow={true}>
                     <EuiToolTip
                     content={enabled ? "" : getTagMethodDisabledMessage('create')}>
@@ -111,7 +111,6 @@ const CreateTagForm = ({createTag, enabled}: {createTag: (tagName: string) => Pr
                             placeholder="Tag name..." 
                             value={tagName} 
                             onChange={(e) => {setClientSideValidationError(null); setTagName(e.target.value || "")}}
-                            css={css`width: 100%; max-width: 100%;`}
                             disabled={!enabled}
                         />
                     </EuiToolTip>

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -172,7 +172,6 @@ const DeleteTagWarning = (
         onClose={() => {setTagToDelete(null)}} 
         initialFocus="[name=popswitch]"
         color="danger"
-        // css={deleteTagWarningCss}
     >
         <EuiModalHeader>
             <EuiModalHeaderTitle>Confirm tag deletion</EuiModalHeaderTitle>

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -107,7 +107,7 @@ const CreateTagForm = ({createTag, enabled}: {createTag: (tagName: string) => Pr
     const [clientSideValidationError, setClientSideValidationError] = useState<string | null>(null);
     const createTagIfSuitable = (tagName: string) => {
         if (!tagName){
-            setClientSideValidationError("A tag must contain text.")
+            setClientSideValidationError("A tag must have a name.")
         } else {
             createTag(tagName)
             setTagName('');
@@ -118,7 +118,7 @@ const CreateTagForm = ({createTag, enabled}: {createTag: (tagName: string) => Pr
         <EuiFlexGroup css={css`width: 100%; display: flex; gap: 0.8rem;`}>
             <EuiFlexItem grow={true}>
                 <EuiFieldText 
-                    placeholder="Tag text..." 
+                    placeholder="Tag name..." 
                     value={tagName} 
                     onChange={(e) => {setClientSideValidationError(null); setTagName(e.target.value || "")}}
                     css={css`width: 100%; max-width: 100%;`}

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -73,7 +73,6 @@ const createTagTableColumns = (
     hasEditPermissions: boolean,
     tagToDelete: Tag | null,
 ): Array<EuiBasicTableColumn<Tag>> => {
-    console.log(tagToDelete)
     return [
         {
             field: 'name',

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -1,23 +1,156 @@
-import { EuiFlexGroup, EuiFlexItem, EuiInMemoryTable, EuiTitle } from "@elastic/eui"
+import { EuiBasicTableColumn, EuiButton, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiInMemoryTable, EuiInMemoryTableProps, EuiInlineEditText, EuiTitle, EuiToast, EuiToolTip } from "@elastic/eui"
 import { css } from "@emotion/react"
-import { useTags } from "./hooks/useTags";
-import React from "react";
+import { Tag, useTags } from "./hooks/useTags";
+import React, { useState } from "react";
+import styled from "@emotion/styled";
+import { useCreateEditPermissions } from "./RulesTable";
+import { update } from "lodash";
 
-const createTagTableColumns = () => {
+
+// const EditTag = ({
+//     editIsEnabled,
+//     editTag,
+//     tag, 
+//   }: { editIsEnabled: boolean, editTag: (ruleId: number) => void, tag: Tag }) => {
+//     return <EuiToolTip
+//             content={editIsEnabled ? "" : "You do not have the correct permissions to edit a Tag. Please contact Central Production if you need to edit tags."}>
+//             <EditTagButton editIsEnabled={editIsEnabled}
+//                 onClick={() => (editIsEnabled ? editTag(tag.id) : () => null)}>
+//             <EuiIcon type="pencil"/>
+//         </EditTagButton>
+//     </EuiToolTip>
+// }
+
+
+type DeleteTagButtonProps = {
+    editIsEnabled: boolean;
+}
+
+const DeleteTagButton = styled.button<DeleteTagButtonProps>(props => ({
+    width: '16px',
+    cursor: props.editIsEnabled ? 'pointer' : 'not-allowed',
+}))
+
+const editableNameWidth = '18rem';
+
+const DeleteTag = ({editIsEnabled, tag, openDeleteTagDialogue}: {editIsEnabled: boolean, tag: Tag, openDeleteTagDialogue: (tag: Tag) => void}) => {
+
+    return <DeleteTagButton editIsEnabled={editIsEnabled} onClick={() => openDeleteTagDialogue(tag)}>
+        <EuiIcon type="trash" color="danger"/>
+        </DeleteTagButton>
+}
+
+export const EditableNameField = ({
+    editIsEnabled,
+    editTag,
+    tag,
+    fetchTags,
+    isLoading,
+  }: { editIsEnabled: boolean, editTag: (tag: Tag) => void, tag: Tag, fetchTags: () => void, isLoading: boolean }) => {
+    console.log(tag)
+    return (
+      <>
+        <EuiFlexGroup css={css`width: ${editableNameWidth}`}>
+            <EuiInlineEditText
+                inputAriaLabel="Edit text inline"
+                defaultValue={tag.name}
+                size='s'
+                onSave={(newInlineEditValue: string) => {
+                    console.log("WHU")
+                    const newTag = {id: tag.id, name: newInlineEditValue}
+                    editTag(newTag)
+                }}
+                css={css`width: 100%; color: black`}
+            />
+        </EuiFlexGroup>
+      </>
+    );
+  };
+
+const createTagTableColumns = (editTag: (tag: Tag) => void, fetchTags: () => void, isLoading: boolean, openDeleteTagDialogue: (tag: Tag) => void): Array<EuiBasicTableColumn<Tag>> => {
+    const hasEditPermissions = useCreateEditPermissions();
     return [
         {
             field: 'id',
-            name: 'id'
-        },{
+            name: 'Tag ID',
+            width: '4rem'
+        },
+        {
             field: 'name',
-            name: 'Name'
+            name: 'Name',
+            width: editableNameWidth,
+            actions: [{
+              name: 'Edit',
+              render: (item, enabled) => <EditableNameField editIsEnabled={enabled} editTag={editTag} tag={item} fetchTags={fetchTags} isLoading={isLoading} />,
+              isPrimary: true,
+              description: 'Edit this tag',
+            //   onClick: (tag: Tag) => {
+            //     editTag(tag.id)
+            //   },
+              enabled: () => hasEditPermissions,
+              'data-test-subj': 'action-edit',
+            }]
+          },
+        {
+            field: 'ruleCount',
+            width: '10rem',
+            name: 'Associated rules',
+        },
+        {
+            width: '4rem',
+            name: 'Delete',
+            actions: [{
+                name: 'Delete',
+                render: (item, enabled) => <DeleteTag editIsEnabled={enabled} tag={item} openDeleteTagDialogue={openDeleteTagDialogue}/>
+            }]
         }
     ]
 }
-export const TagsTable = () => {
-    const {tags, fetchTags} = useTags();
 
-    const fetchUsages = 
+const DeleteTagWarning = ({tag, setTagToDelete, deleteTag}: {tag: Tag, setTagToDelete: (tag: Tag | null) => void, deleteTag: (tag: Tag) => void}) => {
+    return <EuiToast
+        title="Confirm Tag delete action"
+        color="danger"
+        iconType="warning"
+        onClose={() => {setTagToDelete(null)}}
+        css={css`
+            position: absolute;
+            bottom: 20px;
+            right: 20px;
+            background-color: white;
+            padding: 20px;
+            z-index: 1;
+            box-shadow: 2px 2px 10px rgba(0,0,0,0.4)
+        `}
+    >
+    <p>
+      Are you sure you want to delete the tag '{tag.name}'?
+    <br/>
+      This action is <strong>permanent</strong> and will remove the tag from all associated rules.
+    </p>
+
+    <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+      <EuiFlexItem grow={false}>
+        <EuiButton onClick={() => deleteTag(tag)}size="s" color="danger">Delete the '{tag.name}' tag</EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </EuiToast>
+}
+export const TagsTable = () => {
+    const {tags, fetchTags, isLoading, tagRuleCounts, fetchTagRuleCounts, isLoadingTagRuleCounts, updateTag, deleteTag} = useTags();
+    const items = Object.values(tags).map(tag => {
+        return {id: tag.id, name: tag.name, ruleCount: tagRuleCounts ? tagRuleCounts.draft.find(tagRule => tagRule.tagId === tag.id)?.ruleCount : 0}
+    })
+
+    const [tagToDelete, setTagToDelete] = useState<Tag | null>(null)
+
+    const openDeleteTagDialogue = (tag: Tag) => {
+        console.log(tag)
+        setTagToDelete(tag)
+    }
+
+    const columns = createTagTableColumns(updateTag, fetchTags, isLoading, openDeleteTagDialogue)
+      
     return (<>
         <EuiFlexGroup>
             <EuiFlexItem/>
@@ -30,11 +163,16 @@ export const TagsTable = () => {
                     </EuiFlexItem>
                 </EuiFlexGroup>
                 <EuiFlexGroup>
+                    {tagToDelete ? <DeleteTagWarning tag={tagToDelete} setTagToDelete={setTagToDelete} deleteTag={deleteTag}/> : null}
                     <EuiFlexItem>
                         <EuiInMemoryTable
-                            columns={createTagTableColumns()}
-                            items={Object.values(tags)}
+                            columns={columns}
+                            items={items}
                             css={css`max-width: 500px`}
+                            sorting={{sort: {
+                                field: 'id',
+                                direction: 'asc',
+                            }}}
                         >
                         </EuiInMemoryTable>
                     </EuiFlexItem>

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -41,7 +41,7 @@ export const EditableNameField = ({
     }, [tag])
     return (
       <>
-        <EuiFlexGroup css={css`width: ${editableNameWidth}`}>
+        <EuiFlexGroup css={css`width: ${editableNameWidth}; padding-left: 1.2rem;`}>
             {editIsEnabled ? 
                 <EuiInlineEditText
                     inputAriaLabel="Edit text inline"
@@ -65,13 +65,15 @@ export const EditableNameField = ({
 const createTagTableColumns = (editTag: (tag: Tag) => void, fetchTags: () => void, isLoading: boolean, openDeleteTagDialogue: (tag: Tag) => void, hasEditPermissions: boolean): Array<EuiBasicTableColumn<Tag>> => {
     return [
         {
-            field: 'id',
-            name: 'Tag ID',
-            width: '5rem',
-            sortable: true
+            // Bit of a hack to sort alphabetically on load
+            field: 'name',
+            width: '0rem',
+            name: 'Name',
+            render: (item, enabled) => null,
+            dataType: 'string',
+            sortable: ({ name }) => name.toLowerCase(),
         },
         {
-            field: 'name',
             name: 'Name',
             width: editableNameWidth,
             actions: [{
@@ -79,7 +81,7 @@ const createTagTableColumns = (editTag: (tag: Tag) => void, fetchTags: () => voi
               render: (item, enabled) => <EditableNameField editIsEnabled={enabled} editTag={editTag} tag={item} fetchTags={fetchTags} isLoading={isLoading} key={item.id} />,
               enabled: () => hasEditPermissions,
             //   'data-test-subj': 'action-edit',
-            }]
+            }],
           },
         {
             field: 'ruleCount',
@@ -209,7 +211,7 @@ export const TagsTable = () => {
                             columns={columns}
                             items={items}
                             sorting={{sort: {
-                                field: 'id',
+                                field: 'name',
                                 direction: 'asc',
                             }}}
                         >

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -175,8 +175,20 @@ const DeleteTagWarning = ({tag, setTagToDelete, deleteTag}: {tag: Tag, setTagToD
     </EuiFlexGroup>
   </EuiToast>
 }
+
+const ServerErrorNotification =  ({error}: {error: string}) => {
+   return <EuiToast
+        title="Server Error"
+        color="danger"
+        iconType="error"
+        css={deleteTagWarningCss}
+    >
+        <p>{error}</p>
+    </EuiToast>
+
+}
 export const TagsTable = () => {
-    const {tags, fetchTags, isLoading, tagRuleCounts, fetchTagRuleCounts, isLoadingTagRuleCounts, updateTag, deleteTag, createTag} = useTags();
+    const {tags, fetchTags, isLoading, tagRuleCounts, fetchTagRuleCounts, isLoadingTagRuleCounts, updateTag, deleteTag, createTag, error} = useTags();
     const items = Object.values(tags).map(tag => {
         return {id: tag.id, name: tag.name, ruleCount: tagRuleCounts ? tagRuleCounts.draft.find(tagRule => tagRule.tagId === tag.id)?.ruleCount : 0}
     })
@@ -220,6 +232,7 @@ export const TagsTable = () => {
                 </EuiFlexGroup>
             </ EuiFlexItem>
             <EuiFlexItem/>
+            {error ? <ServerErrorNotification error={error}/> : null}
         </EuiFlexGroup>
     </>)
 }

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -206,10 +206,8 @@ const ServerErrorNotification =  ({error}: {error: string}) => {
 
 }
 export const TagsTable = () => {
-    const {tags, fetchTags, isLoading, tagRuleCounts, fetchTagRuleCounts, isLoadingTagRuleCounts, updateTag, deleteTag, createTag, error, isLoadingCreatedTag} = useTags();
-    const items = Object.values(tags).map(tag => {
-        return {id: tag.id, name: tag.name, ruleCount: tagRuleCounts ? tagRuleCounts.draft.find(tagRule => tagRule.tagId === tag.id)?.ruleCount : 0}
-    })
+    const {tags, fetchTags, isLoading, tagRuleCounts, updateTag, deleteTag, createTag, error, isLoadingCreatedTag} = useTags();
+    const items = Object.values(tags)
 
     const [tagToDelete, setTagToDelete] = useState<Tag | null>(null)
     const [hideDeletionModal, setHideDeletionModal] = useState(false);

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -1,12 +1,11 @@
 import { EuiBasicTableColumn, EuiButton, EuiButtonEmpty, EuiFieldText, EuiFlexGroup, EuiFlexItem, EuiForm, EuiFormRow, EuiIcon, EuiInMemoryTable, EuiInMemoryTableProps, EuiInlineEditText, EuiLoadingSpinner, EuiModal, EuiModalBody, EuiModalHeader, EuiModalHeaderTitle, EuiSpacer, EuiText, EuiTextColor, EuiTitle, EuiToast, EuiToolTip } from "@elastic/eui"
 import { css } from "@emotion/react"
-import { Tag, useTags } from "./hooks/useTags";
+import { Tag, useTags, TagContent } from "./hooks/useTags";
 import React, { useEffect, useState } from "react";
 import styled from "@emotion/styled";
 import { useCreateEditPermissions } from "./RulesTable";
 import { RuleFormSection } from "./RuleFormSection";
 import { ErrorIResponse } from "../utils/api";
-
 
 type DeleteTagButtonProps = {
     editIsEnabled: boolean;
@@ -19,13 +18,13 @@ const DeleteTagButton = styled.button<DeleteTagButtonProps>(props => ({
 
 const editableNameWidth = '18rem';
 
-const getTagMethodDisabledMessage = (methodName: string) => 
+const getTagMethodDisabledMessage = (methodName: string) =>
     `You do not have the correct permissions to ${methodName} a tag. Please contact Central Production if you need to do so.`
 
 const DeleteTag = (
-    {editIsEnabled, tag, openDeleteTagDialogue, isLoading, tagToDelete}: 
+    {editIsEnabled, tag, openDeleteTagDialogue, isLoading, tagToDelete}:
     {editIsEnabled: boolean, tag: Tag, openDeleteTagDialogue: (tag: Tag) => void, isLoading: boolean, tagToDelete: Tag | null}
-) => 
+) =>
     <EuiToolTip
         content={editIsEnabled ? "" : getTagMethodDisabledMessage('delete')}>
         <DeleteTagButton editIsEnabled={editIsEnabled} onClick={() => editIsEnabled ? openDeleteTagDialogue(tag) : null}>
@@ -37,7 +36,7 @@ export const EditableNameField = ({
     editIsEnabled,
     editTag,
     tag,
-  }: { editIsEnabled: boolean, editTag: (tag: Tag) => void, tag: Tag, fetchTags: () => void }) => {
+  }: { editIsEnabled: boolean, editTag: (tag: TagContent) => void, tag: Tag, fetchTags: () => void }) => {
     const [tagName, setTagName] = useState(tag.name);
     useEffect(() => {
         setTagName(tag.name)
@@ -45,7 +44,7 @@ export const EditableNameField = ({
     return (
       <>
         <EuiFlexGroup css={css`width: ${editableNameWidth};`}>
-            {editIsEnabled ? 
+            {editIsEnabled ?
                 <EuiInlineEditText
                     inputAriaLabel="Edit text inline"
                     defaultValue={tagName}
@@ -66,10 +65,10 @@ export const EditableNameField = ({
   };
 
 const createTagTableColumns = (
-    editTag: (tag: Tag) => void, 
-    fetchTags: () => void, 
-    isLoading: boolean, 
-    openDeleteTagDialogue: (tag: Tag) => void, 
+    editTag: (tag: TagContent) => void,
+    fetchTags: () => void,
+    isLoading: boolean,
+    openDeleteTagDialogue: (tag: Tag) => void,
     hasEditPermissions: boolean,
     tagToDelete: Tag | null,
 ): Array<EuiBasicTableColumn<Tag>> => {
@@ -118,9 +117,9 @@ const CreateTagForm = ({createTag, enabled, isLoadingCreatedTag}: {createTag: (t
                 <EuiFlexItem grow={true}>
                     <EuiToolTip
                     content={enabled ? "" : getTagMethodDisabledMessage('create')}>
-                        <EuiFieldText 
-                            placeholder="Tag name..." 
-                            value={tagName} 
+                        <EuiFieldText
+                            placeholder="Tag name..."
+                            value={tagName}
                             onChange={(e) => {setClientSideValidationError(null); setTagName(e.target.value || "")}}
                             disabled={!enabled}
                         />
@@ -132,7 +131,7 @@ const CreateTagForm = ({createTag, enabled, isLoadingCreatedTag}: {createTag: (t
                         <EuiButton onClick={() => createTagIfSuitable(tagName)} color={"primary"} fill disabled={!enabled || isLoadingCreatedTag}>
                             {isLoadingCreatedTag ? <EuiLoadingSpinner size="s" /> : "Create Tag"}
                         </EuiButton>
-                    
+
                     </EuiToolTip>
                 </EuiFlexItem>
             </EuiFlexGroup>
@@ -156,19 +155,19 @@ const deleteTagWarningCss = css`
 `;
 
 const DeleteTagWarning = (
-    {tag, setTagToDelete, deleteTag, setHideDeletionModal}: 
+    {tag, setTagToDelete, deleteTag, setHideDeletionModal}:
     {tag: Tag, setTagToDelete: (tag: Tag | null) => void, deleteTag: (tag: Tag) => Promise<ErrorIResponse | undefined>, setHideDeletionModal: (bool: boolean) => void}
 ) => {
-    const deleteAndClosePrompty = (tag: Tag) => { 
+    const deleteAndClosePrompty = (tag: Tag) => {
         setHideDeletionModal(true);
         deleteTag(tag).then(() => {
             setTagToDelete(null);
             setHideDeletionModal(false);
         })
-        
+
     }
-    return <EuiModal 
-        onClose={() => {setTagToDelete(null)}} 
+    return <EuiModal
+        onClose={() => {setTagToDelete(null)}}
         initialFocus="[name=popswitch]"
         color="danger"
     >
@@ -206,7 +205,7 @@ const ServerErrorNotification =  ({error}: {error: string}) => {
 
 }
 export const TagsTable = () => {
-    const {tags, fetchTags, isLoading, tagRuleCounts, updateTag, deleteTag, createTag, error, isLoadingCreatedTag} = useTags();
+    const {tags, fetchTags, isLoading, updateTag, deleteTag, createTag, error, isLoadingCreatedTag} = useTags();
     const items = Object.values(tags)
 
     const [tagToDelete, setTagToDelete] = useState<Tag | null>(null)

--- a/apps/rule-manager/client/src/ts/components/context/featureSwitches.tsx
+++ b/apps/rule-manager/client/src/ts/components/context/featureSwitches.tsx
@@ -17,12 +17,7 @@ const allFeatureSwitches = [
     name: "Enable destructive reload from rules sheet",
     id: "enable-destructive-reload",
     default: false,
-  },
-  {
-    name: "Show tags page",
-    id: "show-tags-page",
-    default: false,
-  },
+  }
 ] as const;
 
 type FeatureSwitchIds = (typeof allFeatureSwitches)[number]["id"];

--- a/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
@@ -192,7 +192,7 @@ export function useRule(ruleId: number | undefined) {
         body: JSON.stringify(ruleForm)
       })
 
-      const parsedResponse = await responseHandler(response);
+      const parsedResponse = await responseHandler<DraftRule>(response);
       if (parsedResponse.status === "ok") {
         setRuleDataAndClearErrors({ ...ruleData || { live: [] }, draft: parsedResponse.data });
       } else {
@@ -217,7 +217,7 @@ export function useRule(ruleId: number | undefined) {
         body: JSON.stringify(ruleForm)
       });
 
-      const parsedResponse = await responseHandler(createRuleResponse);
+      const parsedResponse = await responseHandler<DraftRule>(createRuleResponse);
       if (parsedResponse.status === "ok") {
         setRuleDataAndClearErrors({...ruleData || {live: []}, draft: parsedResponse.data});
       } else {

--- a/apps/rule-manager/client/src/ts/components/hooks/useTags.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useTags.ts
@@ -25,6 +25,7 @@ export function useTags() {
   const [tags, setTags] = useState<Record<number, Tag>>(defaultTags)
   const [tagRuleCounts, setTagRuleCounts] = useState<TagRuleCounts | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingCreatedTag, setIsLoadingCreatedTag] = useState(false);
   const [isLoadingTagRuleCounts, setIsLoadingTagRuleCounts] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
 
@@ -95,7 +96,7 @@ export function useTags() {
 
   const createTag = async (tagName: string) => {
 
-    setIsLoading(true);
+    setIsLoadingCreatedTag(true);
     try {
       const response = await fetch(`${location.origin}/api/tags`, {
         method: 'POST',
@@ -115,7 +116,7 @@ export function useTags() {
     } catch (error) {
       setError(errorToString(error));
     } finally {
-      setIsLoading(false);
+      setIsLoadingCreatedTag(false);
     }
   }
 
@@ -137,7 +138,7 @@ export function useTags() {
       const parsedResponse = await textResponseHandler(response);
 
       if (parsedResponse.status === "ok") {
-        fetchTags();
+        await fetchTags();
       } else {
         setError(parsedResponse.errorMessage);
       }
@@ -153,5 +154,5 @@ export function useTags() {
     fetchTagRuleCounts();
   }, [])
 
-  return { tags, isLoading, error, fetchTags, fetchTagRuleCounts, tagRuleCounts, isLoadingTagRuleCounts, updateTag, deleteTag, createTag };
+  return { tags, isLoading, error, fetchTags, fetchTagRuleCounts, tagRuleCounts, isLoadingTagRuleCounts, updateTag, deleteTag, createTag, isLoadingCreatedTag };
 }

--- a/apps/rule-manager/client/src/ts/components/hooks/useTags.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useTags.ts
@@ -8,11 +8,16 @@ export type Tag = {
   name: string
 }
 
+export type TagRuleCount = {
+  live: number[][]
+}
+
 export type TagMap = Record<string, Tag>;
 
 export function useTags() {
   const [tags, setTags] = useState<Record<number, Tag>>(defaultTags)
   const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingTagRuleCounts, setIsLoadingTagRuleCount] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
 
   const fetchTags = async (): Promise<void> => {
@@ -35,9 +40,28 @@ export function useTags() {
     setIsLoading(false);
   }
 
+  const fetchTagRuleCounts = async (): Promise<void> => {
+    setIsLoadingTagRuleCount(true);
+
+    try {
+      const response = await fetch(`${location.origin}/api/tags/ruleCount`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch rules: ${response.status} ${response.statusText}`);
+      }
+      const tagsRuleCounts: {} = await response.json();
+      const tagMap = {} as Record<string, Tag>;
+      for (const tag of tags) {
+        tagMap[tag.id] = tag
+      }
+      setTags(tagMap);
+    } catch (error) {
+      setError(errorToString(error));
+    }
+  }
+
   useEffect(() => {
     fetchTags()
   }, [])
 
-  return { tags, isLoading, error, fetchTags };
+  return { tags, isLoading, error, fetchTags, fetchTagRuleCounts, isLoadingTagRuleCounts, setIsLoadingTagRuleCount };
 }

--- a/apps/rule-manager/client/src/ts/components/hooks/useTags.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useTags.ts
@@ -6,27 +6,18 @@ const defaultTags = {}
 
 export type Tag = {
   id: number,
-  name: string
-}
-
-type TagRuleCount = {
-  tagId: number,
+  name: string,
   ruleCount: number
 }
 
-type TagRuleCounts = {
-  draft: TagRuleCount[],
-  live: TagRuleCount[]
-}
+export type TagContent = Omit<Tag, "ruleCount">;
 
 export type TagMap = Record<string, Tag>;
 
 export function useTags() {
   const [tags, setTags] = useState<Record<number, Tag>>(defaultTags)
-  const [tagRuleCounts, setTagRuleCounts] = useState<TagRuleCounts | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingCreatedTag, setIsLoadingCreatedTag] = useState(false);
-  const [isLoadingTagRuleCounts, setIsLoadingTagRuleCounts] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
 
   const fetchTags = async (): Promise<void> => {
@@ -49,7 +40,7 @@ export function useTags() {
     setIsLoading(false);
   }
 
-  const updateTag = async (tagForm: Tag) => {
+  const updateTag = async (tagForm: TagContent) => {
     setIsLoading(true);
 
     // We would always expect the ruleForm to include an ID when updating a rule
@@ -118,7 +109,7 @@ export function useTags() {
         },
         body: JSON.stringify(tagForm)
       })
-      
+
       const parsedResponse = await textResponseHandler(response);
 
       if (parsedResponse.status === "ok") {
@@ -137,5 +128,5 @@ export function useTags() {
     fetchTags();
   }, [])
 
-  return { tags, isLoading, error, fetchTags, tagRuleCounts, isLoadingTagRuleCounts, updateTag, deleteTag, createTag, isLoadingCreatedTag };
+  return { tags, isLoading, error, fetchTags, updateTag, deleteTag, createTag, isLoadingCreatedTag };
 }

--- a/apps/rule-manager/client/src/ts/components/hooks/useTags.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useTags.ts
@@ -49,22 +49,6 @@ export function useTags() {
     setIsLoading(false);
   }
 
-  const fetchTagRuleCounts = async (): Promise<void> => {
-    setIsLoadingTagRuleCounts(true);
-
-    try {
-      const response = await fetch(`${location.origin}/api/tags/ruleCount`);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch rules: ${response.status} ${response.statusText}`);
-      }
-      const tagsRuleCounts: TagRuleCounts = await response.json();
-      setTagRuleCounts(tagsRuleCounts);
-    } catch (error) {
-      setError(errorToString(error));
-    }
-    setIsLoadingTagRuleCounts(false);
-  }
-
   const updateTag = async (tagForm: Tag) => {
     setIsLoading(true);
 
@@ -151,8 +135,7 @@ export function useTags() {
 
   useEffect(() => {
     fetchTags();
-    fetchTagRuleCounts();
   }, [])
 
-  return { tags, isLoading, error, fetchTags, fetchTagRuleCounts, tagRuleCounts, isLoadingTagRuleCounts, updateTag, deleteTag, createTag, isLoadingCreatedTag };
+  return { tags, isLoading, error, fetchTags, tagRuleCounts, isLoadingTagRuleCounts, updateTag, deleteTag, createTag, isLoadingCreatedTag };
 }

--- a/apps/rule-manager/client/src/ts/components/hooks/useTags.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useTags.ts
@@ -81,8 +81,34 @@ export function useTags() {
 
       const parsedResponse = await responseHandler<Tag>(response);
       if (parsedResponse.status === "ok") {
-        fetchTags()
-        //TODO: use the returned data instead
+        const updatedTag = parsedResponse.data;
+        setTags({...tags, [`${updatedTag.id}`]: updatedTag})
+      } else {
+        setError(parsedResponse.errorMessage);
+      }
+    } catch (error) {
+      setError(errorToString(error));
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  const createTag = async (tagName: string) => {
+
+    setIsLoading(true);
+    try {
+      const response = await fetch(`${location.origin}/api/tags`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({name: tagName})
+      })
+
+      const parsedResponse = await responseHandler<Tag>(response);
+      if (parsedResponse.status === "ok") {
+        const updatedTag = parsedResponse.data;
+        setTags({...tags, [`${updatedTag.id}`]: updatedTag})
       } else {
         setError(parsedResponse.errorMessage);
       }
@@ -127,5 +153,5 @@ export function useTags() {
     fetchTagRuleCounts();
   }, [])
 
-  return { tags, isLoading, error, fetchTags, fetchTagRuleCounts, tagRuleCounts, isLoadingTagRuleCounts, updateTag, deleteTag };
+  return { tags, isLoading, error, fetchTags, fetchTagRuleCounts, tagRuleCounts, isLoadingTagRuleCounts, updateTag, deleteTag, createTag };
 }

--- a/apps/rule-manager/client/src/ts/components/hooks/useTags.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useTags.ts
@@ -1,6 +1,6 @@
 import {useEffect, useState} from "react"
 import {errorToString} from "../../utils/error";
-import { ErrorIResponse, responseHandler } from "../../utils/api";
+import { ErrorIResponse, responseHandler, textResponseHandler } from "../../utils/api";
 
 const defaultTags = {}
 
@@ -79,7 +79,7 @@ export function useTags() {
         body: JSON.stringify(tagForm)
       })
 
-      const parsedResponse = await responseHandler(response);
+      const parsedResponse = await responseHandler<Tag>(response);
       if (parsedResponse.status === "ok") {
         fetchTags()
         //TODO: use the returned data instead
@@ -107,11 +107,11 @@ export function useTags() {
         },
         body: JSON.stringify(tagForm)
       })
+      
+      const parsedResponse = await textResponseHandler(response);
 
-      const parsedResponse = await responseHandler(response);
       if (parsedResponse.status === "ok") {
         fetchTags();
-        //TODO: use the returned data instead
       } else {
         setError(parsedResponse.errorMessage);
       }

--- a/apps/rule-manager/client/src/ts/components/icons/index.ts
+++ b/apps/rule-manager/client/src/ts/components/icons/index.ts
@@ -19,6 +19,7 @@ import { icon as pageSelect } from "@elastic/eui/src/components/icon/assets/page
 import { icon as dot } from "@elastic/eui/src/components/icon/assets/dot";
 import { icon as checkInCircleFilled } from "@elastic/eui/src/components/icon/assets/checkInCircleFilled";
 import { icon as apps } from "@elastic/eui/src/components/icon/assets/apps";
+<<<<<<< HEAD
 import { icon as eye } from "@elastic/eui/src/components/icon/assets/eye";
 import { icon as eyeClosed } from "@elastic/eui/src/components/icon/assets/eye_closed";
 import { icon as iInCircle } from "@elastic/eui/src/components/icon/assets/iInCircle";
@@ -47,6 +48,38 @@ const cachedIcons = {
   eye,
   eyeClosed,
   iInCircle,
+=======
+import { icon as sortDown } from "@elastic/eui/src/components/icon/assets/sort_down";
+import { icon as sortUp } from "@elastic/eui/src/components/icon/assets/sort_up";
+import { icon as trash } from "@elastic/eui/src/components/icon/assets/trash";
+
+
+
+const cachedIcons = {
+    apps,
+    arrowDown,
+    arrowRight,
+    arrowLeft,
+    arrowStart,
+    arrowEnd,
+    search,
+    empty,
+    cross,
+    check,
+    error,
+    exit,
+    starEmptySpace,
+    starFilled,
+    pencil,
+    returnKey,
+    warning,
+    pageSelect,
+    dot,
+    checkInCircleFilled,
+    sortDown,
+    sortUp,
+    trash
+>>>>>>> 1b85ff1 (Add UI for tag edit and deletion)
 };
 
 appendIconComponentCache(cachedIcons);

--- a/apps/rule-manager/client/src/ts/components/icons/index.ts
+++ b/apps/rule-manager/client/src/ts/components/icons/index.ts
@@ -19,10 +19,12 @@ import { icon as pageSelect } from "@elastic/eui/src/components/icon/assets/page
 import { icon as dot } from "@elastic/eui/src/components/icon/assets/dot";
 import { icon as checkInCircleFilled } from "@elastic/eui/src/components/icon/assets/checkInCircleFilled";
 import { icon as apps } from "@elastic/eui/src/components/icon/assets/apps";
-<<<<<<< HEAD
 import { icon as eye } from "@elastic/eui/src/components/icon/assets/eye";
 import { icon as eyeClosed } from "@elastic/eui/src/components/icon/assets/eye_closed";
 import { icon as iInCircle } from "@elastic/eui/src/components/icon/assets/iInCircle";
+import { icon as sortDown } from "@elastic/eui/src/components/icon/assets/sort_down";
+import { icon as sortUp } from "@elastic/eui/src/components/icon/assets/sort_up";
+import { icon as trash } from "@elastic/eui/src/components/icon/assets/trash";
 
 const cachedIcons = {
   apps,
@@ -48,38 +50,9 @@ const cachedIcons = {
   eye,
   eyeClosed,
   iInCircle,
-=======
-import { icon as sortDown } from "@elastic/eui/src/components/icon/assets/sort_down";
-import { icon as sortUp } from "@elastic/eui/src/components/icon/assets/sort_up";
-import { icon as trash } from "@elastic/eui/src/components/icon/assets/trash";
-
-
-
-const cachedIcons = {
-    apps,
-    arrowDown,
-    arrowRight,
-    arrowLeft,
-    arrowStart,
-    arrowEnd,
-    search,
-    empty,
-    cross,
-    check,
-    error,
-    exit,
-    starEmptySpace,
-    starFilled,
-    pencil,
-    returnKey,
-    warning,
-    pageSelect,
-    dot,
-    checkInCircleFilled,
-    sortDown,
-    sortUp,
-    trash
->>>>>>> 1b85ff1 (Add UI for tag edit and deletion)
+  sortDown,
+  sortUp,
+  trash
 };
 
 appendIconComponentCache(cachedIcons);

--- a/apps/rule-manager/client/src/ts/components/layout/Header.tsx
+++ b/apps/rule-manager/client/src/ts/components/layout/Header.tsx
@@ -73,7 +73,7 @@ export const Header = () => {
           <Link to="/tags">
             <EuiHeaderLink isActive={useLocation().pathname === "/tags"}>Tags</EuiHeaderLink>
           </Link>
-        </EuiHeaderLinks> : null
+</EuiHeaderLinks>
       </NavContainer>
       <EuiPopover
         button={ProfileMenuButton}

--- a/apps/rule-manager/client/src/ts/components/layout/Header.tsx
+++ b/apps/rule-manager/client/src/ts/components/layout/Header.tsx
@@ -66,17 +66,14 @@ export const Header = () => {
             <Logo />
           </Link>
         </HeaderLogo>
-        {
-        getFeatureSwitchValue('show-tags-page') ?
-          <EuiHeaderLinks>
-            <Link to="/">
-              <EuiHeaderLink isActive={useLocation().pathname === "/"}>Rules</EuiHeaderLink>
-            </Link>
-            <Link to="/tags">
-              <EuiHeaderLink isActive={useLocation().pathname === "/tags"}>Tags</EuiHeaderLink>
-            </Link>
-          </EuiHeaderLinks> : null
-        }
+        <EuiHeaderLinks>
+          <Link to="/">
+            <EuiHeaderLink isActive={useLocation().pathname === "/"}>Rules</EuiHeaderLink>
+          </Link>
+          <Link to="/tags">
+            <EuiHeaderLink isActive={useLocation().pathname === "/tags"}>Tags</EuiHeaderLink>
+          </Link>
+        </EuiHeaderLinks> : null
       </NavContainer>
       <EuiPopover
         button={ProfileMenuButton}

--- a/apps/rule-manager/client/src/ts/components/layout/Page.tsx
+++ b/apps/rule-manager/client/src/ts/components/layout/Page.tsx
@@ -11,6 +11,7 @@ import { PageDataProvider } from "../../utils/window";
 import RulesTable from "../RulesTable";
 import styled from "@emotion/styled";
 import { PageNotFound } from "../PageNotFound";
+import { TagsTable } from "../TagsTable";
 
 // Necessary while SASS and Emotion styles coexist within EUI.
 const cache = createCache({
@@ -42,7 +43,7 @@ export const Page = () => (
             <Route path="/tags" element={
                 <>
                   <PageContent>
-                    Tags will be here
+                    <TagsTable />
                   </PageContent>
                 </>
               }

--- a/apps/rule-manager/client/src/ts/utils/api.ts
+++ b/apps/rule-manager/client/src/ts/utils/api.ts
@@ -1,8 +1,13 @@
 import {DraftRule} from "../components/hooks/useRule";
 
-export interface OkIResponse {
+export interface OkIResponse<T>{
     status: 'ok'
-    data: DraftRule
+    data: T
+}
+
+export interface OkIStringResponse {
+    status: 'ok'
+    data: string
 }
 
 export interface ErrorIResponse {
@@ -17,15 +22,24 @@ export const createErrorResponse = (errorMessage: string, statusCode: number): E
     statusCode
 });
 
-export const createOkResponse = (apiRule: DraftRule): OkIResponse => ({
+export const createOkResponse = <T>(apiRule: T): OkIResponse<T> => ({
     status: 'ok',
     data: apiRule
 })
 
-export const responseHandler = async (response: Response) => {
+export const responseHandler = async <T>(response: Response) => {
     if (response.ok){
         const message = await response.json()
-        return createOkResponse(message)
+        return createOkResponse<T>(message)
+    } else {
+        return createErrorResponse(response.statusText, response.status)
+    }
+}
+
+export const textResponseHandler = async (response: Response) => {
+    if (response.ok){
+        const message = await response.text()
+        return createOkResponse<string>(message)
     } else {
         return createErrorResponse(response.statusText, response.status)
     }

--- a/apps/rule-manager/client/src/ts/utils/error.ts
+++ b/apps/rule-manager/client/src/ts/utils/error.ts
@@ -1,2 +1,2 @@
 export const errorToString = (error: unknown): string =>
-  error instanceof Error ? error.message : error ? error.toString() : typeof error;
+  error instanceof Error ? error.message : error ? (error as object).toString() : typeof error;

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -35,11 +35,9 @@ POST    /api/rules/:id/unarchive        controllers.RulesController.unarchive(id
 
 # Tags
 +nocsrf
-GET     /api/tags                       controllers.TagsController.list()
+GET     /api/tags                       controllers.TagsController.listWithRuleCounts()
 +nocsrf
 POST    /api/tags                       controllers.TagsController.create()
-+nocsrf
-GET     /api/tags/ruleCount             controllers.TagsController.getRuleCountForAllTags()
 +nocsrf
 GET     /api/tags/:id                   controllers.TagsController.get(id: Int)
 +nocsrf

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -39,6 +39,8 @@ GET     /api/tags                       controllers.TagsController.list()
 +nocsrf
 POST    /api/tags                       controllers.TagsController.create()
 +nocsrf
+GET     /api/tags/ruleCount             controllers.TagsController.getRuleCountForAllTags()
++nocsrf
 GET     /api/tags/:id                   controllers.TagsController.get(id: Int)
 +nocsrf
 POST    /api/tags/:id                   controllers.TagsController.update(id: Int)

--- a/apps/rule-manager/test/db/RuleTagDraftSpec.scala
+++ b/apps/rule-manager/test/db/RuleTagDraftSpec.scala
@@ -23,6 +23,11 @@ class RuleTagDraftSpec extends FixtureAnyFlatSpec with Matchers with RuleFixture
     maybeFound should be(List(1))
   }
 
+  it should "find the count of rules for each tag" in { implicit session =>
+    val count = RuleTagDraft.countRulesForAllTags()
+    count should be(List((1,1)))
+  }
+
   it should "find all records" in { implicit session =>
     val allResults = RuleTagDraft.findAll()
     allResults should be(List(RuleTagDraft(1, 1)))

--- a/apps/rule-manager/test/db/RuleTagDraftSpec.scala
+++ b/apps/rule-manager/test/db/RuleTagDraftSpec.scala
@@ -25,7 +25,7 @@ class RuleTagDraftSpec extends FixtureAnyFlatSpec with Matchers with RuleFixture
 
   it should "find the count of rules for each tag" in { implicit session =>
     val count = RuleTagDraft.countRulesForAllTags()
-    count should be(List((1,1)))
+    count should be(List((1, 1)))
   }
 
   it should "find all records" in { implicit session =>

--- a/apps/rule-manager/test/db/RuleTagDraftSpec.scala
+++ b/apps/rule-manager/test/db/RuleTagDraftSpec.scala
@@ -23,11 +23,6 @@ class RuleTagDraftSpec extends FixtureAnyFlatSpec with Matchers with RuleFixture
     maybeFound should be(List(1))
   }
 
-  it should "find the count of rules for each tag" in { implicit session =>
-    val count = RuleTagDraft.countRulesForAllTags()
-    count should be(List((1, 1)))
-  }
-
   it should "find all records" in { implicit session =>
     val allResults = RuleTagDraft.findAll()
     allResults should be(List(RuleTagDraft(1, 1)))

--- a/apps/rule-manager/test/db/TagsSpec.scala
+++ b/apps/rule-manager/test/db/TagsSpec.scala
@@ -5,7 +5,12 @@ import org.scalatest.matchers.should.Matchers
 import scalikejdbc.scalatest.AutoRollback
 import scalikejdbc._
 
-class TagsSpec extends FixtureAnyFlatSpec with Matchers with RuleFixture with AutoRollback with DBTest {
+class TagsSpec
+    extends FixtureAnyFlatSpec
+    with Matchers
+    with RuleFixture
+    with AutoRollback
+    with DBTest {
   val t = Tags.syntax("t")
 
   behavior of "Tags"

--- a/apps/rule-manager/test/db/TagsSpec.scala
+++ b/apps/rule-manager/test/db/TagsSpec.scala
@@ -29,7 +29,7 @@ class TagsSpec
   }
   it should "find all records with rule counts" in { implicit session =>
     val allResults = Tags.findAllWithRuleCounts()
-    allResults should be(List((Tag(Some(1), "testTag"), 1)))
+    allResults should be(List(TagWithRuleCount(Some(1), "testTag", 1)))
   }
   it should "count all records" in { implicit session =>
     val count = Tags.countAll()


### PR DESCRIPTION
## What does this change?

This PR adds: 
- a Tags page at the `/tags` path
- a table of tags, listing how many rules they are associated with
- a new method to count the rules associated with a tag
- a 'create tag' form
- inline-editing in the table for tag names
- a 'delete tag' action on the tag table, with a confirmation action

## How to test

Run the application locally according to the instructions in the readme. Enable the Tags page feature switch in teh dropdown in the top right of the rule manager.

If you have Typerighter permissions, can you do all of the following:
- List all tags, and see the number of rules they're associated with?
- Delete a tag?
- Edit a tag name?

If you lack edit permissions, are you prevented from creating, editing, or deleting rules?

## Images

![Kapture 2023-07-12 at 16 27 47](https://github.com/guardian/typerighter/assets/34686302/cfbc039b-62bc-477e-a29c-d9790ff2d6bf)