### PR TITLE
Validate patterns for regex and xml rules

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11.0.17.8.1

--- a/apps/rule-manager/app/model/CheckerRuleForm.scala
+++ b/apps/rule-manager/app/model/CheckerRuleForm.scala
@@ -10,11 +10,22 @@ import com.gu.typerighter.model.{
 }
 import play.api.data.Form
 import play.api.data.Forms._
+import play.api.data.validation.{Constraint, Invalid, Valid, ValidationError}
+
+import scala.util.{Failure, Success, Try}
+import scala.xml.XML
 
 object RegexRuleForm {
+  val regexConstraint: Constraint[String] = Constraint("constraints.regexcheck") { regexStr =>
+    Try(regexStr.r) match {
+      case Success(_)         => Valid
+      case Failure(exception) => Invalid(Seq(ValidationError(exception.getMessage())))
+    }
+  }
+
   val form = Form(
     tuple(
-      "pattern" -> nonEmptyText(),
+      "pattern" -> nonEmptyText().verifying(regexConstraint),
       "replacement" -> optional(text()),
       "category" -> nonEmptyText(),
       "description" -> nonEmptyText(),
@@ -41,9 +52,16 @@ object RegexRuleForm {
 }
 
 object LTRuleXMLForm {
+  val xmlConstraint: Constraint[String] = Constraint("constraints.xmlcheck") { xmlStr =>
+    Try(XML.loadString(xmlStr)) match {
+      case Success(_)         => Valid
+      case Failure(exception) => Invalid(Seq(ValidationError(exception.getMessage())))
+    }
+  }
+
   val form = Form(
     tuple(
-      "pattern" -> nonEmptyText(),
+      "pattern" -> nonEmptyText().verifying(xmlConstraint),
       "category" -> nonEmptyText(),
       "description" -> nonEmptyText(),
       "externalId" -> nonEmptyText()

--- a/apps/rule-manager/app/model/CheckerRuleForm.scala
+++ b/apps/rule-manager/app/model/CheckerRuleForm.scala
@@ -18,8 +18,11 @@ import scala.xml.XML
 object RegexRuleForm {
   val regexConstraint: Constraint[String] = Constraint("constraints.regexcheck") { regexStr =>
     Try(regexStr.r) match {
-      case Success(_)         => Valid
-      case Failure(exception) => Invalid(Seq(ValidationError(exception.getMessage())))
+      case Success(_) => Valid
+      case Failure(exception) =>
+        Invalid(
+          Seq(ValidationError(s"Error parsing the regular expression: ${exception.getMessage()}"))
+        )
     }
   }
 
@@ -54,8 +57,9 @@ object RegexRuleForm {
 object LTRuleXMLForm {
   val xmlConstraint: Constraint[String] = Constraint("constraints.xmlcheck") { xmlStr =>
     Try(XML.loadString(xmlStr)) match {
-      case Success(_)         => Valid
-      case Failure(exception) => Invalid(Seq(ValidationError(exception.getMessage())))
+      case Success(_) => Valid
+      case Failure(exception) =>
+        Invalid(Seq(ValidationError(s"Error parsing the XML: ${exception.getMessage()}")))
     }
   }
 

--- a/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
@@ -3,7 +3,8 @@ import { useEffect, useState } from 'react';
 import { EuiFormRow, EuiComboBox } from '@elastic/eui';
 import { FormError, PartiallyUpdateRuleData } from './RuleForm';
 import { existingCategories } from '../constants/constants';
-import { hasErrorsForField } from './helpers/errors';
+import { getErrorPropsForField } from './helpers/errors';
+import { Label } from './Label';
 
 export type MetadataOption = { label: string };
 const singleSelectionOptions = { asPlainText: true };
@@ -35,11 +36,13 @@ export const CategorySelector = ({
 		partiallyUpdateRuleData({ category: newCategory });
 	}, [selectedCategory]);
 
+	const categoryErrors = getErrorPropsForField('category', validationErrors);
+
 	return (
 		<EuiFormRow
-			label="Source"
+			label={<Label text="Source" required={true} />}
 			fullWidth={true}
-			isInvalid={hasErrorsForField('category', validationErrors)}
+			{...categoryErrors}
 		>
 			<EuiComboBox
 				options={categories}
@@ -49,7 +52,7 @@ export const CategorySelector = ({
 				isClearable={true}
 				isCaseSensitive
 				fullWidth={true}
-				isInvalid={hasErrorsForField('category', validationErrors)}
+				{...categoryErrors}
 			/>
 		</EuiFormRow>
 	);

--- a/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
@@ -1,18 +1,20 @@
+import React from 'react';
 import { useEffect, useState } from 'react';
 import { EuiFormRow, EuiComboBox } from '@elastic/eui';
-import React from 'react';
-import { PartiallyUpdateRuleData } from './RuleForm';
+import { FormError, PartiallyUpdateRuleData } from './RuleForm';
 import { existingCategories } from '../constants/constants';
-import { RuleData } from './hooks/useRule';
+import { hasErrorsForField } from './helpers/errors';
 
 export type MetadataOption = { label: string };
 const singleSelectionOptions = { asPlainText: true };
 export const CategorySelector = ({
 	currentCategory,
 	partiallyUpdateRuleData,
+	validationErrors,
 }: {
 	currentCategory: string | undefined;
 	partiallyUpdateRuleData: PartiallyUpdateRuleData;
+	validationErrors: FormError[] | undefined;
 }) => {
 	// This is an array in order to match the expected type for EuiComboBox, but
 	// it will never have more than one category selected
@@ -34,7 +36,11 @@ export const CategorySelector = ({
 	}, [selectedCategory]);
 
 	return (
-		<EuiFormRow label="Source" fullWidth={true}>
+		<EuiFormRow
+			label="Source"
+			fullWidth={true}
+			isInvalid={hasErrorsForField('category', validationErrors)}
+		>
 			<EuiComboBox
 				options={categories}
 				singleSelection={singleSelectionOptions}
@@ -43,6 +49,7 @@ export const CategorySelector = ({
 				isClearable={true}
 				isCaseSensitive
 				fullWidth={true}
+				isInvalid={hasErrorsForField('category', validationErrors)}
 			/>
 		</EuiFormRow>
 	);

--- a/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
+++ b/apps/rule-manager/client/src/ts/components/CategorySelector.tsx
@@ -15,7 +15,7 @@ export const CategorySelector = ({
 }: {
 	currentCategory: string | undefined;
 	partiallyUpdateRuleData: PartiallyUpdateRuleData;
-	validationErrors: FormError[] | undefined;
+	validationErrors?: FormError[];
 }) => {
 	// This is an array in order to match the expected type for EuiComboBox, but
 	// it will never have more than one category selected

--- a/apps/rule-manager/client/src/ts/components/RuleContent.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleContent.tsx
@@ -17,10 +17,11 @@ import { css } from '@emotion/react';
 import React, { useState } from 'react';
 import { RuleFormSection } from './RuleFormSection';
 import { LineBreak } from './LineBreak';
-import { PartiallyUpdateRuleData } from './RuleForm';
+import {FormError, PartiallyUpdateRuleData} from './RuleForm';
 import { Label } from './Label';
 import { DraftRule, RuleData, RuleType } from './hooks/useRule';
 import { RuleDataLastUpdated } from './RuleDataLastUpdated';
+import { hasErrorsForField } from './helpers/errors';
 
 type RuleTypeOption = {
 	id: RuleType;
@@ -42,16 +43,16 @@ export const RuleContent = ({
 	ruleData,
 	ruleFormData,
 	isLoading,
-	errors,
 	partiallyUpdateRuleData,
-	showErrors,
+  validationErrors,
+  hasSaveErrors
 }: {
 	ruleData: RuleData | undefined;
 	ruleFormData: DraftRule;
 	partiallyUpdateRuleData: PartiallyUpdateRuleData;
-	showErrors: boolean;
+  validationErrors: FormError[] | undefined;
+  hasSaveErrors: boolean;
 	isLoading: boolean;
-	errors: string | undefined;
 }) => {
 	const TextField =
 		ruleFormData.ruleType === 'languageToolXML' ? EuiTextArea : EuiFieldText;
@@ -70,7 +71,7 @@ export const RuleContent = ({
 					<RuleDataLastUpdated
 						ruleData={ruleData}
 						isLoading={isLoading}
-						hasErrors={!!errors}
+						hasErrors={hasSaveErrors}
 					/>
 				)
 			}
@@ -143,8 +144,8 @@ export const RuleContent = ({
 				<EuiSpacer size="s" />
 				<EuiFormRow
 					label={<Label text="Pattern" required={true} />}
-					isInvalid={showErrors && !ruleFormData.pattern}
 					fullWidth={true}
+          isInvalid={hasErrorsForField("pattern", validationErrors)}
 				>
 					<TextField
 						value={ruleFormData.pattern || ''}
@@ -152,8 +153,8 @@ export const RuleContent = ({
 							partiallyUpdateRuleData({ pattern: _.target.value })
 						}
 						required={true}
-						isInvalid={showErrors && !ruleFormData.pattern}
 						fullWidth={true}
+            isInvalid={hasErrorsForField("pattern", validationErrors)}
 					/>
 				</EuiFormRow>
 				<EuiFormRow

--- a/apps/rule-manager/client/src/ts/components/RuleContent.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleContent.tsx
@@ -17,11 +17,11 @@ import { css } from '@emotion/react';
 import React, { useState } from 'react';
 import { RuleFormSection } from './RuleFormSection';
 import { LineBreak } from './LineBreak';
-import {FormError, PartiallyUpdateRuleData} from './RuleForm';
+import { FormError, PartiallyUpdateRuleData } from './RuleForm';
 import { Label } from './Label';
 import { DraftRule, RuleData, RuleType } from './hooks/useRule';
 import { RuleDataLastUpdated } from './RuleDataLastUpdated';
-import { hasErrorsForField } from './helpers/errors';
+import { getErrorPropsForField } from './helpers/errors';
 
 type RuleTypeOption = {
 	id: RuleType;
@@ -44,14 +44,14 @@ export const RuleContent = ({
 	ruleFormData,
 	isLoading,
 	partiallyUpdateRuleData,
-  validationErrors,
-  hasSaveErrors
+	validationErrors,
+	hasSaveErrors,
 }: {
 	ruleData: RuleData | undefined;
 	ruleFormData: DraftRule;
 	partiallyUpdateRuleData: PartiallyUpdateRuleData;
-  validationErrors: FormError[] | undefined;
-  hasSaveErrors: boolean;
+	validationErrors: FormError[] | undefined;
+	hasSaveErrors: boolean;
 	isLoading: boolean;
 }) => {
 	const TextField =
@@ -62,6 +62,8 @@ export const RuleContent = ({
 	const handleButtonClick = () => {
 		setShowMarkdownPreview(!showMarkdownPreview);
 	};
+
+	const patternErrors = getErrorPropsForField('pattern', validationErrors);
 
 	return (
 		<RuleFormSection
@@ -145,7 +147,7 @@ export const RuleContent = ({
 				<EuiFormRow
 					label={<Label text="Pattern" required={true} />}
 					fullWidth={true}
-          isInvalid={hasErrorsForField("pattern", validationErrors)}
+					{...patternErrors}
 				>
 					<TextField
 						value={ruleFormData.pattern || ''}
@@ -154,7 +156,7 @@ export const RuleContent = ({
 						}
 						required={true}
 						fullWidth={true}
-            isInvalid={hasErrorsForField("pattern", validationErrors)}
+						{...patternErrors}
 					/>
 				</EuiFormRow>
 				<EuiFormRow

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -49,10 +49,6 @@ export const SpinnerContainer = styled.div`
 `;
 
 const formDebounceMs = 1000;
-export const emptyPatternFieldError = {
-	key: 'pattern',
-	message: 'A pattern is required',
-};
 
 export const RuleForm = ({
 	tags,
@@ -86,7 +82,6 @@ export const RuleForm = ({
 	} = useRule(ruleId);
 	const [ruleFormData, setRuleFormData] = useState(rule?.draft ?? baseForm);
 	const debouncedFormData = useDebouncedValue(ruleFormData, formDebounceMs);
-	const [formErrors, setFormErrors] = useState<FormError[]>([]);
 	const [isReasonModalVisible, setIsReasonModalVisible] = useState(false);
 
 	const partiallyUpdateRuleData: PartiallyUpdateRuleData = (
@@ -105,19 +100,12 @@ export const RuleForm = ({
 		}
 	}, [rule]);
 
+	// Remove the form errors when the data is altered
 	useEffect(() => {
-		if (!ruleFormData.pattern) {
-			setFormErrors([emptyPatternFieldError]);
-		} else {
-			setFormErrors([]);
-		}
-	}, [ruleFormData]);
-
-	useEffect(() => {
-		if (!errors && !formErrors.length) {
+		if (!errors) {
 			setShowErrors(false);
 		}
-	}, [errors, formErrors]);
+	}, [errors]);
 
 	/**
 	 * Automatically save the form data when it changes. Debounces saves.
@@ -127,7 +115,7 @@ export const RuleForm = ({
 			return;
 		}
 
-		if (formErrors.length > 0 || errors) {
+		if (errors) {
 			setShowErrors(true);
 			return;
 		}
@@ -231,17 +219,18 @@ export const RuleForm = ({
 							<RuleStatus ruleData={rule} />
 							<RuleContent
 								isLoading={isLoading}
-								errors={errors}
+								validationErrors={publishValidationErrors}
 								ruleData={rule}
 								ruleFormData={ruleFormData}
 								partiallyUpdateRuleData={partiallyUpdateRuleData}
-								showErrors={showErrors}
+								hasSaveErrors={!!errors}
 							/>
 							<RuleFormSection title="RULE METADATA">
 								<LineBreak />
 								<CategorySelector
 									currentCategory={ruleFormData.category}
 									partiallyUpdateRuleData={partiallyUpdateRuleData}
+									validationErrors={publishValidationErrors}
 								/>
 								<TagsSelector
 									tags={tags}
@@ -333,9 +322,7 @@ export const RuleForm = ({
 									color="danger"
 									iconType="error"
 								>
-									{formErrors.map((error, index) => (
-										<EuiText key={index}>{`${error.message}`}</EuiText>
-									))}
+									<EuiText>{errors}</EuiText>
 								</EuiCallOut>
 							</>
 						) : null}

--- a/apps/rule-manager/client/src/ts/components/helpers/errors.ts
+++ b/apps/rule-manager/client/src/ts/components/helpers/errors.ts
@@ -1,6 +1,21 @@
+import { capitalize } from 'lodash';
 import { FormError } from '../RuleForm';
 
-export const hasErrorsForField = (
+const defaultErrors: FormError[] = [];
+
+/**
+ * Given a list of validation errors and a field name, return props that can be
+ * spread in
+ */
+export const getErrorPropsForField = (
 	fieldName: string,
 	formErrors: FormError[] | undefined,
-) => !!formErrors?.some(({ key }) => key === fieldName);
+) => {
+	const fieldErrors =
+		formErrors?.filter(({ key }) => key === fieldName) || defaultErrors;
+
+	return {
+		isInvalid: !!fieldErrors?.length,
+		error: fieldErrors?.map(({ message }) => capitalize(message)),
+	};
+};

--- a/apps/rule-manager/client/src/ts/components/helpers/errors.ts
+++ b/apps/rule-manager/client/src/ts/components/helpers/errors.ts
@@ -1,0 +1,6 @@
+import { FormError } from '../RuleForm';
+
+export const hasErrorsForField = (
+	fieldName: string,
+	formErrors: FormError[] | undefined,
+) => !!formErrors?.some(({ key }) => key === fieldName);

--- a/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
@@ -187,9 +187,17 @@ export function useRule(ruleId: number | undefined) {
 			);
 			if (response.status === 200) {
 				const validationErrors: FormError[] = await response.json();
-				return validationErrors.length > 0
-					? setPublishValidationErrors(validationErrors)
-					: setPublishValidationErrors(undefined);
+				if (validationErrors.length > 0) {
+					setPublishValidationErrors(
+						validationErrors.map(({ key, message }) => ({
+							key: key.replace('invalid-', ''),
+							message,
+						})),
+					);
+				} else {
+					setPublishValidationErrors(undefined);
+				}
+        return;
 			}
 			setPublishValidationErrors(undefined);
 		} catch (error) {

--- a/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
@@ -197,7 +197,7 @@ export function useRule(ruleId: number | undefined) {
 				} else {
 					setPublishValidationErrors(undefined);
 				}
-        return;
+				return;
 			}
 			setPublishValidationErrors(undefined);
 		} catch (error) {

--- a/apps/rule-manager/test/db/RuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/RuleManagerSpec.scala
@@ -88,6 +88,11 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
       maybeCheckerRule shouldBe Left(
         List(
           FormError("invalid-pattern", List("error.required"), List()),
+          FormError(
+            "invalid-pattern",
+            List("Error parsing the XML: Premature end of file."),
+            List()
+          ),
           FormError("invalid-category", List("error.required"), List()),
           FormError("invalid-description", List("error.required"), List()),
           FormError("invalid-external-id", List("error.required"), List())

--- a/apps/rule-manager/test/model/CheckerRuleFormSpec.scala
+++ b/apps/rule-manager/test/model/CheckerRuleFormSpec.scala
@@ -19,7 +19,10 @@ class RuleManagerSpec extends AnyFlatSpec with Matchers {
       ("(invalidRegex", None, "category", "description", "externalId")
     )
     result.errors shouldBe Seq(
-      FormError("pattern", List("Unclosed group near index 13\n(invalidRegex"))
+      FormError(
+        "pattern",
+        List("Error parsing the regular expression: Unclosed group near index 13\n(invalidRegex")
+      )
     )
   }
 
@@ -37,7 +40,9 @@ class RuleManagerSpec extends AnyFlatSpec with Matchers {
     result.errors shouldBe Seq(
       FormError(
         "pattern",
-        List("XML document structures must start and end within the same entity.")
+        List(
+          "Error parsing the XML: XML document structures must start and end within the same entity."
+        )
       )
     )
   }

--- a/apps/rule-manager/test/model/CheckerRuleFormSpec.scala
+++ b/apps/rule-manager/test/model/CheckerRuleFormSpec.scala
@@ -1,0 +1,44 @@
+package model
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.data.FormError
+
+class RuleManagerSpec extends AnyFlatSpec with Matchers {
+  behavior of "CheckerRuleForm"
+
+  it should "accept valid regexes" in {
+    val result = RegexRuleForm.form.fillAndValidate(
+      ("validRegex", None, "category", "description", "externalId")
+    )
+    result.errors shouldBe Nil
+  }
+
+  it should "reject invalid regexes" in {
+    val result = RegexRuleForm.form.fillAndValidate(
+      ("(invalidRegex", None, "category", "description", "externalId")
+    )
+    result.errors shouldBe Seq(
+      FormError("pattern", List("Unclosed group near index 13\n(invalidRegex"))
+    )
+  }
+
+  it should "accept valid xml" in {
+    val result = LTRuleXMLForm.form.fillAndValidate(
+      ("<rulegroup id=\"VS\" name=\"vs\"></rulegroup>", "category", "description", "externalId")
+    )
+    result.errors shouldBe Nil
+  }
+
+  it should "reject invalid xml" in {
+    val result = LTRuleXMLForm.form.fillAndValidate(
+      ("<rulegroup id=\"VS\" name=\"vs\">", "category", "description", "externalId")
+    )
+    result.errors shouldBe Seq(
+      FormError(
+        "pattern",
+        List("XML document structures must start and end within the same entity.")
+      )
+    )
+  }
+}


### PR DESCRIPTION
## What does this change?

Adds validation for regex and LTXML rules. It's surfaced under the field. The validation errors themselves can be rather obscure, but I've tried to make it clear that they're related to the syntax of the pattern.

It all happens server-side.

Also links the validator errors for categories.

|regex|xml|
|-|-|
|<img width="541" alt="Screenshot 2023-08-11 at 13 59 50" src="https://github.com/guardian/typerighter/assets/7767575/8b5dc45a-75aa-4879-94ae-bdbf22e3c4b5">|<img width="541" alt="Screenshot 2023-08-11 at 13 59 59" src="https://github.com/guardian/typerighter/assets/7767575/8dc58220-ceeb-4e2e-ac6b-40f6998ee3a4">|


## How to test

Create a rule, and then enter an invalid regex (for example, an unterminated pair of parentheses), or invalid xml (for example, an unterminated tag, or no tag at all!) for regex and languagetool rules respectively. You should get the appropriate error messages