### PR TITLE
Remove create and edit rule feature switch

### DIFF
--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -164,13 +164,12 @@ const RulesTable = () => {
       incremental: true,
       schema: true,
     },
-    toolsRight: getFeatureSwitchValue("create-and-edit") ?
-    <EuiToolTip content={hasCreatePermissions ? "" : "You do not have the correct permissions to create a rule. Please contact Central Production if you need to create rules."}>
+    toolsRight: <EuiToolTip content={hasCreatePermissions ? "" : "You do not have the correct permissions to create a rule. Please contact Central Production if you need to create rules."}>
       <EuiButton
         isDisabled={!hasCreatePermissions}
         onClick={() => openEditRulePanel(undefined)}
       >Create Rule</EuiButton>
-    </EuiToolTip> : <></>
+    </EuiToolTip>
 };
 
   const openEditRulePanel = (ruleId: number | undefined) => {

--- a/apps/rule-manager/client/src/ts/components/context/featureSwitches.tsx
+++ b/apps/rule-manager/client/src/ts/components/context/featureSwitches.tsx
@@ -9,11 +9,6 @@ export type FeatureSwitch = {
 
 const allFeatureSwitches = [
   {
-    name: "Create and edit rules",
-    id: "create-and-edit",
-    default: false,
-  },
-  {
     name: "Enable destructive reload from rules sheet",
     id: "enable-destructive-reload",
     default: false,


### PR DESCRIPTION
## What does this change?

This removes the redundant 'Create and edit rules' feature switch, which was hiding the Create rule button.

## How to test

Run the application locally according to the instructions in the readme. Is the feature switch gone from the top right dropdown? Does the 'Create rule' button show up by default in the application?
