### PR TITLE
A few UI tweaks/fixes for the rules table

### DIFF
--- a/apps/rule-manager/app/db/DbRuleDraft.scala
+++ b/apps/rule-manager/app/db/DbRuleDraft.scala
@@ -245,7 +245,7 @@ object DbRuleDraft extends SQLSyntaxSupport[DbRuleDraft] {
         }
       }
 
-      sqls"ORDER BY ${sqls.join(orderStmts, sqls",")}"
+      sqls"ORDER BY ${sqls.join(orderStmts, sqls",")}, ${rd.ruleType} ASC"
     } else sqls.empty
 
     val searchClause = maybeWord

--- a/apps/rule-manager/client/src/ts/components/hooks/useRules.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRules.ts
@@ -12,7 +12,6 @@ export type PaginatedResponse<Data> = {
 
 export type PaginatedRuleData = {
 	data: DraftRule[];
-	loadedRules: Set<number>;
 	pageSize: number;
 	total: number;
 };
@@ -58,26 +57,10 @@ export function useRules() {
 			const incomingRuleData =
 				(await response.json()) as PaginatedResponse<DraftRule>;
 
-			setRulesData((currentRuleDataData) => {
-				const loadedRules = new Set([
-					...(currentRuleDataData?.loadedRules ?? []),
-					...incomingRuleData.data.map(
-						(_, index) => (page - 1) * incomingRuleData.pageSize + index,
-					),
-				]);
-
-				const data: BaseRule[] = [];
-				incomingRuleData.data.forEach((rule, index) => {
-					const offsetIndex = (page - 1) * incomingRuleData.pageSize + index;
-					data[offsetIndex] = rule;
-				});
-
-				return {
-					data,
-					loadedRules,
-					pageSize: incomingRuleData?.pageSize ?? 0,
-					total: incomingRuleData?.total ?? 0,
-				};
+			setRulesData({
+				data: incomingRuleData.data,
+				pageSize: incomingRuleData?.pageSize ?? 0,
+				total: incomingRuleData?.total ?? 0,
 			});
 		} catch (error) {
 			setError(errorToString(error));

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -197,6 +197,10 @@ export const Rules = () => {
 								fetchRules(pageIndex, queryStr, sortColumns);
 							}}
 							onUpdate={(id) => {
+								if (id === currentRuleId) {
+									return;
+								}
+
 								fetchRules(pageIndex, queryStr, sortColumns);
 								setCurrentRuleId(id);
 								if (formMode === 'create') {

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -154,7 +154,7 @@ export const Rules = () => {
 		<>
 			{ruleData && (
 				<PaginatedRulesTable
-          isLoading={isLoading}
+					isLoading={isLoading}
 					ruleData={ruleData}
 					canEditRule={hasCreatePermissions}
 					onSelectionChanged={(rows) => {

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -42,9 +42,7 @@ export const Rules = () => {
 		'closed',
 	);
 	const [pageIndex, setPageIndex] = useState(0);
-	const [sortColumns, setSortColumns] = useState<SortColumns>([
-		{ id: 'description', direction: 'asc' },
-	]);
+	const [sortColumns, setSortColumns] = useState<SortColumns>([]);
 	const [currentRuleId, setCurrentRuleId] = useState<number | undefined>(
 		undefined,
 	);

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -30,6 +30,7 @@ export const Rules = () => {
 	const debouncedQueryStr = useDebouncedValue(queryStr, 200);
 	const {
 		ruleData,
+		isLoading,
 		error,
 		refreshRules,
 		isRefreshing,
@@ -153,6 +154,7 @@ export const Rules = () => {
 		<>
 			{ruleData && (
 				<PaginatedRulesTable
+          isLoading={isLoading}
 					ruleData={ruleData}
 					canEditRule={hasCreatePermissions}
 					onSelectionChanged={(rows) => {

--- a/apps/rule-manager/client/src/ts/components/table/PaginatedRulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/table/PaginatedRulesTable.tsx
@@ -16,11 +16,16 @@ import {
 	EuiDataGridRowHeightsOptions,
 	EuiIcon,
 	EuiSkeletonText,
+	EuiText,
 	EuiToolTip,
+	withEuiTheme,
+	WithEuiThemeProps,
 } from '@elastic/eui';
 import styled from '@emotion/styled';
 import { ConciseRuleStatus } from '../rule/ConciseRuleStatus';
 import { TagsContext } from '../context/tags';
+import { EuiDataGridToolBarVisibilityOptions } from '@elastic/eui/src/components/datagrid/data_grid_types';
+import { useEuiFontSize } from '@elastic/eui/src/global_styling/mixins/_typography';
 
 type EditRuleButtonProps = {
 	editIsEnabled: boolean;
@@ -45,6 +50,12 @@ const PaginatedRulesTableContainer = styled.div`
 	minheight: 0;
 	height: 100%;
 `;
+
+const ToolbarText = withEuiTheme(styled.span<WithEuiThemeProps>`
+	vertical-align: middle;
+	${({ theme }) => `padding-left: ${theme.euiTheme.base / 2}px;`}
+	${() => useEuiFontSize('xs')}
+`);
 
 const EditRuleButton = styled.button<EditRuleButtonProps>((props) => ({
 	width: '16px',
@@ -164,6 +175,24 @@ export const PaginatedRulesTable = ({
 	useEffect(() => {
 		onSelectionChanged(rowSelection);
 	}, [rowSelection]);
+
+	const toolbarVisibility: EuiDataGridToolBarVisibilityOptions = useMemo(
+		() => ({
+			additionalControls: {
+				left: {
+					append: (
+						<ToolbarText>
+							{ruleData.data.length} of {ruleData.total.toLocaleString()} rules
+							{rowSelection.size > 1 && (
+								<span>, {rowSelection.size} selected</span>
+							)}
+						</ToolbarText>
+					),
+				},
+			},
+		}),
+		[rowSelection, ruleData],
+	);
 
 	const leadingColumns: EuiDataGridControlColumn[] = useMemo(
 		() => [
@@ -322,6 +351,7 @@ export const PaginatedRulesTable = ({
 			<EuiDataGrid
 				aria-label="Rules grid"
 				inMemory={inMemory}
+				toolbarVisibility={toolbarVisibility}
 				columnVisibility={columnVisibility}
 				renderCellValue={renderCellValue}
 				leadingControlColumns={leadingColumns}

--- a/apps/rule-manager/client/src/ts/components/table/PaginatedRulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/table/PaginatedRulesTable.tsx
@@ -333,24 +333,27 @@ export const PaginatedRulesTable = ({
 	);
 
 	const gridStyle = useMemo(() => {
-		if (rowSelection.size !== 1) {
-			return {};
+		if (isLoading) {
+			return { rowClasses: {} };
 		}
-		const ruleId = [...rowSelection].pop();
-		const rowIndex = ruleData.data.findIndex((rule) => rule?.id === ruleId);
 
-		if (rowIndex === -1) {
-			return {};
-		}
+		const rowClasses: Record<number, string> = {};
+		rowSelection.forEach((ruleId) => {
+			const rowIndex =
+				ruleData.data.findIndex((rule) => rule?.id === ruleId) +
+				pagination.pageIndex * pagination.pageSize;
+
+			if (rowIndex !== -1) {
+				rowClasses[rowIndex] = 'typerighter-euiDataGrid--selected-row';
+			}
+		});
 
 		// Bit of an CSS escape hatch as EuiDataGrid is still reliant on classes – see
 		// https://github.com/elastic/eui/issues/4401
 		return {
-			rowClasses: {
-				[rowIndex]: 'typerighter-euiDataGrid--selected-row',
-			},
+			rowClasses,
 		};
-	}, [rowSelection]);
+	}, [rowSelection, pagination, isLoading]);
 
 	return (
 		<PaginatedRulesTableContainer>

--- a/apps/rule-manager/conf/evolutions/default/15.sql
+++ b/apps/rule-manager/conf/evolutions/default/15.sql
@@ -1,0 +1,7 @@
+-- !Ups
+
+CREATE INDEX rules_draft_rule_type ON rules_draft (rule_type);
+
+-- !Downs
+
+DROP INDEX rules_draft_rule_type;


### PR DESCRIPTION
## What does this change?

A few tweaks to the rules table:

- Fixes a crash when users select a rule that's not on page 1 😅 
- Adds a summary to indicate how many rules are available for the current search, displayed, and selected (if more than one rule is selected)
- Sorts the rules by ruleType ascending, putting regex rules first, to make the initial rules page look a bit more sensible (we will have ruleType in a column in another PR, which will make this clearer to users) – at the moment we surface LTRuleCore rules first, which results in a very blank first set of rules for PROD datasets (LTRuleCore rules do not have pattern, description etc.)

|No selection, no search|With selection|With search|
|-|-|-|
|<img width="861" alt="Screenshot 2023-09-13 at 16 01 38" src="https://github.com/guardian/typerighter/assets/7767575/d578dd7e-6848-4d08-81d6-606f62183a12">|<img width="863" alt="Screenshot 2023-09-13 at 15 32 53" src="https://github.com/guardian/typerighter/assets/7767575/76986ae9-5d50-41de-a38d-ce29969b40b6">|<img width="861" alt="Screenshot 2023-09-13 at 15 33 36" src="https://github.com/guardian/typerighter/assets/7767575/65e65940-b602-4e9b-85cf-924378013f33">|

## How to test

Have a play in local or CODE. Useful? Comments?