### PR TITLE
Show error message when composer credentials are missing

### DIFF
--- a/docs/01-running-locally.md
+++ b/docs/01-running-locally.md
@@ -3,6 +3,8 @@ We will need dev-nginx: `brew install dev-nginx`
 
 # Set up
 
+Get credentials for Composer profile.
+
 Run `./script/setup` from the root of the project.
 
 This will:

--- a/script/setup
+++ b/script/setup
@@ -8,5 +8,9 @@ ln -sfn  ../../script/hooks/pre-commit .git/hooks/pre-commit
 printf "✅ Pre-commit hooks set up\n"
 
 printf "⚙️  Downloading dictionary for local use\n"
-aws s3 cp --profile composer --region eu-west-1 s3://typerighter-app-dev/dictionary/typerighter-dictionary.xml ~/.gu/typerighter/typerighter-dictionary.xml
-printf "✅ Dictionary downloaded\n"
+{
+    aws s3 cp --profile composer --region eu-west-1 s3://typerighter-app-dev/dictionary/typerighter-dictionary.xml ~/.gu/typerighter/typerighter-dictionary.xml &&
+    printf "✅ Dictionary downloaded\n"
+} || {
+    printf "❌ Dictionary download failed. Are your Composer credentials up to date?\n"
+}


### PR DESCRIPTION
## What does this change?

Show an error message to the setup script when composer credentials are missing so the failure is less cryptic. 

## How to test

Run the setup script (`./script/setup`) with or without composer credentials and note the relevant output.