### PR TITLE
Add refresh dictionary button

### DIFF
--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -204,6 +204,7 @@ const RulesTable = () => {
 		isLoading,
 		error,
 		refreshRules,
+		refreshDictionaryRules,
 		isRefreshing,
 		setError,
 		fetchRules,
@@ -280,6 +281,10 @@ const RulesTable = () => {
 		await fetchTags();
 	};
 
+	const handleRefreshDictionaryRules = async () => {
+		await refreshDictionaryRules();
+	}
+
 	return (
 		<>
 			<EuiFlexGroup
@@ -332,6 +337,18 @@ const RulesTable = () => {
 												<strong>
 													Destroy all rules in the manager and reload from the
 													original Google Sheet
+												</strong>
+											</EuiButton>
+											&nbsp;
+											<EuiButton
+												size="s"
+												fill={true}
+												color={'danger'}
+												onClick={handleRefreshDictionaryRules}
+												isLoading={isRefreshing}
+											>
+												<strong>
+													Destroy all dictionary rules and reload from Collins XML wordlist
 												</strong>
 											</EuiButton>
 										</>

--- a/apps/rule-manager/client/src/ts/components/RulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/RulesTable.tsx
@@ -283,7 +283,7 @@ const RulesTable = () => {
 
 	const handleRefreshDictionaryRules = async () => {
 		await refreshDictionaryRules();
-	}
+	};
 
 	return (
 		<>
@@ -348,7 +348,8 @@ const RulesTable = () => {
 												isLoading={isRefreshing}
 											>
 												<strong>
-													Destroy all dictionary rules and reload from Collins XML wordlist
+													Destroy all dictionary rules and reload from Collins
+													XML wordlist
 												</strong>
 											</EuiButton>
 										</>

--- a/apps/rule-manager/client/src/ts/components/context/featureSwitches.tsx
+++ b/apps/rule-manager/client/src/ts/components/context/featureSwitches.tsx
@@ -9,7 +9,7 @@ export type FeatureSwitch = {
 
 const allFeatureSwitches = [
 	{
-		name: 'Enable destructive reload from rules sheet',
+		name: 'Enable destructive reload from rules sheet and Collins dictionary XML doc',
 		id: 'enable-destructive-reload',
 		default: false,
 	},

--- a/apps/rule-manager/client/src/ts/components/hooks/useRules.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRules.ts
@@ -51,6 +51,31 @@ export function useRules() {
 		}
 	};
 
+	const refreshDictionaryRules = async (): Promise<void> => {
+		setIsRefreshing(true);
+		try {
+			const updatedRulesResponse = await fetch(
+				`${location.origin}/api/refreshDictionary`,
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+				},
+			);
+			if (!updatedRulesResponse.ok) {
+				throw new Error(
+					`Failed to refresh rules: ${updatedRulesResponse.status} ${updatedRulesResponse.statusText}`,
+				);
+			}
+			await updatedRulesResponse.json();
+		} catch (e) {
+			setError(errorToString(error));
+		} finally {
+			setIsRefreshing(false);
+		}
+	};
+
 	useEffect(() => {
 		fetchRules();
 	}, []);
@@ -60,6 +85,7 @@ export function useRules() {
 		isLoading,
 		error,
 		refreshRules,
+		refreshDictionaryRules,
 		isRefreshing,
 		setError,
 		fetchRules,


### PR DESCRIPTION
## What does this change?

This adds a button for refreshing the dictionary button, hidden behind the same feature switch as the refresh rules button.

Until now we've been manually creating POST requests to the endpoint, which is laborious.

## How to test

1. Run locally according to the instructions in the readme
2. Activate the 'Enable destructive reload [...]' feature switch
3. Click the 'Destroy all dictionary rules [...]' button
4. Does this send a request to `refreshDictionary` endpoint?

(Don't worry if the request times out)
