### PR TITLE
Make FormError keys machine-readable rather than user facing

### DIFF
--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -31,7 +31,7 @@ class RulesController(
       dbRules <- sheetsRuleResource
         .getRules()
         .left
-        .map(toFormError("Error getting rules from Google Sheet"))
+        .map(toFormError("refresh-sheet"))
       _ <- RuleManager.destructivelyPublishRules(dbRules, bucketRuleResource)
     } yield {
       RuleManager.getDraftRules()

--- a/apps/rule-manager/test/db/RuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/RuleManagerSpec.scala
@@ -63,10 +63,10 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
 
       maybeCheckerRule shouldBe Left(
         List(
-          FormError("pattern", List("error.required"), List()),
-          FormError("category", List("error.required"), List()),
-          FormError("description", List("error.required"), List()),
-          FormError("externalId", List("error.required"), List())
+          FormError("invalid-pattern", List("error.required"), List()),
+          FormError("invalid-category", List("error.required"), List()),
+          FormError("invalid-description", List("error.required"), List()),
+          FormError("invalid-external-id", List("error.required"), List())
         )
       )
   }
@@ -87,10 +87,10 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
 
       maybeCheckerRule shouldBe Left(
         List(
-          FormError("pattern", List("error.required"), List()),
-          FormError("category", List("error.required"), List()),
-          FormError("description", List("error.required"), List()),
-          FormError("externalId", List("error.required"), List())
+          FormError("invalid-pattern", List("error.required"), List()),
+          FormError("invalid-category", List("error.required"), List()),
+          FormError("invalid-description", List("error.required"), List()),
+          FormError("invalid-external-id", List("error.required"), List())
         )
       )
   }
@@ -111,7 +111,7 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
 
       maybeCheckerRule shouldBe Left(
         List(
-          FormError("externalId", List("error.required"), List())
+          FormError("invalid-external-id", List("error.required"), List())
         )
       )
   }


### PR DESCRIPTION
## What does this change?

At the moment, we have FormError objects we send back to the client on publication validation failures. Both key and message are human readable.

This PR treats the key as an error id (e. field-missing). Only the message should be human readable. This applies whenever we’re passing FormError events back to the client.

## How to test

Have a play around with the form on the client and see if the form error IDs make sense. 

Tests should pass.

We shouldn't lose necessary error context in this change.