### PR TITLE
Include dictionary rules in json artefact used by Checker

### DIFF
--- a/apps/common-lib/src/main/scala/com/gu/typerighter/model/CheckerRule.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/model/CheckerRule.scala
@@ -2,7 +2,7 @@ package com.gu.typerighter.model
 
 import java.util.{List => JList}
 import java.util.regex.Pattern
-import play.api.libs.json.{JsPath, JsString, Json, Reads, Writes}
+import play.api.libs.json.{JsPath, JsString, Json, OFormat, Reads, Writes}
 import play.api.libs.json.Reads._
 import org.languagetool.Languages
 import org.languagetool.rules.patterns.{
@@ -205,12 +205,8 @@ case class DictionaryRule(
     id: String,
     word: String,
     category: Category
-) extends CheckerRule {
-  val suggestions = List.empty
-  val replacement: Option[TextSuggestion] = None
-}
+) extends CheckerRule
 
 object DictionaryRule {
-  implicit val writes: Writes[DictionaryRule] = Json.writes[DictionaryRule]
-  implicit val reads: Reads[DictionaryRule] = Json.reads[DictionaryRule]
+  implicit val formats: OFormat[DictionaryRule] = Json.format[DictionaryRule]
 }

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/model/CheckerRule.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/model/CheckerRule.scala
@@ -200,3 +200,17 @@ object LTRule {
   implicit val writes: Writes[LTRule] = Json.writes[LTRule]
   implicit val reads: Reads[LTRule] = Json.reads[LTRule]
 }
