### PR TITLE
Add permissions to appropriate action endpoints

### DIFF
--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -27,33 +27,41 @@ class RulesController(
     extends PandaAuthController(controllerComponents, config)
     with PermissionsHandler
     with FormHelpers {
-  def refresh = APIAuthAction {
-    val maybeWrittenRules = for {
-      dbRules <- sheetsRuleResource
-        .getRules()
-        .left
-        .map(toFormError("refresh-sheet"))
-      _ <- RuleManager.destructivelyPublishRules(dbRules, bucketRuleResource)
-    } yield {
-      RuleManager.getDraftRules()
-    }
+  def refresh = APIAuthAction { implicit request =>
+    hasPermission(request.user, PermissionDefinition("manage_rules", "typerighter")) match {
+      case false => Unauthorized("You don't have permission to refresh rules")
+      case true =>
+        val maybeWrittenRules = for {
+          dbRules <- sheetsRuleResource
+            .getRules()
+            .left
+            .map(toFormError("refresh-sheet"))
+          _ <- RuleManager.destructivelyPublishRules(dbRules, bucketRuleResource)
+        } yield {
+          RuleManager.getDraftRules()
+        }
 
-    maybeWrittenRules match {
-      case Right(ruleResource) => Ok(Json.toJson(ruleResource))
-      case Left(errors)        => InternalServerError(Json.toJson(errors))
+        maybeWrittenRules match {
+          case Right(ruleResource) => Ok(Json.toJson(ruleResource))
+          case Left(errors)        => InternalServerError(Json.toJson(errors))
+        }
     }
   }
 
-  def refreshDictionaryRules() = APIAuthAction {
-    val wordsOrError = bucketRuleResource.getDictionaryWords()
+  def refreshDictionaryRules() = APIAuthAction { implicit request =>
+    hasPermission(request.user, PermissionDefinition("manage_rules", "typerighter")) match {
+      case false => Unauthorized("You don't have permission to refresh dictionary rules")
+      case true =>
+        val wordsOrError = bucketRuleResource.getDictionaryWords()
 
-    val newRuleWords =
-      wordsOrError.flatMap(words =>
-        RuleManager.destructivelyPublishDictionaryRules(words, bucketRuleResource)
-      )
-    newRuleWords match {
-      case Left(errors) => InternalServerError(Json.toJson(errors))
-      case Right(words) => Ok(Json.toJson(words))
+        val newRuleWords =
+          wordsOrError.flatMap(words =>
+            RuleManager.destructivelyPublishDictionaryRules(words, bucketRuleResource)
+          )
+        newRuleWords match {
+          case Left(errors) => InternalServerError(Json.toJson(errors))
+          case Right(words) => Ok(Json.toJson(words))
+        }
     }
   }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds a permissions check to several actions that were initially too permissive. A check was added to the `publish`, `refresh` and `refreshDictionaryRules` endpoints as these actions make changes to rule data in the database.

Trello card is [here](https://trello.com/c/WKI2rD8M/1497-add-permissions-to-endpoints-that-dont-currently-have-them).

@rhystmills and I looked at refactoring to combine the authentication checking (currently done using `APIAuthAction`) with authorisation/permissions checking, to create an action `APIAuthActionWithPermission`. We attempted to extend the trait `AbstractApiAuthAction with PlainErrorResponses` and considered overriding the `invokeBlock` method to include permission checking. However it proved trickier than expected to customise to our needs, so we decided to prioritise OKR work and come back to this refactor at a later point.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Run Typerighter locally and check you can still publish rules and refresh rules (clicking the red button to destructively pull in rules from the spreadsheet). As you'll already need Composer credentials to run the Typerighter app locally, adding this permissions check should not affect your ability to publish / refresh rules.
