### PR TITLE
Remove setting up node version from script

### DIFF
--- a/script/lib/check-java-version
+++ b/script/lib/check-java-version
@@ -13,7 +13,7 @@ checkJavaVersion() {
 
   if [ "$runningJavaVersion" != "$requiredJavaVersion" ]; then
     echo -e "Using wrong version of Java. Required ${requiredJavaVersion}. Running ${runningJavaVersion}."
-    exit 0
+    exit 1
   fi
 }
 

--- a/script/lib/check-node-version
+++ b/script/lib/check-node-version
@@ -1,52 +1,7 @@
 #!/bin/bash -e
 
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
-
 APP_FOLDER="apps"
 ROOT_DIR="$APP_FOLDER/../"
-
-nvmUse() {
-  echo "Using nvm to switch node versions..."
-  rc=0
-  nvm use || rc=$?
-  if [[ $rc == 0 ]] ; then
-    echo "✅ nvm successfully switched node versions."
-  else
-    echo "❌ nvm failed to switch node versions. Please change node versions manually."
-    exit 1
-  fi
-}
-
-fnmUse() {
-  echo "Using fnm to switch node versions..."
-  rc=0
-  fnm use || rc=$?;
-  if [[ $rc == 0 ]] ; then
-    echo "✅ fnm successfully switched node versions."
-  else
-    echo "❌ fnm failed to switch node versions."
-    # fallback to nvm
-    nvmUse
-  fi
-}
-
-setupNodeEnv() {
-  echo "Attempting to switch node versions for you..."
-
-  if command -v fnm &> /dev/null
-    then
-      fnmUse
-  else
-    if command -v nvm &> /dev/null
-    then
-      nvmUse
-    else
-      echo "❌ No known node version manager found. Please change node versions manually."
-      exit 1
-    fi
-  fi
-}
 
 checkNodeVersion() {
   runningNodeVersion=$(node -v)
@@ -57,7 +12,7 @@ checkNodeVersion() {
 
   if [ "$runningNodeVersionNumber" != "$requiredNodeVersion" ]; then
     echo -e "❌ Using wrong version of Node. Required ${requiredNodeVersion}. Running ${runningNodeVersion}."
-    setupNodeEnv $requiredNodeVersion
+    exit 1
   fi
 }
 

--- a/script/start
+++ b/script/start
@@ -11,7 +11,7 @@ do
 done
 
 makeChecks() {
-  . "${DIR}"/lib/check
+  source "${DIR}"/lib/check
 }
 
 runChecker() {

--- a/script/start-checker
+++ b/script/start-checker
@@ -18,7 +18,7 @@ do
 done
 
 makeChecks() {
-  . "${DIR}"/lib/check
+  source "${DIR}"/lib/check
 }
 
 runChecker() {

--- a/script/start-manager
+++ b/script/start-manager
@@ -19,7 +19,7 @@ do
 done
 
 makeChecks() {
-  . "${DIR}"/lib/check
+  source "${DIR}"/lib/check
 }
 
 setupDependencies() {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This removes the steps that try to set up the correct node version from the `check-node-version` script. These changes were added [here](https://github.com/guardian/typerighter/pull/384). However they were preventing me from running the `start-manager` locally, with the script exiting at [this line](https://github.com/guardian/typerighter/pull/384/files#diff-118f9a380506b6024afd5a8be1c0133756597d95cae682bcc995b1c1de0fc0cdR4):
```
[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
```
@Fweddi and I looked at this together and didn't find the exact cause of the issue. Rather than adding more code to handle whether someone has fnm, nvm, asdf etc. and where it might be installed (e.g. homebrew installs it somewhere specific), we thought it would be better to remove this code and simply notify someone they're using the wrong node version, allowing them to change versions manually themselves.

Now if someone tries to run the script locally and they have the wrong version, the script will simply print an error message letting them know they're using wrong version of node and will then exit. This matches behaviour if you're using the wrong java version. This PR also changes the exit code if you have the wrong java version to reflect the operation not being permitted.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Change node versions and try running the `start-manager` or `start` script. You should see an error message explaining you're using the wrong node version and the script should exit.
