### PR TITLE
Add breadcrumbs

### DIFF
--- a/apps/rule-manager/client/src/ts/components/PageNotFound.tsx
+++ b/apps/rule-manager/client/src/ts/components/PageNotFound.tsx
@@ -54,17 +54,7 @@ const TypeyArrow = styled.img`
 
 export const PageNotFound = () => {
 	return (
-		<>
-			<EuiFlexItem
-				grow={false}
-				css={css`
-					padding-bottom: 20px;
-				`}
-			>
-				<EuiTitle>
-					<h1>404 - Page not found</h1>
-				</EuiTitle>
-			</EuiFlexItem>
+		<div>
 			<EuiFlexGroup>
 				<EuiFlexItem></EuiFlexItem>
 				<TypeyContainer>
@@ -86,6 +76,6 @@ export const PageNotFound = () => {
 				</TypeyContainer>
 				<EuiFlexItem></EuiFlexItem>
 			</EuiFlexGroup>
-		</>
+		</div>
 	);
 };

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -347,10 +347,10 @@ const TagsTableContainer = styled.div`
 	max-width: 600px;
 	height: 100%;
 	thead {
-	  position: sticky;
-	  top: 0;
-	  background-color: white;
-	  z-index: 1;
+		position: sticky;
+		top: 0;
+		background-color: white;
+		z-index: 1;
 	}
 `;
 

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -5,11 +5,8 @@ import {
 	EuiFieldText,
 	EuiFlexGroup,
 	EuiFlexItem,
-	EuiForm,
-	EuiFormRow,
 	EuiIcon,
 	EuiInMemoryTable,
-	EuiInMemoryTableProps,
 	EuiInlineEditText,
 	EuiLoadingSpinner,
 	EuiModal,
@@ -19,7 +16,6 @@ import {
 	EuiSpacer,
 	EuiText,
 	EuiTextColor,
-	EuiTitle,
 	EuiToast,
 	EuiToolTip,
 } from '@elastic/eui';
@@ -30,6 +26,7 @@ import styled from '@emotion/styled';
 import { useCreateEditPermissions } from './pages/Rules';
 import { RuleFormSection } from './RuleFormSection';
 import { ErrorIResponse } from '../utils/api';
+import { FullHeightContentWithFixedHeader } from './layout/FullHeightContentWithFixedHeader';
 
 type DeleteTagButtonProps = {
 	editIsEnabled: boolean;
@@ -345,6 +342,18 @@ const ServerErrorNotification = ({ error }: { error: string }) => {
 		</EuiToast>
 	);
 };
+
+const TagsTableContainer = styled.div`
+	max-width: 600px;
+	height: 100%;
+	thead {
+	  position: sticky;
+	  top: 0;
+	  background-color: white;
+	  z-index: 1;
+	}
+`;
+
 export const TagsTable = () => {
 	const {
 		tags,
@@ -376,17 +385,20 @@ export const TagsTable = () => {
 	);
 
 	return (
-		<>
-			<EuiFlexGroup>
-				<EuiFlexItem>
-					<EuiFlexGroup>
+		<TagsTableContainer>
+			<FullHeightContentWithFixedHeader
+				header={
+					<>
 						<CreateTagForm
 							createTag={createTag}
 							enabled={hasEditPermissions}
 							isLoadingCreatedTag={isLoadingCreatedTag}
 						/>
-					</EuiFlexGroup>
-					<EuiFlexGroup>
+						{error ? <ServerErrorNotification error={error} /> : null}
+					</>
+				}
+				content={
+					<EuiFlexGroup style={{ overflowY: 'scroll', height: '100%' }}>
 						{tagToDelete && !hideDeletionModal ? (
 							<DeleteTagWarning
 								tag={tagToDelete}
@@ -408,10 +420,8 @@ export const TagsTable = () => {
 							></EuiInMemoryTable>
 						</EuiFlexItem>
 					</EuiFlexGroup>
-				</EuiFlexItem>
-				<EuiFlexItem />
-				{error ? <ServerErrorNotification error={error} /> : null}
-			</EuiFlexGroup>
-		</>
+				}
+			/>
+		</TagsTableContainer>
 	);
 };

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -378,8 +378,7 @@ export const TagsTable = () => {
 	return (
 		<>
 			<EuiFlexGroup>
-				<EuiFlexItem
-				>
+				<EuiFlexItem>
 					<EuiFlexGroup>
 						<CreateTagForm
 							createTag={createTag}

--- a/apps/rule-manager/client/src/ts/components/TagsTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/TagsTable.tsx
@@ -379,22 +379,7 @@ export const TagsTable = () => {
 		<>
 			<EuiFlexGroup>
 				<EuiFlexItem
-					css={css`
-						width: 32rem;
-					`}
 				>
-					<EuiFlexGroup>
-						<EuiFlexItem
-							grow={false}
-							css={css`
-								padding-bottom: 20px;
-							`}
-						>
-							<EuiTitle>
-								<h1>Tags</h1>
-							</EuiTitle>
-						</EuiFlexItem>
-					</EuiFlexGroup>
 					<EuiFlexGroup>
 						<CreateTagForm
 							createTag={createTag}

--- a/apps/rule-manager/client/src/ts/components/layout/Breadcrumbs.tsx
+++ b/apps/rule-manager/client/src/ts/components/layout/Breadcrumbs.tsx
@@ -1,0 +1,18 @@
+import { EuiBreadcrumbs } from '@elastic/eui';
+import { useMatches } from 'react-router-dom';
+
+export const Breadcrumbs = () => {
+	const matches = useMatches();
+	const crumbs = matches.map((match) => ({
+		text: (match.handle as { name: string })?.name || '',
+		href: match.pathname,
+	}));
+
+	return (
+		<EuiBreadcrumbs
+			breadcrumbs={crumbs}
+			truncate={false}
+			aria-label="Page breadcrumbs"
+		/>
+	);
+};

--- a/apps/rule-manager/client/src/ts/components/layout/FullHeightContentWithFixedHeader.tsx
+++ b/apps/rule-manager/client/src/ts/components/layout/FullHeightContentWithFixedHeader.tsx
@@ -1,0 +1,43 @@
+import { ReactNode } from 'react';
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	width: 100%;
+	min-width: 0;
+	min-height: 0;
+`;
+
+const Header = styled.div`
+	flex-grow: 0;
+`;
+const Content = styled.div`
+	flex-grow: 2;
+	overflow: hidden;
+`;
+
+/**
+ * +---------------------+
+ * |       Header        |
+ * +---------------------+
+ * |         ^           |
+ * |         |           |
+ * | Full-height content |
+ * |         |           |
+ * |         v           |
+ * +---------------------+
+ */
+export const FullHeightContentWithFixedHeader = ({
+	header,
+	content,
+}: {
+	header: ReactNode;
+	content: ReactNode;
+}) => (
+	<Container>
+		<Header>{header}</Header>
+		<Content>{content}</Content>
+	</Container>
+);

