### PR TITLE
Pin SASS version to reduce log noise

### DIFF
--- a/apps/rule-manager/client/package-lock.json
+++ b/apps/rule-manager/client/package-lock.json
@@ -30,7 +30,7 @@
         "@types/react-dom": "~17.0.19",
         "@vitejs/plugin-react-swc": "^3.0.0",
         "jest": "^29.5.0",
-        "sass": "^1.60.0",
+        "sass": "~1.32.13",
         "ts-jest": "^29.1.0",
         "typescript": "^5.1.3",
         "utility-types": "^3.10.0",
@@ -3738,12 +3738,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/immutable": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
-      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
-      "dev": true
-    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -6976,20 +6970,18 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.0.tgz",
-      "integrity": "sha512-Q4USplo4pLYgCi+XlipZCWUQz5pkg/ruSSgJ0WRDSb/+3z9tXUOkQ7QPYn4XrhZKYAK4HlpaQecRwKLJX6+DBg==",
+      "version": "1.32.13",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.13.tgz",
+      "integrity": "sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==",
       "dev": true,
       "dependencies": {
-        "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^4.0.0",
-        "source-map-js": ">=0.6.2 <2.0.0"
+        "chokidar": ">=3.0.0 <4.0.0"
       },
       "bin": {
         "sass": "sass.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=8.9.0"
       }
     },
     "node_modules/scheduler": {
@@ -10947,12 +10939,6 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
     },
-    "immutable": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
-      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
-      "dev": true
-    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -13276,14 +13262,12 @@
       }
     },
     "sass": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.0.tgz",
-      "integrity": "sha512-Q4USplo4pLYgCi+XlipZCWUQz5pkg/ruSSgJ0WRDSb/+3z9tXUOkQ7QPYn4XrhZKYAK4HlpaQecRwKLJX6+DBg==",
+      "version": "1.32.13",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.13.tgz",
+      "integrity": "sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==",
       "dev": true,
       "requires": {
-        "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^4.0.0",
-        "source-map-js": ">=0.6.2 <2.0.0"
+        "chokidar": ">=3.0.0 <4.0.0"
       }
     },
     "scheduler": {

--- a/apps/rule-manager/client/package.json
+++ b/apps/rule-manager/client/package.json
@@ -20,7 +20,7 @@
     "@types/react-dom": "~17.0.19",
     "@vitejs/plugin-react-swc": "^3.0.0",
     "jest": "^29.5.0",
-    "sass": "^1.60.0",
+    "sass": "~1.32.13",
     "ts-jest": "^29.1.0",
     "typescript": "^5.1.3",
     "utility-types": "^3.10.0",


### PR DESCRIPTION
For versions >1.32, SASS spits out deprecation warnings for certain calc() functions. These warnings are from our dependency on ElasticUI, who currently have no intention to fix them - see: https://github.com/elastic/eui/pull/5682#issuecomment-1064378362. 

The best solution until ElasticUI have fixed these warnings is to pin our SASS version.

I've tested locally and the application runs as expected.