### PR TITLE
Allow list of excluded categories rather than requiring an allowlist

### DIFF
--- a/apps/checker/app/model/Check.scala
+++ b/apps/checker/app/model/Check.scala
@@ -17,14 +17,16 @@ case class Check(
     documentId: Option[String],
     requestId: String,
     categoryIds: Option[Set[String]],
-    blocks: List[TextBlock]
+    blocks: List[TextBlock],
+    excludeCategoryIds: Option[Set[String]] = None
 ) {
   def toMarker: LogstashMarker = Markers.appendEntries(
     Map(
       "requestId" -> this.requestId,
       "documentId" -> this.documentId,
       "blocks" -> this.blocks.map(_.id).mkString(", "),
-      "categoryIds" -> this.categoryIds.mkString(", ")
+      "categoryIds" -> this.categoryIds.mkString(", "),
+      "excludeCategoryIds" -> this.excludeCategoryIds.mkString(", ")
     ).asJava
   )
 

--- a/apps/checker/app/services/MatcherPool.scala
+++ b/apps/checker/app/services/MatcherPool.scala
@@ -374,9 +374,11 @@ class MatcherPool(
   /** Get the categories to apply to this check. If no categories are supplied, default to all
     * available categories.
     */
-  private def getApplicableCategories(query: Check) = (query.categoryIds, query.excludeCategoryIds) match {
-    case (Some(ids), _) if ids.nonEmpty => ids
-    case (_, Some(excludeIds)) if excludeIds.nonEmpty => getCurrentCategories.map(_.id).filter(!excludeIds.contains(_))
-    case _                         => getCurrentCategories.map(_.id)
-  }
+  private def getApplicableCategories(query: Check) =
+    (query.categoryIds, query.excludeCategoryIds) match {
+      case (Some(ids), _) if ids.nonEmpty => ids
+      case (_, Some(excludeIds)) if excludeIds.nonEmpty =>
+        getCurrentCategories.map(_.id).filter(!excludeIds.contains(_))
+      case _ => getCurrentCategories.map(_.id)
+    }
 }

--- a/apps/checker/app/services/MatcherPool.scala
+++ b/apps/checker/app/services/MatcherPool.scala
@@ -374,8 +374,9 @@ class MatcherPool(
   /** Get the categories to apply to this check. If no categories are supplied, default to all
     * available categories.
     */
-  private def getApplicableCategories(query: Check) = query.categoryIds match {
-    case Some(ids) if ids.size > 0 => ids
+  private def getApplicableCategories(query: Check) = (query.categoryIds, query.excludeCategoryIds) match {
+    case (Some(ids), _) if ids.nonEmpty => ids
+    case (_, Some(excludeIds)) if excludeIds.nonEmpty => getCurrentCategories.map(_.id).filter(!excludeIds.contains(_))
     case _                         => getCurrentCategories.map(_.id)
   }
 }

--- a/apps/checker/test/scala/services/MatcherPoolTest.scala
+++ b/apps/checker/test/scala/services/MatcherPoolTest.scala
@@ -150,7 +150,7 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
       text: String,
       categoryIds: Option[Set[String]] = None,
       skippedRanges: List[TextRange] = Nil,
-      excludeCategoryIds: Option[Set[String]] = None,
+      excludeCategoryIds: Option[Set[String]] = None
   ) = Check(
     Some("example-document"),
     setId,
@@ -338,7 +338,8 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     matchers(0).completeWith(firstMatch)
     matchers(1).completeWith(secondMatch)
 
-    val futureResult = pool.check(getCheck(text = "Example text", excludeCategoryIds = Some(categoriesToExclude)))
+    val futureResult =
+      pool.check(getCheck(text = "Example text", excludeCategoryIds = Some(categoriesToExclude)))
 
     futureResult.map { result =>
       result.matches.size shouldMatchTo (1)


### PR DESCRIPTION
## What does this change?

Allows an exclude list of categories in addition to an allowlist of categories to the `checkStream` endpoint.

This means that, in order to an exclude an existing category (i.e. the dictionary category) from a consumer (i.e. Composer), we don't have to fetch the categories, filter it out, then request all those categories. Therefore, we can leave out a network request (and avoid a race condition in [prosemirror-typerighter](https://github.com/guardian/prosemirror-typerighter/pull/259)).

## How to test

### How to test:
1. Run Typerighter locally using this branch.
2. Build `prosemirror-typerighter` locally using this branch: https://github.com/guardian/prosemirror-typerighter/pull/259 and use in `flexible-content` with `yalc`
3. Run Composer using this branch: https://github.com/guardian/flexible-content/pull/4391
4. Activate the feature switch via <kbd>shift-f12</kbd> and refresh Composer
5. Try the toggle in both the liveblog and article views. Do matches refresh on enabling or disabling the dictionary, so that only the appopriate matches show?
6. If Collins is disabled, and you de-active the feature switch, does it remain disabled?