+
+case class DictionaryRule(
+    id: String,
+    word: String,
+    category: Category
+) extends CheckerRule {
+  val suggestions = List.empty
+  val replacement: Option[TextSuggestion] = None
+}
+
+object DictionaryRule {
+  implicit val writes: Writes[DictionaryRule] = Json.writes[DictionaryRule]
+  implicit val reads: Reads[DictionaryRule] = Json.reads[DictionaryRule]
+}

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/rules/BucketRuleResource.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/rules/BucketRuleResource.scala
@@ -15,6 +15,8 @@ class BucketRuleResource(s3: AmazonS3, bucketName: String, stage: String) extend
   private val RULES_KEY = s"$stage/rules/typerighter-rules.json"
   private val DICTIONARY_KEY = s"$stage/dictionary/typerighter-dictionary.xml"
   def putRules(ruleResource: CheckerRuleResource): Either[Exception, Unit] = {
+    println("HowdyEight")
+
     val ruleJson = Json.toJson(ruleResource)
     val bytes = ruleJson.toString.getBytes(java.nio.charset.StandardCharsets.UTF_8.name)
 
@@ -31,6 +33,7 @@ class BucketRuleResource(s3: AmazonS3, bucketName: String, stage: String) extend
 
   def getRules(): Either[Exception, (CheckerRuleResource, Date)] = {
     logOnError(s"getting rules from S3 at $bucketName/$RULES_KEY") {
+      println("twotwo")
       val rules = s3.getObject(bucketName, RULES_KEY)
       val rulesStream = rules.getObjectContent()
       val rulesJson = Json.parse(rulesStream)

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/rules/BucketRuleResource.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/rules/BucketRuleResource.scala
@@ -15,10 +15,8 @@ class BucketRuleResource(s3: AmazonS3, bucketName: String, stage: String) extend
   private val RULES_KEY = s"$stage/rules/typerighter-rules.json"
   private val DICTIONARY_KEY = s"$stage/dictionary/typerighter-dictionary.xml"
   def putRules(ruleResource: CheckerRuleResource): Either[Exception, Unit] = {
-    println("HowdyEight")
-
     val ruleJson = Json.toJson(ruleResource)
-    val bytes = ruleJson.toString.getBytes(java.nio.charset.StandardCharsets.UTF_8.name)
+    val bytes = Json.toBytes(ruleJson)
 
     logOnError(
       s"writing rules to S3 at $bucketName/$RULES_KEY with JSON hash ${ruleJson.hashCode}"
@@ -33,7 +31,6 @@ class BucketRuleResource(s3: AmazonS3, bucketName: String, stage: String) extend
 
   def getRules(): Either[Exception, (CheckerRuleResource, Date)] = {
     logOnError(s"getting rules from S3 at $bucketName/$RULES_KEY") {
-      println("twotwo")
       val rules = s3.getObject(bucketName, RULES_KEY)
       val rulesStream = rules.getObjectContent()
       val rulesJson = Json.parse(rulesStream)
@@ -48,8 +45,7 @@ class BucketRuleResource(s3: AmazonS3, bucketName: String, stage: String) extend
   def getDictionaryWords(): Either[Seq[FormError], List[String]] = {
     val words = Try({
       val dictionary = s3.getObject(bucketName, DICTIONARY_KEY).getObjectContent()
-      val dictionaryStream = dictionary
-      val dictionaryXml = SafeXMLParser.load(dictionaryStream)
+      val dictionaryXml = SafeXMLParser.load(dictionary)
       val words = Dictionary.dictionaryXmlToWordList(dictionaryXml)
       dictionary.close()
       words

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/rules/Dictionary.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/rules/Dictionary.scala
@@ -16,7 +16,7 @@ object Dictionary {
     // - one top-level "lemma_list" node, containing:
     //   - n child "entry" nodes, each containing:
     //     - one "lemma" node with a single string as its text
-    //     - zero or one "infl_list" nodes, each containing:
+    //     - zero or more "infl_list" nodes, each containing:
     //       - one or more "infl" nodes with a single string as its text
     val entries = dictionaryXml.child.toList
     val words = for {
@@ -25,7 +25,7 @@ object Dictionary {
       lemmaOrInflList <- lemmaOrInfl.toList
       word <- lemmaOrInflListToText(lemmaOrInflList)
     } yield word
-    words.distinct
+    words.distinct.filterNot(_ == "")
   }
 
 }

--- a/apps/rule-manager/app/db/DbRuleDraft.scala
+++ b/apps/rule-manager/app/db/DbRuleDraft.scala
@@ -165,8 +165,6 @@ object DbRuleDraft extends SQLSyntaxSupport[DbRuleDraft] {
   override val autoSession = AutoSession
 
   def find(id: Int)(implicit session: DBSession = autoSession): Option[DbRuleDraft] = {
-    println("HowdyTwo")
-
     withSQL {
       select(dbColumnsToFind, isPublishedColumn, hasUnpublishedChangesColumn, tagColumn)
         .from(DbRuleDraft as rd)
@@ -283,7 +281,9 @@ object DbRuleDraft extends SQLSyntaxSupport[DbRuleDraft] {
         .eq(rd.ruleType, "dictionary")
         .groupBy(dbColumnsToFind, rl.externalId, rl.revisionId)
         .orderBy(rd.ruleOrder)
-    }.map(DbRuleDraft.fromRow)
+    }
+      .fetchSize(1000)
+      .map(DbRuleDraft.fromRow)
       .list()
       .apply()
   }

--- a/apps/rule-manager/app/db/DbRuleDraft.scala
+++ b/apps/rule-manager/app/db/DbRuleDraft.scala
@@ -35,7 +35,7 @@ case class DbRuleDraft(
     hasUnpublishedChanges: Boolean
 ) extends DbRuleCommon {
 
-  def toLive(reason: String): DbRuleLive = {
+  def toLive(reason: String, isActive: Boolean = false): DbRuleLive = {
     id match {
       case None =>
         throw new Exception(
@@ -59,7 +59,8 @@ case class DbRuleDraft(
           updatedAt = updatedAt,
           updatedBy = updatedBy,
           reason = reason,
-          ruleOrder = ruleOrder
+          ruleOrder = ruleOrder,
+          isActive = isActive
         )
     }
   }
@@ -164,6 +165,8 @@ object DbRuleDraft extends SQLSyntaxSupport[DbRuleDraft] {
   override val autoSession = AutoSession
 
   def find(id: Int)(implicit session: DBSession = autoSession): Option[DbRuleDraft] = {
+    println("HowdyTwo")
+
     withSQL {
       select(dbColumnsToFind, isPublishedColumn, hasUnpublishedChangesColumn, tagColumn)
         .from(DbRuleDraft as rd)

--- a/apps/rule-manager/app/db/DbRuleLive.scala
+++ b/apps/rule-manager/app/db/DbRuleLive.scala
@@ -151,6 +151,7 @@ object DbRuleLive extends SQLSyntaxSupport[DbRuleLive] {
   }
 
   def findAllActive()(implicit session: DBSession = autoSession): List[DbRuleLive] = {
+    println("howdyeightone")
     withSQL(
       select(dbColumnsToFind, tagColumn)
         .from(DbRuleLive as r)
@@ -209,6 +210,8 @@ object DbRuleLive extends SQLSyntaxSupport[DbRuleLive] {
   def create(liveRule: DbRuleLive, user: String)(implicit
       session: DBSession = autoSession
   ): Try[DbRuleLive] = Try {
+    println("HowdyFive")
+
     withSQL {
       update(DbRuleLive)
         .set(column.isActive -> false)
@@ -255,8 +258,7 @@ object DbRuleLive extends SQLSyntaxSupport[DbRuleLive] {
   }
 
   def batchInsert(
-      entities: collection.Seq[DbRuleLive],
-      overrideIsActive: Boolean = false
+      entities: collection.Seq[DbRuleLive]
   )(implicit session: DBSession = autoSession): Unit = {
     val params: collection.Seq[Seq[(Symbol, Any)]] = entities.map(entity =>
       Seq(
@@ -310,7 +312,7 @@ object DbRuleLive extends SQLSyntaxSupport[DbRuleLive] {
       {updatedAt},
       {updatedBy},
       {reason},
-      ${if (overrideIsActive) "TRUE" else "{isActive}"},
+      {isActive},
       {ruleOrder}
     )""").batchByName(params.toSeq: _*).apply[List]()
     val ruleTags = entities.flatMap(entity =>

--- a/apps/rule-manager/app/db/DbRuleLive.scala
+++ b/apps/rule-manager/app/db/DbRuleLive.scala
@@ -151,7 +151,6 @@ object DbRuleLive extends SQLSyntaxSupport[DbRuleLive] {
   }
 
   def findAllActive()(implicit session: DBSession = autoSession): List[DbRuleLive] = {
-    println("howdyeightone")
     withSQL(
       select(dbColumnsToFind, tagColumn)
         .from(DbRuleLive as r)
@@ -164,6 +163,7 @@ object DbRuleLive extends SQLSyntaxSupport[DbRuleLive] {
         .groupBy(dbColumnsToFind)
         .orderBy(r.ruleOrder)
     )
+      .fetchSize(1000)
       .map(DbRuleLive.fromRow)
       .list()
       .apply()
@@ -210,8 +210,6 @@ object DbRuleLive extends SQLSyntaxSupport[DbRuleLive] {
   def create(liveRule: DbRuleLive, user: String)(implicit
       session: DBSession = autoSession
   ): Try[DbRuleLive] = Try {
-    println("HowdyFive")
-
     withSQL {
       update(DbRuleLive)
         .set(column.isActive -> false)

--- a/apps/rule-manager/app/model/CheckerRuleForm.scala
+++ b/apps/rule-manager/app/model/CheckerRuleForm.scala
@@ -6,7 +6,8 @@ import com.gu.typerighter.model.{
   LTRuleCore,
   LTRuleXML,
   RegexRule,
-  TextSuggestion
+  TextSuggestion,
+  DictionaryRule
 }
 import play.api.data.Form
 import play.api.data.Forms._
@@ -71,6 +72,24 @@ object LTRuleCoreForm {
     LTRuleCore(
       id = externalId,
       languageToolRuleId = externalId
+    )
+  }
+}
+
+object DictionaryForm {
+  val form = Form(
+    tuple(
+      "pattern" -> nonEmptyText(),
+      "category" -> nonEmptyText(),
+      "externalId" -> nonEmptyText()
+    )
+  )
+
+  def toDictionary(pattern: String, externalId: String, category: String) = {
+    DictionaryRule(
+      id = externalId,
+      word = pattern,
+      category = Category(id = category, name = category)
     )
   }
 }

--- a/apps/rule-manager/app/model/CheckerRuleForm.scala
+++ b/apps/rule-manager/app/model/CheckerRuleForm.scala
@@ -85,7 +85,7 @@ object DictionaryForm {
     )
   )
 
-  def toDictionary(pattern: String, externalId: String, category: String) = {
+  def toDictionary(pattern: String, category: String, externalId: String) = {
     DictionaryRule(
       id = externalId,
       word = pattern,

--- a/apps/rule-manager/app/service/RuleManager.scala
+++ b/apps/rule-manager/app/service/RuleManager.scala
@@ -4,6 +4,7 @@ import com.gu.typerighter.lib.Loggable
 import com.gu.typerighter.model.{
   CheckerRule,
   CheckerRuleResource,
+  DictionaryRule,
   LTRule,
   LTRuleCore,
   LTRuleXML,
@@ -11,7 +12,7 @@ import com.gu.typerighter.model.{
 }
 import com.gu.typerighter.rules.BucketRuleResource
 import db.{DbRuleDraft, DbRuleLive, RuleTagDraft, RuleTagLive}
-import db.DbRuleDraft.{autoSession}
+import db.DbRuleDraft.autoSession
 import model.{LTRuleCoreForm, LTRuleXMLForm, RegexRuleForm}
 import play.api.data.FormError
 import play.api.libs.json.Json
@@ -70,6 +71,18 @@ object RuleManager extends Loggable {
           id = None,
           ruleType = RuleType.languageToolCore,
           externalId = Some(languageToolRuleId),
+          ignore = false,
+          user = "Google Sheet",
+          replacement = None,
+          ruleOrder = 0
+        )
+      case DictionaryRule(id, word, category) =>
+        DbRuleDraft.withUser(
+          id = None,
+          pattern = Some(word),
+          ruleType = RuleType.dictionary,
+          category = Some(category.name),
+          externalId = Some(id),
           ignore = false,
           user = "Google Sheet",
           ruleOrder = 0

--- a/apps/rule-manager/app/service/RuleManager.scala
+++ b/apps/rule-manager/app/service/RuleManager.scala
@@ -294,11 +294,7 @@ object RuleManager extends Loggable {
 
     liveRules
       .grouped(100)
-<<<<<<< HEAD
       .foreach(DbRuleLive.batchInsert(_))
-=======
-      .foreach(rule => DbRuleLive.batchInsert(rule))
->>>>>>> 6964b1e8 (WIP include dict rules in artefact)
 
     val persistedRules = getDraftRules()
 

--- a/apps/rule-manager/app/service/RuleManager.scala
+++ b/apps/rule-manager/app/service/RuleManager.scala
@@ -1,7 +1,15 @@
 package service
 
 import com.gu.typerighter.lib.Loggable
-import com.gu.typerighter.model.{CheckerRule, CheckerRuleResource, DictionaryRule, LTRule, LTRuleCore, LTRuleXML, RegexRule}
+import com.gu.typerighter.model.{
+  CheckerRule,
+  CheckerRuleResource,
+  DictionaryRule,
+  LTRule,
+  LTRuleCore,
+  LTRuleXML,
+  RegexRule
+}
 import com.gu.typerighter.rules.BucketRuleResource
 import db.{DbRuleDraft, DbRuleLive, RuleTagDraft, RuleTagLive}
 import db.DbRuleDraft.autoSession
@@ -135,7 +143,7 @@ object RuleManager extends Loggable {
           )
           .fold(
             err => Left(err.errors),
-            form => Right((DictionaryForm.toDictionary  _).tupled(form))
+            form => Right((DictionaryForm.toDictionary _).tupled(form))
           )
       case other =>
         Left(


### PR DESCRIPTION
## What does this change?

This PR includes dictionary rules in the published artefact ingested by the Checker service.

It also includes some fixes to problems caused by the much larger number of rules now included in the Rule Manager.
- Adds `.fetchSize(1000)` call to some database methods that select a very large number of rows. According to the [scalikeJDBC docs](http://scalikejdbc.org/documentation/operations.html):
	> the PostgreSQL JDBC driver does infinite(!) caching for result sets if fetchSize is set to 0 (the default) and this causes memory problems.

	Setting an explicit `.fetchSize` solved the `outOfMemory` errors we encountered in these cases. Testing sizes of 100, 1000, 10,000 and 100,000 rows led to no significant performance differences. 
- We also saw an `outOfMemory` error for `ruleJson.toString.getBytes(java.nio.charset.StandardCharsets.UTF_8.name)`. Avoiding the intermediate `toString` step by using `Json.toBytes(ruleJson)` resolved the error. This highlights the increased possibility of previously acceptable inefficiencies leading to problems now that we are handling great deal more rules.

Separately, we encountered an odd issue where a duplicated word in the dictionary ended up with an empty string as its pattern in our live table. We didn't get to the bottom of the mechanism behind this, but added a `words.distinct.filterNot(_ == "")` filter to our word list to resolve the problem.

## How to test

1. Run the application locally according to the instructions in the readme. Make sure you run the setup script to pull the dictionary xml files locally.
2. Hit the `/api/refreshDictionary` endpoint with a POST request (e.g. in Postman, with cookies from a valid browser request)
3. Check the artefact in the your localstack instance, e.g. with these commands run in the Docker localstack_main container CLI to pull, pretty print, and find rows containing 'DictionaryRule':
	```
	awslocal s3 cp s3://typerighter-app-local/local/rules/typerighter-rules.json /etc
	sed 's/},{/},\n{/g' /etc/typerighter-rules.json > /etc/parsed.json
	grep -hnr "DictionaryRule" /etc/parsed.json
	```
4. Do dictionary rules appear in the artefact?