--- a/apps/rule-manager/client/src/ts/components/layout/Header.tsx
+++ b/apps/rule-manager/client/src/ts/components/layout/Header.tsx
@@ -13,7 +13,6 @@ import { ProfileMenu } from './ProfileMenu';
 import { EuiPopover } from '@elastic/eui';
 import { PageContext } from '../../utils/window';
 import { Link, useLocation } from 'react-router-dom';
-import { FeatureSwitchesContext } from '../context/featureSwitches';
 
 export const headerHeight = '50px';
 
@@ -52,7 +51,6 @@ const UserActionMenu = withEuiTheme(styled.div<WithEuiThemeProps>`
 export const Header = () => {
 	const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
 	const pageData = useContext(PageContext);
-	const { getFeatureSwitchValue } = useContext(FeatureSwitchesContext);
 
 	const toggleProfileMenu = () => setIsProfileMenuOpen(!isProfileMenuOpen);
 

--- a/apps/rule-manager/client/src/ts/components/layout/Page.tsx
+++ b/apps/rule-manager/client/src/ts/components/layout/Page.tsx
@@ -90,7 +90,7 @@ const router = createBrowserRouter([
 			{
 				path: '*',
 				handle: {
-					name: 'Page not found',
+					name: '404 – Page not found',
 				},
 				element: <PageNotFound />,
 			},

--- a/apps/rule-manager/client/src/ts/components/layout/Page.tsx
+++ b/apps/rule-manager/client/src/ts/components/layout/Page.tsx
@@ -1,8 +1,21 @@
 import React from 'react';
-import {EuiFlexGroup, EuiFlexItem, EuiPageTemplate, EuiProvider, EuiSpacer, EuiTitle} from '@elastic/eui';
+import {
+	EuiFlexGroup,
+	EuiFlexItem,
+	EuiPageTemplate,
+	EuiProvider,
+	EuiSpacer,
+	EuiTitle,
+} from '@elastic/eui';
 import { Header, headerHeight } from './Header';
 import { euiThemeOverrides } from '../../constants/euiTheme';
-import {Outlet, RouterProvider, createBrowserRouter, useMatch, useMatches} from 'react-router-dom';
+import {
+	Outlet,
+	RouterProvider,
+	createBrowserRouter,
+	useMatch,
+	useMatches,
+} from 'react-router-dom';
 import createCache from '@emotion/cache';
 import { FeatureSwitchesProvider } from '../context/featureSwitches';
 import { PageDataProvider } from '../../utils/window';
@@ -10,7 +23,7 @@ import styled from '@emotion/styled';
 import { PageNotFound } from '../PageNotFound';
 import { TagsTable } from '../TagsTable';
 import { Breadcrumbs } from './Breadcrumbs';
-import {Rules} from "../pages/Rules";
+import { Rules } from '../pages/Rules';
 
 // Necessary while SASS and Emotion styles coexist within EUI.
 const cache = createCache({
@@ -25,28 +38,32 @@ const PageContentContainer = styled.div`
 `;
 
 const PageContent: React.FC = () => {
-  const { name } = (useMatches()?.pop()?.handle || {}) as { name?: string }
-	return <EuiPageTemplate>
-		<Header />
-		<PageContentContainer>
-      <EuiFlexGroup
-        direction="column"
-        gutterSize="none"
-        style={{ height: '100%' }}
-      >
-        <EuiFlexItem grow={0} >
-        <Breadcrumbs />
-        <EuiSpacer size="s" />
-        <EuiTitle><h1>{name}</h1></EuiTitle>
-        <EuiSpacer size="m" />
-        </EuiFlexItem>
-      <EuiFlexItem style={{overflow: "hidden"}}>
-        <Outlet />
-      </EuiFlexItem>
-      </EuiFlexGroup>
-		</PageContentContainer>
-	</EuiPageTemplate>
-}
+	const { name } = (useMatches()?.pop()?.handle || {}) as { name?: string };
+	return (
+		<EuiPageTemplate>
+			<Header />
+			<PageContentContainer>
+				<EuiFlexGroup
+					direction="column"
+					gutterSize="none"
+					style={{ height: '100%' }}
+				>
+					<EuiFlexItem grow={0}>
+						<Breadcrumbs />
+						<EuiSpacer size="s" />
+						<EuiTitle>
+							<h1>{name}</h1>
+						</EuiTitle>
+						<EuiSpacer size="m" />
+					</EuiFlexItem>
+					<EuiFlexItem style={{ overflow: 'hidden' }}>
+						<Outlet />
+					</EuiFlexItem>
+				</EuiFlexGroup>
+			</PageContentContainer>
+		</EuiPageTemplate>
+	);
+};
 
 const router = createBrowserRouter([
 	{
@@ -72,9 +89,9 @@ const router = createBrowserRouter([
 			},
 			{
 				path: '*',
-        handle: {
-          name: 'Page not found'
-        },
+				handle: {
+					name: 'Page not found',
+				},
 				element: <PageNotFound />,
 			},
 		],

--- a/apps/rule-manager/client/src/ts/components/layout/Page.tsx
+++ b/apps/rule-manager/client/src/ts/components/layout/Page.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
-import { EuiPageTemplate, EuiProvider } from '@elastic/eui';
+import {EuiFlexGroup, EuiFlexItem, EuiPageTemplate, EuiProvider, EuiSpacer, EuiTitle} from '@elastic/eui';
 import { Header, headerHeight } from './Header';
-import { Rules } from '../pages/Rules';
 import { euiThemeOverrides } from '../../constants/euiTheme';
-import { Routes, Route } from 'react-router-dom';
+import {Outlet, RouterProvider, createBrowserRouter, useMatch, useMatches} from 'react-router-dom';
 import createCache from '@emotion/cache';
 import { FeatureSwitchesProvider } from '../context/featureSwitches';
 import { PageDataProvider } from '../../utils/window';
 import styled from '@emotion/styled';
 import { PageNotFound } from '../PageNotFound';
 import { TagsTable } from '../TagsTable';
+import { Breadcrumbs } from './Breadcrumbs';
+import {Rules} from "../pages/Rules";
 
 // Necessary while SASS and Emotion styles coexist within EUI.
 const cache = createCache({
@@ -18,50 +19,73 @@ const cache = createCache({
 	prepend: true,
 });
 
-const PageContent = styled.div`
+const PageContentContainer = styled.div`
 	height: 100vh;
 	padding: calc(${headerHeight} + 24px) 24px 24px 24px;
 `;
+
+const PageContent: React.FC = () => {
+  const { name } = (useMatches()?.pop()?.handle || {}) as { name?: string }
+	return <EuiPageTemplate>
+		<Header />
+		<PageContentContainer>
+      <EuiFlexGroup
+        direction="column"
+        gutterSize="none"
+        style={{ height: '100%' }}
+      >
+        <EuiFlexItem grow={0} >
+        <Breadcrumbs />
+        <EuiSpacer size="s" />
+        <EuiTitle><h1>{name}</h1></EuiTitle>
+        <EuiSpacer size="m" />
+        </EuiFlexItem>
+      <EuiFlexItem style={{overflow: "hidden"}}>
+        <Outlet />
+      </EuiFlexItem>
+      </EuiFlexGroup>
+		</PageContentContainer>
+	</EuiPageTemplate>
+}
+
+const router = createBrowserRouter([
+	{
+		path: '/',
+		handle: {
+			name: 'Home',
+		},
+		element: <PageContent />,
+		children: [
+			{
+				index: true,
+				handle: {
+					name: 'Search rules',
+				},
+				element: <Rules />,
+			},
+			{
+				path: 'tags',
+				handle: {
+					name: 'Tags',
+				},
+				element: <TagsTable />,
+			},
+			{
+				path: '*',
+        handle: {
+          name: 'Page not found'
+        },
+				element: <PageNotFound />,
+			},
+		],
+	},
+]);
 
 export const Page = () => (
 	<PageDataProvider>
 		<FeatureSwitchesProvider>
 			<EuiProvider modify={euiThemeOverrides} cache={cache}>
-				<EuiPageTemplate>
-					<Header />
-					<Routes>
-						<Route
-							path="/"
-							element={
-								<>
-									<PageContent>
-										<Rules />
-									</PageContent>
-								</>
-							}
-						/>
-						<Route
-							path="/tags"
-							element={
-								<>
-									<PageContent>
-										<TagsTable />
-									</PageContent>
-								</>
-							}
-						/>
-						<Route
-							path="/*"
-							element={
-								<>
-									<PageContent>
-										<PageNotFound />
-									</PageContent>
-								</>
-							}
-						/>
-					</Routes>
-				</EuiPageTemplate>
+				<RouterProvider router={router} />
 			</EuiProvider>
 		</FeatureSwitchesProvider>
 	</PageDataProvider>

--- a/apps/rule-manager/client/src/ts/components/layout/Page.tsx
+++ b/apps/rule-manager/client/src/ts/components/layout/Page.tsx
@@ -24,6 +24,7 @@ import { PageNotFound } from '../PageNotFound';
 import { TagsTable } from '../TagsTable';
 import { Breadcrumbs } from './Breadcrumbs';
 import { Rules } from '../pages/Rules';
+import { FullHeightContentWithFixedHeader } from './FullHeightContentWithFixedHeader';
 
 // Necessary while SASS and Emotion styles coexist within EUI.
 const cache = createCache({
@@ -43,23 +44,19 @@ const PageContent: React.FC = () => {
 		<EuiPageTemplate>
 			<Header />
 			<PageContentContainer>
-				<EuiFlexGroup
-					direction="column"
-					gutterSize="none"
-					style={{ height: '100%' }}
-				>
-					<EuiFlexItem grow={0}>
-						<Breadcrumbs />
-						<EuiSpacer size="s" />
-						<EuiTitle>
-							<h1>{name}</h1>
-						</EuiTitle>
-						<EuiSpacer size="m" />
-					</EuiFlexItem>
-					<EuiFlexItem style={{ overflow: 'hidden' }}>
-						<Outlet />
-					</EuiFlexItem>
-				</EuiFlexGroup>
+				<FullHeightContentWithFixedHeader
+					header={
+						<>
+							<Breadcrumbs />
+							<EuiSpacer size="s" />
+							<EuiTitle>
+								<h1>{name}</h1>
+							</EuiTitle>
+							<EuiSpacer size="m" />
+						</>
+					}
+					content={<Outlet />}
+				/>
 			</PageContentContainer>
 		</EuiPageTemplate>
 	);

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -100,6 +100,36 @@ export const Rules = () => {
 					<EuiButtonIcon onClick={() => setError(undefined)} iconType="cross" />
 				</EuiFlexItem>
 			)}
+			{getFeatureSwitchValue('enable-destructive-reload') ? (
+				<>
+					&nbsp;
+					<EuiButton
+						size="s"
+						fill={true}
+						color={'danger'}
+						onClick={handleRefreshRules}
+						isLoading={isRefreshing}
+					>
+						<strong>
+							Destroy all rules in the manager and reload from the original
+							Google Sheet
+						</strong>
+					</EuiButton>
+					&nbsp;
+					<EuiButton
+						size="s"
+						fill={true}
+						color={'danger'}
+						onClick={refreshDictionaryRules}
+						isLoading={isRefreshing}
+					>
+						<strong>
+							Destroy all dictionary rules and reload from Collins XML wordlist
+						</strong>
+					</EuiButton>
+					<EuiSpacer />
+				</>
+			) : null}
 			<EuiFlexGroup>
 				<EuiFlexItem>
 					<EuiFieldSearch

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -111,36 +111,36 @@ export const Rules = () => {
 						)}
 					</EuiFlexGrid>
 					<EuiFlexGroup>
-									{getFeatureSwitchValue('enable-destructive-reload') ? (
-
-                      <div>
-											<EuiButton
-												size="s"
-												fill={true}
-												color={'danger'}
-												onClick={handleRefreshRules}
-												isLoading={isRefreshing}
-											>
-												<strong>
-													Destroy all rules in the manager and reload from the
-													original Google Sheet
-												</strong>
-											</EuiButton>&nbsp;
-											<EuiButton
-												size="s"
-												fill={true}
-												color={'danger'}
-												onClick={refreshDictionaryRules}
-												isLoading={isRefreshing}
-											>
-												<strong>
-													Destroy all dictionary rules and reload from Collins
-													XML wordlist
-												</strong>
-											</EuiButton>
-                      <EuiSpacer />
-                      </div>
-									) : null}
+						{getFeatureSwitchValue('enable-destructive-reload') ? (
+							<div>
+								<EuiButton
+									size="s"
+									fill={true}
+									color={'danger'}
+									onClick={handleRefreshRules}
+									isLoading={isRefreshing}
+								>
+									<strong>
+										Destroy all rules in the manager and reload from the
+										original Google Sheet
+									</strong>
+								</EuiButton>
+								&nbsp;
+								<EuiButton
+									size="s"
+									fill={true}
+									color={'danger'}
+									onClick={refreshDictionaryRules}
+									isLoading={isRefreshing}
+								>
+									<strong>
+										Destroy all dictionary rules and reload from Collins XML
+										wordlist
+									</strong>
+								</EuiButton>
+								<EuiSpacer />
+							</div>
+						) : null}
 					</EuiFlexGroup>
 				</EuiFlexItem>
 				<EuiFlexGroup style={{ overflow: 'hidden' }}>

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -111,13 +111,9 @@ export const Rules = () => {
 						)}
 					</EuiFlexGrid>
 					<EuiFlexGroup>
-						<EuiFlexItem grow={0} style={{ paddingBottom: '20px' }}>
-							<EuiTitle>
-								<h1>
-									Current rules
 									{getFeatureSwitchValue('enable-destructive-reload') ? (
-										<>
-											&nbsp;
+
+                      <div>
 											<EuiButton
 												size="s"
 												fill={true}
@@ -129,8 +125,7 @@ export const Rules = () => {
 													Destroy all rules in the manager and reload from the
 													original Google Sheet
 												</strong>
-											</EuiButton>
-											&nbsp;
+											</EuiButton>&nbsp;
 											<EuiButton
 												size="s"
 												fill={true}
@@ -143,11 +138,9 @@ export const Rules = () => {
 													XML wordlist
 												</strong>
 											</EuiButton>
-										</>
+                      <EuiSpacer />
+                      </div>
 									) : null}
-								</h1>
-							</EuiTitle>
-						</EuiFlexItem>
 					</EuiFlexGroup>
 				</EuiFlexItem>
 				<EuiFlexGroup style={{ overflow: 'hidden' }}>

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -19,6 +19,7 @@ import { RuleFormBatchEdit } from '../RuleFormBatchEdit';
 import { EuiFieldSearch } from '@elastic/eui/src/components/form/field_search';
 import { PaginatedRulesTable } from '../table/PaginatedRulesTable';
 import { useDebouncedValue } from '../hooks/useDebounce';
+import { FullHeightContentWithFixedHeader } from '../layout/FullHeightContentWithFixedHeader';
 
 export const useCreateEditPermissions = () => {
 	const permissions = useContext(PageContext).permissions;
@@ -76,155 +77,120 @@ export const Rules = () => {
 
 	const rowSelectionArray = useMemo(() => [...rowSelection], [rowSelection]);
 
-	return (
-		<>
-			<EuiFlexGroup
-				direction="column"
-				gutterSize="none"
-				style={{ height: '100%' }}
-			>
-				<EuiFlexItem grow={0}>
-					<EuiFlexGrid>
-						{error && (
-							<EuiFlexItem
-								grow={true}
-								style={{
-									display: 'flex',
-									justifyContent: 'space-between',
-									alignItems: 'center',
-									width: '100%',
-									backgroundColor: '#F8D7DA',
-									color: '#721C24',
-									flexDirection: 'row',
-									padding: '10px',
-									borderRadius: '5px',
-									marginBottom: '10px',
-									fontWeight: 'bold',
-								}}
-							>
-								<div>{`${error}`}</div>
-								<EuiButtonIcon
-									onClick={() => setError(undefined)}
-									iconType="cross"
-								/>
-							</EuiFlexItem>
-						)}
-					</EuiFlexGrid>
-					<EuiFlexGroup>
-						{getFeatureSwitchValue('enable-destructive-reload') ? (
-							<div>
-								<EuiButton
-									size="s"
-									fill={true}
-									color={'danger'}
-									onClick={handleRefreshRules}
-									isLoading={isRefreshing}
-								>
-									<strong>
-										Destroy all rules in the manager and reload from the
-										original Google Sheet
-									</strong>
-								</EuiButton>
-								&nbsp;
-								<EuiButton
-									size="s"
-									fill={true}
-									color={'danger'}
-									onClick={refreshDictionaryRules}
-									isLoading={isRefreshing}
-								>
-									<strong>
-										Destroy all dictionary rules and reload from Collins XML
-										wordlist
-									</strong>
-								</EuiButton>
-								<EuiSpacer />
-							</div>
-						) : null}
-					</EuiFlexGroup>
+	const tableHeader = (
+		<div>
+			{error && (
+				<EuiFlexItem
+					grow={true}
+					style={{
+						display: 'flex',
+						justifyContent: 'space-between',
+						alignItems: 'center',
+						width: '100%',
+						backgroundColor: '#F8D7DA',
+						color: '#721C24',
+						flexDirection: 'row',
+						padding: '10px',
+						borderRadius: '5px',
+						marginBottom: '10px',
+						fontWeight: 'bold',
+					}}
+				>
+					<div>{`${error}`}</div>
+					<EuiButtonIcon onClick={() => setError(undefined)} iconType="cross" />
 				</EuiFlexItem>
-				<EuiFlexGroup style={{ overflow: 'hidden' }}>
-					<EuiFlexItem grow={2} style={{ minWidth: 0 }}>
-						<EuiFlexGroup style={{ flexGrow: 0 }}>
-							<EuiFlexItem>
-								<EuiFieldSearch
-									fullWidth
-									value={queryStr}
-									onChange={(e) => setQueryStr(e.target.value)}
-								/>
-							</EuiFlexItem>
-							<EuiFlexItem grow={0}>
-								<EuiToolTip
-									content={
-										hasCreatePermissions
-											? ''
-											: 'You do not have the correct permissions to create a rule. Please contact Central Production if you need to create rules.'
-									}
-								>
-									<EuiButton
-										isDisabled={!hasCreatePermissions}
-										onClick={() => openEditRulePanel(undefined)}
-									>
-										Create Rule
-									</EuiButton>
-								</EuiToolTip>
-							</EuiFlexItem>
-						</EuiFlexGroup>
-						<EuiSpacer />
-						{ruleData && (
-							<PaginatedRulesTable
-								ruleData={ruleData}
-								tags={tags}
-								canEditRule={hasCreatePermissions}
-								onSelectionChanged={(rows) => {
-									setRowSelection(rows);
-									if (rows.size === 1) {
-										setCurrentRuleId([...rows].pop());
-									}
-									setFormMode('edit');
-								}}
-								pageIndex={pageIndex}
-								setPageIndex={setPageIndex}
-								sortColumns={sortColumns}
-								setSortColumns={setSortColumns}
-							/>
-						)}
-					</EuiFlexItem>
-					{formMode !== 'closed' && (
-						<EuiFlexItem>
-							{rowSelection.size > 1 ? (
-								<RuleFormBatchEdit
-									tags={tags}
-									isTagMapLoading={isTagMapLoading}
-									onClose={() => {
-										setFormMode('closed');
-										fetchRules(pageIndex, queryStr, sortColumns);
-									}}
-									onUpdate={() => fetchRules(pageIndex, queryStr, sortColumns)}
-									ruleIds={rowSelectionArray}
-								/>
-							) : (
-								<RuleForm
-									tags={tags}
-									isTagMapLoading={isTagMapLoading}
-									onClose={() => {
-										setFormMode('closed');
-										fetchRules(pageIndex, queryStr, sortColumns);
-									}}
-									onUpdate={(id) => {
-										fetchRules(pageIndex, queryStr, sortColumns);
-										setCurrentRuleId(id);
-										if (formMode === 'create') {
-											setFormMode('edit');
-										}
-									}}
-									ruleId={currentRuleId}
-								/>
-							)}
-						</EuiFlexItem>
-					)}
-				</EuiFlexGroup>
+			)}
+			<EuiFlexGroup>
+				<EuiFlexItem>
+					<EuiFieldSearch
+						fullWidth
+						value={queryStr}
+						onChange={(e) => setQueryStr(e.target.value)}
+					/>
+				</EuiFlexItem>
+				<EuiFlexItem grow={0}>
+					<EuiToolTip
+						content={
+							hasCreatePermissions
+								? ''
+								: 'You do not have the correct permissions to create a rule. Please contact Central Production if you need to create rules.'
+						}
+					>
+						<EuiButton
+							isDisabled={!hasCreatePermissions}
+							onClick={() => openEditRulePanel(undefined)}
+						>
+							Create Rule
+						</EuiButton>
+					</EuiToolTip>
+				</EuiFlexItem>
 			</EuiFlexGroup>
+			<EuiSpacer />
+		</div>
+	);
+
+	const tableContent = (
+		<>
+			{ruleData && (
+				<PaginatedRulesTable
+					ruleData={ruleData}
+					tags={tags}
+					canEditRule={hasCreatePermissions}
+					onSelectionChanged={(rows) => {
+						setRowSelection(rows);
+						if (rows.size === 1) {
+							setCurrentRuleId([...rows].pop());
+						}
+						setFormMode('edit');
+					}}
+					pageIndex={pageIndex}
+					setPageIndex={setPageIndex}
+					sortColumns={sortColumns}
+					setSortColumns={setSortColumns}
+				/>
+			)}
 		</>
+	);
+
+	return (
+		<EuiFlexGroup direction="row" style={{ height: '100%' }}>
+			<FullHeightContentWithFixedHeader
+				header={tableHeader}
+				content={tableContent}
+			/>
+			{formMode !== 'closed' && (
+				<EuiFlexItem>
+					{rowSelection.size > 1 ? (
+						<RuleFormBatchEdit
+							tags={tags}
+							isTagMapLoading={isTagMapLoading}
+							onClose={() => {
+								setFormMode('closed');
+								fetchRules(pageIndex, queryStr, sortColumns);
+							}}
+							onUpdate={() => fetchRules(pageIndex, queryStr, sortColumns)}
+							ruleIds={rowSelectionArray}
+						/>
+					) : (
+						<RuleForm
+							tags={tags}
+							isTagMapLoading={isTagMapLoading}
+							onClose={() => {
+								setFormMode('closed');
+								fetchRules(pageIndex, queryStr, sortColumns);
+							}}
+							onUpdate={(id) => {
+								fetchRules(pageIndex, queryStr, sortColumns);
+								setCurrentRuleId(id);
+								if (formMode === 'create') {
+									setFormMode('edit');
+								}
+							}}
+							ruleId={currentRuleId}
+						/>
+					)}
+				</EuiFlexItem>
+			)}
+		</EuiFlexGroup>
 	);
 };

--- a/apps/rule-manager/client/src/ts/index.tsx
+++ b/apps/rule-manager/client/src/ts/index.tsx
@@ -6,7 +6,6 @@ import './components/icons';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Page } from './components/layout/Page';
-import { BrowserRouter } from 'react-router-dom';
 
 // For development mode with Vite
 import 'vite/modulepreload-polyfill';
@@ -15,9 +14,4 @@ let rootElem: HTMLElement | null;
 
 rootElem = document.getElementById('rule-manager-app');
 
-ReactDOM.render(
-	<BrowserRouter>
-		<Page />
-	</BrowserRouter>,
-	rootElem,
-);
+ReactDOM.render(<Page />, rootElem);


### PR DESCRIPTION
## What does this change?

Adds breadcrumbs to the rule manager.

|Before|After|
|-|-|
|<img width="864" alt="Screenshot 2023-09-11 at 16 41 34" src="https://github.com/guardian/typerighter/assets/7767575/2ed3bf21-9046-4f36-aad9-9ef450ee5467">|<img width="864" alt="Screenshot 2023-09-11 at 16 41 09" src="https://github.com/guardian/typerighter/assets/7767575/1b422060-397b-4b1f-85a7-8ecf35a0fda4">|

## Why?

This change anticipates adding additional routes to the rule manager as part of our rule testing work – we'll want a route for `rules/:id/test`.

It also anticipates us moving selection state into the route. At the moment it's not possible to deep-link an individual rule or a rule selection, but it'd be good if we could move that state into the URL to allow users to share links to rules.

## Dev notes

I've changed the way our routing is structured to enable the use of `useMatches`, which requires a static route declaration and is [recommended in the docs](https://reactrouter.com/en/main/routers/create-browser-router) for later versions of react-router.

I've also lifted our page layout out of our routes to prevent repetition, and shuffled the page components into `./pages` to better reflect the component structure.

## How to test

Running locally, or in CODE, navigate around the app. Do the breadcrumbs behave as expected? Is the layout working as it should?