### PR TITLE
Reinstate t4g small for rule manager

### DIFF
--- a/cdk/lib/index.ts
+++ b/cdk/lib/index.ts
@@ -144,7 +144,7 @@ dpkg -i /tmp/package.deb`,
 
     const ruleManagerApp = new GuPlayApp(this, {
       app: ruleManagerAppName,
-      instanceType: new InstanceType("t4g.micro"),
+      instanceType: new InstanceType("t4g.small"),
       userData: `#!/bin/bash -ev
         aws --quiet --region ${this.region} s3 cp s3://composer-dist/${this.stack}/${this.stage}/typerighter-rule-manager/typerighter-rule-manager.deb /tmp/package.deb
         dpkg -i /tmp/package.deb


### PR DESCRIPTION
## What does this change?

Reinstates t4g small for rule manager – added in #365 and accidentally regressed in #389. Lots of CDK got moved about in that PR – perils of big diffs!