### PR TITLE
Put form error message in right place

### DIFF
--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -4,6 +4,7 @@ import {
 	EuiFlexGroup,
 	EuiFlexItem,
 	EuiForm,
+	EuiSpacer,
 	EuiText,
 	EuiToolTip,
 } from '@elastic/eui';
@@ -221,12 +222,12 @@ export const RuleForm = ({
 		<>
 			{
 				<EuiFlexGroup
-					gutterSize="m"
+					gutterSize="s"
 					direction="column"
 					style={{ overflow: 'hidden' }}
 				>
 					<EuiFlexItem grow={1} style={{ overflowY: 'scroll' }}>
-						<EuiFlexGroup gutterSize="m" direction="column">
+						<EuiFlexGroup gutterSize="s" direction="column">
 							<RuleStatus ruleData={rule} />
 							<RuleContent
 								isLoading={isLoading}
@@ -253,7 +254,7 @@ export const RuleForm = ({
 						</EuiFlexGroup>
 					</EuiFlexItem>
 					<EuiFlexItem grow={0}>
-						<EuiFlexGroup gutterSize="m">
+						<EuiFlexGroup gutterSize="s">
 							{canEditRuleContent && (
 								<EuiFlexItem>
 									<EuiButton
@@ -323,7 +324,10 @@ export const RuleForm = ({
 									</PublishTooltip>
 								</EuiFlexItem>
 							)}
-							{showErrors ? (
+						</EuiFlexGroup>
+						{showErrors ? (
+							<>
+								<EuiSpacer size="s" />
 								<EuiCallOut
 									title="Please resolve the following errors:"
 									color="danger"
@@ -333,8 +337,8 @@ export const RuleForm = ({
 										<EuiText key={index}>{`${error.message}`}</EuiText>
 									))}
 								</EuiCallOut>
-							) : null}
-						</EuiFlexGroup>
+							</>
+						) : null}
 					</EuiFlexItem>
 				</EuiFlexGroup>
 			}


### PR DESCRIPTION
## What does this change?

The form error message is in a weird place. This PR fixes.

|Before|After|
|-|-|
|![image](https://github.com/guardian/typerighter/assets/7767575/0dc68794-fbe2-45d7-a0b7-111a01d216e4)|<img width="570" alt="Screenshot 2023-08-10 at 10 48 52" src="https://github.com/guardian/typerighter/assets/7767575/5fdb9a62-9859-4130-99cf-e35b5ae67c4d">|

## How to test

Create a rule without a pattern. Does the error message appear in the right place?