### PR TITLE
Log play domains on server start

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,12 +69,13 @@ val commonLib = (project in file(s"$appsFolder/common-lib"))
     )
   )
 
-def playProject(projectName: String, devHttpPorts: Map[String, String]) =
+def playProject(label: String, projectName: String, domainPrefix: String, devHttpPorts: Map[String, String]) =
   Project(projectName, file(s"$appsFolder/$projectName"))
     .dependsOn(commonLib)
     .enablePlugins(PlayScala, BuildInfoPlugin, JDebPackaging, SystemdPlugin)
     .settings(
       PlayKeys.devSettings ++= devHttpPorts.map { case (protocol, value) => s"play.server.$protocol.port" -> value }.toSeq,
+      PlayKeys.playRunHooks += new ViteBuildHook(label, domainPrefix),
       libraryDependencies += ws,
       Universal / javaOptions ++= Seq(
         s"-Dpidfile.path=/dev/null",
@@ -89,7 +90,12 @@ def playProject(projectName: String, devHttpPorts: Map[String, String]) =
       commonSettings
     )
 
-val checker = playProject("checker", Map("http" -> "9100"))
+val checker = playProject(
+  "Rule checker",
+  "checker",
+  "checker",
+  Map("http" -> "9100")
+)
   .enablePlugins(GatlingPlugin)
   .settings(
     Universal / javaOptions += s"-Dconfig.file=/etc/gu/${packageName.value}.conf",
@@ -115,7 +121,12 @@ val checker = playProject("checker", Map("http" -> "9100"))
     ).map(_ % circeVersion)
   )
 
-val ruleManager = playProject("rule-manager", Map("http" -> "9101"))
+val ruleManager = playProject(
+  "Rule manager",
+  "rule-manager",
+  "manager",
+  Map("http" -> "9101")
+)
   .enablePlugins(ScalikejdbcPlugin)
   .settings(
     packageName := "typerighter-rule-manager",

--- a/project/ViteBuildHook.scala
+++ b/project/ViteBuildHook.scala
@@ -1,0 +1,18 @@
+import play.sbt._
+import scala.sys.process._
+class ViteBuildHook(label: String, prefix: String) extends PlayRunHook {
+  val devnullLogger: ProcessLogger = ProcessLogger((_: String) => {})
+
+  override def afterStarted(): Unit = {
+
+    val emoji = prefix match {
+        case "manager" => "🚀"
+        case "checker" => "⭐"
+        case _ => "🔥"
+    }
+
+    println(
+      s"$emoji $label started and available at https://$prefix.typerighter.local.dev-gutools.co.uk!"
+    )
+  }
+}


### PR DESCRIPTION
## What does this change?

I spent a while trying to work this out. It's not in the Play docs, but it is in @andrew-nowak's head. Let that be a lesson, folks.

This uses a simple little play hook to spit out the local nginx domain when each app is ready. We could have opted to open the domain too, as per https://github.com/guardian/birthdays/blob/eea8c84f9938065fec33b9dad03af7642fb37705/project/PlayVite.scala#L60, but we don't necessarily want to open both apps, and sometimes it can be annoying to have a new window opened if you're already working on it.

Hopefully this makes the dev start experience just that little bit quicker.

