### PR TITLE
Downgrade Typescript from `5.1.6` to `4.5.3`

### DIFF
--- a/apps/rule-manager/client/package-lock.json
+++ b/apps/rule-manager/client/package-lock.json
@@ -33,7 +33,7 @@
 				"jest": "^29.5.0",
 				"sass": "~1.32.13",
 				"ts-jest": "^29.1.0",
-				"typescript": "^5.1.3",
+				"typescript": "4.5.3",
 				"utility-types": "^3.10.0",
 				"vite": "^4.2.0",
 				"vite-plugin-checker": "^0.6.0"
@@ -7503,15 +7503,15 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+			"integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=14.17"
+				"node": ">=4.2.0"
 			}
 		},
 		"node_modules/unherit": {
@@ -13643,9 +13643,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA=="
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+			"integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ=="
 		},
 		"unherit": {
 			"version": "1.1.3",

--- a/apps/rule-manager/client/package.json
+++ b/apps/rule-manager/client/package.json
@@ -25,7 +25,7 @@
 		"jest": "^29.5.0",
 		"sass": "~1.32.13",
 		"ts-jest": "^29.1.0",
-		"typescript": "^5.1.3",
+		"typescript": "4.5.3",
 		"utility-types": "^3.10.0",
 		"vite": "^4.2.0",
 		"vite-plugin-checker": "^0.6.0"


### PR DESCRIPTION
## What does this change?

Downgrades Typescript from `5.1.6` to `4.5.3` 

I was having issues building the project because I was on a newer version of npm which forced peer dependencies to match, and Elastic UI required a different version of Typescript to the rest of the project. Downgrading Typescript fixes the issue. They had the same issue/fix in lurch [here](https://github.com/guardian/lurch/pull/618/files#r1141945136).

## How to test

Running `./script/start` boots the project successfully across different versions of npm.

## How can we measure success?

I can run the project, and so can everyone else.

## Have we considered potential risks?

As a dev dependency, this feels like a safe downgrade.