### PR TITLE
Discard rule changes modal

### DIFF
--- a/apps/rule-manager/client/src/ts/components/Diff.tsx
+++ b/apps/rule-manager/client/src/ts/components/Diff.tsx
@@ -152,7 +152,15 @@ export const transformToHumanReadableValues = (
 	});
 };
 
-export const Diff = ({ rule }: { rule: RuleData | undefined }) => {
+export const Diff = ({
+	rule,
+	beforeText,
+	afterText,
+}: {
+	rule: RuleData | undefined;
+	beforeText: string;
+	afterText: string;
+}) => {
 	const { tags } = useTags();
 
 	const diffedFields = rule
@@ -179,10 +187,10 @@ export const Diff = ({ rule }: { rule: RuleData | undefined }) => {
 							<strong>Field</strong>
 						</EuiFlexItem>
 						<EuiFlexItem grow>
-							<strong>Before republish:</strong>
+							<strong>{beforeText}</strong>
 						</EuiFlexItem>
 						<EuiFlexItem grow>
-							<strong>After republish:</strong>
+							<strong>{afterText}</strong>
 						</EuiFlexItem>
 					</EuiFlexGroup>
 					{diffedFields.map((diffedField) => (

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -222,6 +222,9 @@ export const RuleForm = ({
 		}
 
 		await discardRuleChanges(ruleId);
+		if (isRevertModalVisible) {
+			setIsRevertModalVisible(false);
+		}
 		onUpdate(ruleId);
 	};
 

--- a/apps/rule-manager/client/src/ts/components/RuleStatus.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleStatus.tsx
@@ -39,7 +39,7 @@ export const RuleStatus = ({
 	discardRuleChangesHandler,
 }: {
 	ruleData: RuleData | undefined;
-	discardRuleChangesHandler: () => Promise<void>;
+	discardRuleChangesHandler: () => void;
 }) => {
 	const state = capitalize(getRuleStatus(ruleData?.draft));
 

--- a/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
@@ -47,6 +47,7 @@ export function useRule(ruleId: number | undefined) {
 	const [errors, setErrors] = useState<string | undefined>(undefined);
 	const [ruleData, setRuleData] = useState<RuleData | undefined>(undefined);
 	const [ruleStatus, setRuleStatus] = useState<RuleStatus>('draft');
+	const [isDiscarding, setIsDiscarding] = useState(false);
 
 	const setRuleDataAndClearErrors = (ruleData: RuleData) => {
 		setRuleData(ruleData);
@@ -284,7 +285,7 @@ export function useRule(ruleId: number | undefined) {
 	};
 
 	const discardRuleChanges = async (ruleId: number) => {
-		setIsLoading(true);
+		setIsDiscarding(true);
 
 		try {
 			const response = await fetch(
@@ -305,7 +306,7 @@ export function useRule(ruleId: number | undefined) {
 		} catch (error) {
 			setErrors(errorToString(error));
 		} finally {
-			setIsLoading(false);
+			setIsDiscarding(false);
 		}
 	};
 
@@ -338,6 +339,7 @@ export function useRule(ruleId: number | undefined) {
 		unarchiveRule,
 		unpublishRule,
 		ruleStatus,
+		isDiscarding,
 		discardRuleChanges,
 	};
 }

--- a/apps/rule-manager/client/src/ts/components/modals/Reason.tsx
+++ b/apps/rule-manager/client/src/ts/components/modals/Reason.tsx
@@ -60,7 +60,11 @@ export const ReasonModal = ({
 						/>
 					</EuiFormRow>
 				</EuiForm>
-				<Diff rule={rule} />
+				<Diff
+					rule={rule}
+					beforeText={'Before republish:'}
+					afterText={'After republish:'}
+				/>
 			</EuiModalBody>
 
 			<EuiModalFooter>

--- a/apps/rule-manager/client/src/ts/components/modals/Revert.tsx
+++ b/apps/rule-manager/client/src/ts/components/modals/Revert.tsx
@@ -1,0 +1,58 @@
+import {
+	EuiButton,
+	EuiButtonEmpty,
+	EuiForm,
+	EuiModal,
+	EuiModalBody,
+	EuiModalFooter,
+	EuiModalHeader,
+	EuiModalHeaderTitle,
+	EuiSpacer,
+	EuiText,
+} from '@elastic/eui';
+import { FormEventHandler, useState } from 'react';
+import { RuleData } from '../hooks/useRule';
+import { Diff } from '../Diff';
+
+const modalFormId = 'modal-form';
+
+export const RevertModal = ({
+	onClose,
+	onSubmit,
+	isLoading,
+	rule,
+}: {
+	onClose: () => void;
+	onSubmit: () => void;
+	isLoading: boolean;
+	rule: RuleData | undefined;
+}) => {
+	const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+		e.preventDefault();
+		onSubmit();
+	};
+
+	return (
+		<EuiModal onClose={onClose} initialFocus="[name=popswitch]">
+			<EuiModalHeader>
+				<EuiModalHeaderTitle>Revert rule</EuiModalHeaderTitle>
+			</EuiModalHeader>
+			<EuiModalBody>
+				<EuiForm id={modalFormId} component="form" onSubmit={handleSubmit}>
+					<EuiText>
+						Are you sure you want to discard these unpublished changes?
+					</EuiText>
+					<EuiSpacer />
+				</EuiForm>
+				<Diff rule={rule} />
+			</EuiModalBody>
+
+			<EuiModalFooter>
+				<EuiButtonEmpty onClick={onClose}>Cancel</EuiButtonEmpty>
+				<EuiButton type="submit" form={modalFormId} fill isLoading={isLoading}>
+					Discard changes
+				</EuiButton>
+			</EuiModalFooter>
+		</EuiModal>
+	);
+};

--- a/apps/rule-manager/client/src/ts/components/modals/Revert.tsx
+++ b/apps/rule-manager/client/src/ts/components/modals/Revert.tsx
@@ -39,12 +39,14 @@ export const RevertModal = ({
 			</EuiModalHeader>
 			<EuiModalBody>
 				<EuiForm id={modalFormId} component="form" onSubmit={handleSubmit}>
-					<EuiText>
-						Are you sure you want to discard these unpublished changes?
-					</EuiText>
+					<EuiText>Are you sure you want to discard these changes?</EuiText>
 					<EuiSpacer />
 				</EuiForm>
-				<Diff rule={rule} />
+				<Diff
+					rule={rule}
+					beforeText={'Before changes:'}
+					afterText={'After changes:'}
+				/>
 			</EuiModalBody>
 
 			<EuiModalFooter>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds a Revert modal that allows the user to review their unpublished changes before discarding them.

Previously, when a live rule has unpublished changes, a `Discard unpublished changes` button would appear in the 'Rule Status' bar - button added [here](https://github.com/guardian/typerighter/pull/409). Clicking this would immediately revert the draft rule to its previous state, before the changes were made. However, the user might not be sure which unpublished changes they are discarding. The Revert modal will show a before and after diff to the user on clicking the `Discard unpublished changes` button, allowing them to review before confirming discard.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

To test this as a user, do the following:

- publish a draft rule
- make changes to the live rule - the 'Discard unpublished changes' button should appear in the 'RULE STATUS' bar
- click the 'Discard unpublished changes button' - the Revert modal should appear, showing a diff with before and after changes were made
- clicking 'Cancel' should return you back to editing the rule, with the unpublished changes still there
- clicking 'Discard changes' should revert to the most recently published state of the live rule

This can also be tested by running the client app tests with `npm run test`.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

### Before



### After

