### PR TITLE
Speed up the build a bit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,12 +19,15 @@ jobs:
         with:
           java-version: "8"
           distribution: "corretto"
+          cache: "sbt"
       - name: Build the stack
         run: |
           docker-compose up -d
       - uses: actions/setup-node@v3
         with:
           node-version: 16.13.1
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
       - name: build rule-manager-client
         working-directory: ./apps/rule-manager/client
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,6 @@ jobs:
       - name: Build the stack
         run: |
           docker-compose up -d
-      - name: Run tests
-        run: |
-          sbt -v test scalafmtCheckAll
       - uses: actions/setup-node@v3
         with:
           node-version: 16.13.1
@@ -44,10 +41,10 @@ jobs:
         run: |
           yarn
           yarn synth
-      - name: build sbt
+      - name: test and build sbt
         run: |
           set -e
           # Ensure we don't overwrite existing (Teamcity) builds.
           LAST_TEAMCITY_BUILD=1280
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt clean compile test riffRaffUpload
+          sbt clean compile test scalafmtCheckAll riffRaffUpload


### PR DESCRIPTION
## What does this change?

A few things to shorten our build times, which are routinely ~10 minutes at present:
- Test and scalafmt within a single SBT session, rather than multiple sessions.
- Caching for npm and sbt.

## How to test

Check the actions tab. This branch should run a bit quicker:

<img width="1240" alt="Screenshot 2023-07-24 at 18 29 58" src="https://github.com/guardian/typerighter/assets/7767575/ac3ef46c-d6a7-4bb5-8a1f-6ce61757884d">


