### PR TITLE
DRY play-app commonalities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,16 +30,6 @@ val appsFolder = "apps"
 
 val commonSettings = Seq(
   Test / fork := false, // Enables attaching debugger in tests
-  Universal / javaOptions ++= Seq(
-    s"-Dpidfile.path=/dev/null",
-    "-J-XX:MaxRAMFraction=2",
-    "-J-XX:InitialRAMFraction=2",
-    "-J-XX:MaxMetaspaceSize=300m",
-    "-J-XX:+PrintGCDetails",
-    "-J-XX:+PrintGCDateStamps",
-    s"-J-Dlogs.home=/var/log/${packageName.value}",
-    s"-J-Xloggc:/var/log/${packageName.value}/gc.log"
-  ),
   buildInfoPackage := "typerighter",
   buildInfoKeys := {
     lazy val buildInfo = BuildInfo(baseDirectory.value)
@@ -72,7 +62,6 @@ val commonSettings = Seq(
 val commonLib = (project in file(s"$appsFolder/common-lib"))
   .enablePlugins(BuildInfoPlugin)
   .settings(
-    packageName := "common-lib",
     commonSettings,
     libraryDependencies ++= Seq(
       // @todo – we're repeating ourselves. Can we derive this from the plugin?
@@ -80,16 +69,32 @@ val commonLib = (project in file(s"$appsFolder/common-lib"))
     )
   )
 
-val checker = (project in file(s"$appsFolder/checker"))
-  .dependsOn(commonLib)
-  .enablePlugins(PlayScala, GatlingPlugin, BuildInfoPlugin, JDebPackaging, SystemdPlugin)
+def playProject(projectName: String, devHttpPorts: Map[String, String]) =
+  Project(projectName, file(s"$appsFolder/$projectName"))
+    .dependsOn(commonLib)
+    .enablePlugins(PlayScala, BuildInfoPlugin, JDebPackaging, SystemdPlugin)
+    .settings(
+      PlayKeys.devSettings ++= devHttpPorts.map { case (protocol, value) => s"play.server.$protocol.port" -> value }.toSeq,
+      libraryDependencies += ws,
+      Universal / javaOptions ++= Seq(
+        s"-Dpidfile.path=/dev/null",
+        "-J-XX:MaxRAMFraction=2",
+        "-J-XX:InitialRAMFraction=2",
+        "-J-XX:MaxMetaspaceSize=300m",
+        "-J-XX:+PrintGCDetails",
+        "-J-XX:+PrintGCDateStamps",
+        s"-J-Dlogs.home=/var/log/${packageName.value}",
+        s"-J-Xloggc:/var/log/${packageName.value}/gc.log"
+      ),
+      commonSettings
+    )
+
+val checker = playProject("checker", Map("http" -> "9100"))
+  .enablePlugins(GatlingPlugin)
   .settings(
     Universal / javaOptions += s"-Dconfig.file=/etc/gu/${packageName.value}.conf",
     packageName := "typerighter-checker",
-    PlayKeys.devSettings += "play.server.http.port" -> "9100",
-    commonSettings,
     libraryDependencies ++= Seq(
-      ws,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-ssm" % awsSdkVersion,
@@ -100,26 +105,21 @@ val checker = (project in file(s"$appsFolder/checker"))
       "com.gu" %% "content-api-models-json" % capiModelsVersion,
       "com.gu" %% "content-api-client-aws" % "0.7",
       "com.gu" %% "content-api-client-default" % capiClientVersion,
-      "org.apache.opennlp" % "opennlp" % "2.1.0"
-    ),
-    libraryDependencies ++= Seq(
+      "org.apache.opennlp" % "opennlp" % "2.1.0",
+      "io.gatling.highcharts" % "gatling-charts-highcharts" % "3.7.2" % "test,it",
+      "io.gatling"            % "gatling-test-framework"    % "3.7.2" % "test,it"
+    ) ++ Seq(
       "io.circe" %% "circe-core",
       "io.circe" %% "circe-generic",
       "io.circe" %% "circe-parser"
-    ).map(_ % circeVersion),
-    libraryDependencies += "io.gatling.highcharts" % "gatling-charts-highcharts" % "3.7.2" % "test,it",
-    libraryDependencies += "io.gatling"            % "gatling-test-framework"    % "3.7.2" % "test,it",
+    ).map(_ % circeVersion)
   )
 
-val ruleManager = (project in file(s"$appsFolder/rule-manager"))
-  .dependsOn(commonLib)
-  .enablePlugins(PlayScala, BuildInfoPlugin, JDebPackaging, SystemdPlugin, ScalikejdbcPlugin)
+val ruleManager = playProject("rule-manager", Map("http" -> "9101"))
+  .enablePlugins(ScalikejdbcPlugin)
   .settings(
     packageName := "typerighter-rule-manager",
-    PlayKeys.devSettings += "play.server.http.port" -> "9101",
-    commonSettings,
     libraryDependencies ++= Seq(
-      ws,
       guice,
       jdbc,
       evolutions,

--- a/script/start-manager
+++ b/script/start-manager
@@ -29,9 +29,9 @@ teardownDependencies() {
 
 runRuleManager() {
   if [[ "$IS_DEBUG" = true ]] ; then
-    sbt -jvm-debug 5006 "ruleManager / run"
+    sbt -jvm-debug 5006 "rule-manager / run"
   else
-    sbt "ruleManager / run"
+    sbt "rule-manager / run"
   fi
 }
 


### PR DESCRIPTION
The commonLib project was not using javaOptions, because it's not deployable. DRYing the code removes the following sbt warning:
```
[warn] there's a key that's not used by any other settings/tasks:
[warn]
[warn] * commonLib / Universal / javaOptions
[warn]   +- /Users/freddie_preece/Code/typerighter/build.sbt:33
[warn]
[warn] note: a setting might still be used by a command; to exclude a key from this `lintUnused` check
[warn] either append it to `Global / excludeLintKeys` or call .withRank(KeyRanks.Invisible) on the key
```

The new playProject abstraction changes the sub-project ID for rule manager from 'ruleManager' to 'rule-manager'. This brings consistency between the sub-project ID and its base folder name. In practice this means you would now need to execute `rule-manager / run` to run the rule manager sub-project.

This is part of an overall drive to reduce warnings and red ink.