### PR TITLE
Use a more compact diff layout

### DIFF
--- a/apps/rule-manager/client/package-lock.json
+++ b/apps/rule-manager/client/package-lock.json
@@ -33,7 +33,7 @@
 				"jest": "^29.5.0",
 				"sass": "~1.32.13",
 				"ts-jest": "^29.1.0",
-				"typescript": "^4.5.3",
+				"typescript": "^5.1.3",
 				"utility-types": "^3.10.0",
 				"vite": "^4.2.0",
 				"vite-plugin-checker": "^0.6.0"
@@ -7503,15 +7503,15 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/unherit": {
@@ -13643,9 +13643,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA=="
 		},
 		"unherit": {
 			"version": "1.1.3",

--- a/apps/rule-manager/client/src/ts/components/Diff.tsx
+++ b/apps/rule-manager/client/src/ts/components/Diff.tsx
@@ -28,20 +28,12 @@ export type FieldObject = {
 };
 
 const ComparisonPanel = styled.div`
-	background-color: #f1f4fa;
 	height: 100%;
-	padding: 0.5rem;
 `;
 
 const ComparisonPanelHeader = styled.div`
 	padding: 0.25rem 0;
 	color: #444;
-`;
-
-const diffWrapper = css`
-	border: 1px solid #ddd;
-	padding: 1rem;
-	border-radius: 0.5rem;
 `;
 
 const textDiffFields = ['description', 'pattern', 'replacement'];
@@ -176,12 +168,8 @@ export const Diff = ({ rule }: { rule: RuleData | undefined }) => {
 	return (
 		<>
 			<EuiSpacer />
-			<EuiFlexGroup css={diffWrapper}>
+			<EuiFlexGroup>
 				<EuiFlexItem>
-					<EuiText>
-						<h4>What's changed:</h4>
-					</EuiText>
-					<EuiSpacer size="m" />
 					<EuiFlexGroup>
 						<EuiFlexItem
 							css={css`
@@ -191,10 +179,10 @@ export const Diff = ({ rule }: { rule: RuleData | undefined }) => {
 							<strong>Field</strong>
 						</EuiFlexItem>
 						<EuiFlexItem grow>
-							<strong>Before:</strong>
+							<strong>Before republish:</strong>
 						</EuiFlexItem>
 						<EuiFlexItem grow>
-							<strong>After:</strong>
+							<strong>After republish:</strong>
 						</EuiFlexItem>
 					</EuiFlexGroup>
 					{diffedFields.map((diffedField) => (


### PR DESCRIPTION
Co-authored-by: Jonathan Herbert <jonathan.herbert@guardian.co.uk)

Implementing Jon's suggestions from: https://github.com/guardian/typerighter/pull/391 (because I forgot to include them in that PR, and they're a good idea)

![image](https://github.com/guardian/typerighter/assets/34686302/bbd524e9-35a0-42e2-8b27-bfac5811bb43)


## How to test

1. Run the rule manager locally according to the instructions in the readme.
2. Change some fields in a Live rule (If you have no Live rules, publish a Draft rule. If you have no draft rules, pull rules from the Google Sheet by activating the feature switch in the top right dropdown menu).
3. Look on my styles, ye mighty, and despair