### PR TITLE
Only display the total rules per category in the Checker rules page, not all the rules

### DIFF
--- a/apps/checker/app/views/rules.scala.html
+++ b/apps/checker/app/views/rules.scala.html
@@ -27,56 +27,13 @@ rulesIngested: Option[Int] = None, errors: List[String] = List.empty)(implicit r
                     </tr>
                 </thead>
                 <tbody>
-                @for(matcher <- matchers) {
+                @for(matcher <- matchers.sortBy(matcher => 0 - matcher.getRules().size)) {
                     <tr>
                         <td>
                         @matcher.getType()
                         </td>
                         <td>@matcher.getCategories().map(_.id).mkString(", ")</td>
-                        <td>@matcher.getRules().size</td>
-                    </tr>
-                }
-                </tbody>
-            </table>
-        </div>
-        <div class="col-sm-7">
-            <h5>Rules (@rules.length)</h5>
-            <table class="table">
-                <thead>
-                    <tr>
-                        <th scope="col">Type</th>
-                        <th scope="col">ID</th>
-                        <th scope="col">Category</th>
-                        <th scope="col">Match</th>
-                        <th scope="col">Description</th>
-                    </tr>
-                </thead>
-                <tbody>
-                @for(rule <- rules) {
-                    <tr>
-                        <td>@rule match {
-                            case r: RegexRule => { regex }
-                            case r: LTRule => { languagetool }
-                            case _ => { unknown }
-                        }
-                        </td>
-                        <td>
-                        @rule.id
-                        </td>
-                        <td>
-                        @rule.category.name
-                        </td>
-                        <td>@rule match {
-                            case r: RegexRule => { @r.regex.toString.slice(0, 30) }
-                            case _ => { N/A }
-                        }</td>
-                        <td>
-                        @rule match {
-                            case p: RegexRule if p.description.nonEmpty => { @p.description }
-                            case p: LTRuleXML if p.description.nonEmpty => { @p.description }
-                            case _ => { N/A }
-                        }
-                        </td>
+                        <td>@(java.text.NumberFormat.getIntegerInstance.format(matcher.getRules().size))</td>
                     </tr>
                 }
                 </tbody>

--- a/apps/checker/app/views/rules.scala.html
+++ b/apps/checker/app/views/rules.scala.html
@@ -27,7 +27,7 @@ rulesIngested: Option[Int] = None, errors: List[String] = List.empty)(implicit r
                     </tr>
                 </thead>
                 <tbody>
-                @for(matcher <- matchers.sortBy(matcher => 0 - matcher.getRules().size)) {
+                @for(matcher <- matchers.sortBy(0 - _.getRules().size)) {
                     <tr>
                         <td>
                         @matcher.getType()


### PR DESCRIPTION
With the 250,000+ dictionary rules, serialising all the rules to HTML uses all the available memory when we load the `/rules` page in the Checker service. The Rule Manager shows us all rules already, and we don't want to solve this problem in both apps.

Instead, only show the total rules per category in the Checker. This should give us confidence that the correct number of rules are published for each category (e.g. subcategories of style guide rules, language tool rules, dictionary rule).

![image](https://github.com/guardian/typerighter/assets/34686302/cde3ccb6-d7b2-448d-962e-dc637a2a698b)

In the future it may be a good idea to include some kind of artefact id in the Checker, in order to verify that a new artefact from the Rule Manager has been properly ingested by the Checker.

## How to test

1. Run the Checker service according to the instructions in the readme.
2. Visit [the rules page](https://checker.typerighter.local.dev-gutools.co.uk/rules).
3. If there is a table with total rules per category there, including dictionary rules (probably reported as 'Typos'), this branch is working as expected.
	1. If not, run the Rule Manager service, make sure dictionary rules have been created (by hitting the `api/refreshDictionary` endpoint). Then check the `/rules` page in the Checker again.