### PR TITLE
Filter out title case matches from dictionary rule matches

### DIFF
--- a/apps/checker/app/matchers/DictionaryMatcher.scala
+++ b/apps/checker/app/matchers/DictionaryMatcher.scala
@@ -33,10 +33,24 @@ class DictionaryMatcher(
 
   val matcher = new LanguageToolMatcher(instance)
 
+  def isTitleCase(str: String): Boolean = {
+    val upperCaseIncludingAccents = """[A-ZÀ-Ü]"""
+    val lowerCaseIncludingAccents = """[a-zà-ü']"""
+    val validSeparators = """(\s|\b|-)"""
+    // The below regex should match a string of title case words with any number
+    // of spaces, word boundaries, hyphens or apostrophes between them
+    str.matches(
+      raw"""($validSeparators*($upperCaseIncludingAccents$lowerCaseIncludingAccents*\b)$validSeparators*)+"""
+    )
+  }
+
   override def check(
       request: MatcherRequest
   )(implicit ec: ExecutionContext) = {
-    matcher.check(request)
+    val matcherResult = matcher.check(request)
+    matcherResult.map(ruleMatches =>
+      ruleMatches.filter(ruleMatch => !isTitleCase(ruleMatch.matchedText))
+    )
   }
 
   def getCategories() = instance.getAllActiveRules.asScala.toList.map { rule =>

--- a/apps/checker/test/scala/matchers/DictionaryMatcher.scala
+++ b/apps/checker/test/scala/matchers/DictionaryMatcher.scala
@@ -1,0 +1,62 @@
+package matchers
+
+import com.gu.typerighter.model.{Category, DictionaryRule}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DictionaryMatcherTest extends AsyncFlatSpec with Matchers {
+  val dictionaryRules = List(
+    DictionaryRule("1", "one", Category("fakeId", "fakeCategory")),
+    DictionaryRule("2", "two", Category("fakeId", "fakeCategory")),
+    DictionaryRule("3", "three", Category("fakeId", "fakeCategory"))
+  )
+  val matcher = new DictionaryMatcher(dictionaryRules)
+
+  "isTitleCase" should "match a single title case word" in {
+    val regexDoesMatch = matcher.isTitleCase("Word")
+
+    regexDoesMatch shouldBe true
+  }
+
+  "isTitleCase" should "not match a single lower case word" in {
+    val regexDoesMatch = matcher.isTitleCase("word")
+
+    regexDoesMatch shouldBe false
+  }
+
+  "isTitleCase" should "not match a single ALL CAPS word" in {
+    val regexDoesMatch = matcher.isTitleCase("WORD")
+
+    regexDoesMatch shouldBe false
+  }
+
+  "isTitleCase" should "match title case words surrounded by spaces" in {
+    val regexDoesMatch = matcher.isTitleCase("  Hey  Nice Marmot   ")
+
+    regexDoesMatch shouldBe true
+  }
+
+  "isTitleCase" should "match title case words surrounded by spaces and hyphens" in {
+    val regexDoesMatch = matcher.isTitleCase("Not-Exactly A Lightweight")
+
+    regexDoesMatch shouldBe true
+  }
+
+  "isTitleCase" should "match title case words including apostrophes" in {
+    val regexDoesMatch = matcher.isTitleCase("You're Not Wrong Walter")
+
+    regexDoesMatch shouldBe true
+  }
+
+  "isTitleCase" should "match title case words containing accents" in {
+    val regexDoesMatch = matcher.isTitleCase("Él Düderino")
+
+    regexDoesMatch shouldBe true
+  }
+
+  "isTitleCase" should "not match mixed case word sequences" in {
+    val regexDoesMatch = matcher.isTitleCase("Obviously You're Not a Golfer")
+
+    regexDoesMatch shouldBe false
+  }
+}


### PR DESCRIPTION
## What does this change?

This PR filters out Dictionary rule matches that match against Title Case phrases.

Currently, most false positive spellcheck errors are for proper nouns - usually non-english names and places.

This PR filters out such matches before they are sent to Composer (though the DictionaryMatcher LanguageTool instance still generates such matches).

It also adds some tests which try to cover as many edges cases as possible.

### In action in Composer:
<img width="1197" alt="image" src="https://github.com/guardian/typerighter/assets/34686302/e3367a14-b735-4db2-9de0-8349ff05d20f">


## How to test

Run locally:
- Composer, with config pointing to local Typerighter Checker
- Typerighter Checker service
- Typerighter Rule Manager service
- Make sure you have dictionary rules published from the rule manager
- Use Typerighter in an article in your local checker.
- Title Case words and phrases should not be spellchecked