### PR TITLE
Add full file path for composer backend properties file

### DIFF
--- a/docs/03-composer-integration.md
+++ b/docs/03-composer-integration.md
@@ -8,7 +8,7 @@ It should be accessible at `https://composer.local.dev-gutools.co.uk/`.
 
 Run a local typerighter service (see instructions for [running locally](./01-running-locally.md)).
 
-Edit /.gu/flexible-composerbackend.properties and set
+Edit ~/.gu/flexible-composerbackend.properties and set
 `typerighter.url=https://checker.typerighter.local.dev-gutools.co.uk`
 
 ## Running typerighter checker


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This edits the composer integration doc, adding a `~` to the file path where one has to change the typerighter url, making it clear where this file lives.