### PR TITLE
Add a method to the checker service to test a single rule

### DIFF
--- a/apps/checker/app/AppComponents.scala
+++ b/apps/checker/app/AppComponents.scala
@@ -112,7 +112,7 @@ class AppComponents(
   )(matcherPoolDispatcher, materializer)
 
   val bucketRuleResource = new BucketRuleResource(s3Client, typerighterBucket, stage)
-  val ruleProvisioner = new RuleProvisionerService(
+  val matcherProvisionerService = new MatcherProvisionerService(
     bucketRuleResource,
     matcherPool,
     languageToolFactory,
@@ -127,7 +127,8 @@ class AppComponents(
     case _: DevIdentity => "https://manager.typerighter.local.dev-gutools.co.uk"
   }
 
-  val apiController = new ApiController(controllerComponents, matcherPool, publicSettings)
+  val apiController =
+    new ApiController(controllerComponents, matcherPool, matcherProvisionerService, publicSettings)
   val rulesController = new RulesController(
     controllerComponents,
     matcherPool,
@@ -157,5 +158,5 @@ class AppComponents(
 
   /** Set up matchers and add them to the matcher pool as the app starts.
     */
-  ruleProvisioner.scheduleUpdateRules(actorSystem.scheduler)
+  matcherProvisionerService.scheduleUpdateRules(actorSystem.scheduler)
 }

--- a/apps/checker/app/matchers/LanguageToolMatcher.scala
+++ b/apps/checker/app/matchers/LanguageToolMatcher.scala
@@ -51,7 +51,7 @@ class LanguageToolFactory(
         acc
       } else
         new Exception(
-          s"Attempted to enable a core rule with id ${ruleId}, but the rule was not available on the instance"
+          s"Attempted to enable a core rule with id $ruleId, but the rule was not available on the instance"
         ) :: acc
     )
 

--- a/apps/checker/app/model/CheckSingle.scala
+++ b/apps/checker/app/model/CheckSingle.scala
@@ -10,7 +10,7 @@ object CheckSingleRule {
   implicit val reads: Reads[CheckSingleRule] = Json.reads[CheckSingleRule]
 }
 
-/** Everything Typerighter needs to a list of documents against a single rule.
+/** Everything Typerighter needs to get matches for a list of documents against a single rule.
   */
 case class CheckSingleRule(
     requestId: String,

--- a/apps/checker/app/model/CheckSingle.scala
+++ b/apps/checker/app/model/CheckSingle.scala
@@ -1,0 +1,48 @@
+package model
+
+import com.gu.typerighter.model.{CheckerRule, RuleMatch, TextBlock}
+import net.logstash.logback.marker.{LogstashMarker, Markers}
+import play.api.libs.json.{Json, Reads, Writes}
+
+import scala.jdk.CollectionConverters._
+
+object CheckSingleRule {
+  implicit val reads: Reads[CheckSingleRule] = Json.reads[CheckSingleRule]
+}
+
+/** Everything Typerighter needs to a list of documents against a single rule.
+  */
+case class CheckSingleRule(
+    requestId: String,
+    rule: CheckerRule,
+    documents: List[Document]
+) {
+  def toMarker: LogstashMarker = Markers.appendEntries(toMarkerMap.asJava)
+
+  def toMarker(userId: String): LogstashMarker = Markers.appendEntries(
+    (toMarkerMap + ("userId" -> userId)).asJava
+  )
+
+  private def toMarkerMap = Map(
+    "requestId" -> this.requestId,
+    "documentIds" -> this.documents.map(_.id).mkString(", "),
+    "ruleId" -> this.rule.id
+  )
+}
+
+object Document {
+  implicit val reads: Reads[Document] = Json.reads[Document]
+}
+
+case class Document(id: String, blocks: List[TextBlock])
+
+/** A single result produced by a check. Checks can produce many CheckResults.
+  */
+object CheckSingleRuleResult {
+  implicit val writes: Writes[CheckSingleRuleResult] = Json.writes[CheckSingleRuleResult]
+}
+
+case class CheckSingleRuleResult(
+    matches: List[RuleMatch],
+    percentageRequestComplete: Option[Int] = None
+)

--- a/apps/checker/app/services/MatcherPool.scala
+++ b/apps/checker/app/services/MatcherPool.scala
@@ -161,11 +161,9 @@ class MatcherPool(
 
     Source(eventualResponses)
       .mapAsyncUnordered(1)(identity)
-      .map {
-        case (job, matches) => {
-          jobsCompleted.incrementAndGet()
-          CheckResult(job.categoryIds, job.blocks, matches, Some(percentageRequestComplete))
-        }
+      .map { case (job, matches) =>
+        jobsCompleted.incrementAndGet()
+        CheckResult(job.categoryIds, job.blocks, matches, Some(percentageRequestComplete))
       }
       .alsoTo(Sink.onComplete { _ => logCheckComplete(query.toMarker) })
   }
@@ -197,11 +195,9 @@ class MatcherPool(
 
     Source(eventualResponses)
       .mapAsyncUnordered(1)(identity)
-      .map {
-        case (job, matches) => {
-          jobsCompleted.incrementAndGet()
-          CheckSingleRuleResult(matches, Some(percentageRequestComplete))
-        }
+      .map { case (_, matches) =>
+        jobsCompleted.incrementAndGet()
+        CheckSingleRuleResult(matches, Some(percentageRequestComplete))
       }
       .alsoTo(Sink.onComplete { _ => logCheckComplete(query.toMarker) })
   }

--- a/apps/checker/app/utils/JsonHelpers.scala
+++ b/apps/checker/app/utils/JsonHelpers.scala
@@ -1,0 +1,10 @@
+package utils
+
+import java.net.URL
+import play.api.libs.json.{JsString, Json, Writes}
+
+object JsonHelpers {
+  implicit val urlWrites: Writes[URL] = (o: URL) => JsString(o.toString)
+  def toNDJson[T](serializable: T)(implicit tjs: Writes[T]) =
+    Json.toJson(serializable).toString() + 31.toChar
+}

--- a/apps/checker/app/utils/JsonHelpers.scala
+++ b/apps/checker/app/utils/JsonHelpers.scala
@@ -4,7 +4,9 @@ import java.net.URL
 import play.api.libs.json.{JsString, Json, Writes}
 
 object JsonHelpers {
+  val recordSeparatorChar = 31.toChar
+
   implicit val urlWrites: Writes[URL] = (o: URL) => JsString(o.toString)
   def toNDJson[T](serializable: T)(implicit tjs: Writes[T]) =
-    Json.toJson(serializable).toString() + 31.toChar
+    Json.toJson(serializable).toString() + recordSeparatorChar
 }

--- a/apps/checker/app/utils/JsonImplicits.scala
+++ b/apps/checker/app/utils/JsonImplicits.scala
@@ -1,9 +1,0 @@
-package utils
-
-import java.net.URL
-
-import play.api.libs.json.{JsString, Writes}
-
-object JsonImplicits {
-  implicit val urlWrites: Writes[URL] = (o: URL) => JsString(o.toString)
-}

--- a/apps/checker/conf/routes
+++ b/apps/checker/conf/routes
@@ -16,6 +16,8 @@ GET     /audit                      controllers.AuditController.index()
 POST    /check                      controllers.ApiController.check()
 +nocsrf
 POST    /checkStream                controllers.ApiController.checkStream
++nocsrf
+POST     /checkSingle               controllers.ApiController.checkSingleRule
 
 GET     /categories                 controllers.ApiController.getCurrentCategories()
 


### PR DESCRIPTION
_PR 1/3 to to fulfil the workflow described in https://github.com/guardian/typerighter/discussions/344._

## What does this change?

Adds a method to the checker service to test a single rule, and exposes an endpoint to call it in the controller.

Here's an example of a valid request:

```json
{
    "requestId": "1650f358-4dfe-4f74-aa4b-1d07ae4478ea",
    "rule": {
        "id": "0298e1b6-e28d-4091-a9b4-0c0ff1d3450f",
        "category": {
            "id": "Style guide and names",
            "name": "Style guide and names"
        },
        "description": "MP last elected in 2019: Conservative, South West Surrey",
        "suggestions": [],
        "replacement": {
            "type": "TEXT_SUGGESTION",
            "text": "Jeremy Hunt"
        },
        "regex": "Jeremy Hunt",
        "_type": "com.gu.typerighter.model.RegexRule"
    },
    "documents": [
        {
            "id": "business/2023/jul/13/uk-economy-shrinks-by-01-in-may-despite-coronation-festivities",
            "blocks": [
                {
                    "id": "elem-0",
                    "text": "The chancellor, [Jeremy Hunt](https://www.theguardian.com/politics/jeremy-hunt), said the best way to get growth going again was to ease pressure on households by bringing down inflation. “While an extra bank holiday had an impact on growth in May, high inflation remains a drag anchor on economic growth,” he said.",
                    "from": 0,
                    "to": 413
                }
            ]
        }
    ]
}
```

## How to test

- The new automated tests should pass, and you should be convinced they adequately test the new method
- Running locally or in CODE, run a check with the example request above. It should give some matches as we'd expect.

To succesfully request a check, you'll need to add a pan-domain auth cookie to the request. [Postman](https://www.postman.com/) can be really useful here – this is perhaps most easily done by right-clicking a valid request to checker.typerighter.{stage}.dev-gutools.co.uk, right clicking, and selecting 'copy as curl'. You can then [import the request](https://www.postman.com/postman/workspace/postman-team-collections/folder/1559645-a1d259e3-29ee-4c4c-814c-3a8e2ec71118?ctx=documentation#:~:text=Find%20the%20request%20that%20you,then%20select%20Copy%20as%20cURL.&text=In%20the%20Postman%20app%2C%20click,here%2C%20and%20confirm%20the%20import.) (which will have a valid cookie) in Postman, and alter it for the correct URL and verb (`POST /checkSingle`).
