### PR TITLE
Add rule check UI

### DIFF
--- a/apps/common-lib/src/main/scala/com/gu/typerighter/lib/ContentClient.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/lib/ContentClient.scala
@@ -12,7 +12,8 @@ class ContentClient(client: GuardianContentClient) {
       queryStr: String,
       tags: List[String] = List.empty,
       sections: List[String] = List.empty,
-      page: Int = 1
+      page: Int = 1,
+      pageSize: Int = 10
   )(implicit ec: ExecutionContext): Future[SearchResponse] = {
     val query = ContentApiClient.search
       .q(queryStr)

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -247,9 +247,7 @@ class RulesController(
             ruleTesting
               .testRule(rule, List(document))
               .map { stream =>
-                Ok.chunked(stream.map {
-                  Json.toJson(_)
-                })
+                Ok.chunked(stream.map(record => JsonHelpers.toJsonSeq(record)))
               }
               .recover { error =>
                 InternalServerError(error.getMessage())
@@ -266,9 +264,7 @@ class RulesController(
         DbRuleDraft.find(id) match {
           case Some(rule) =>
             val matchStream = ruleTesting.testRuleWithCapiQuery(rule, query)
-            Ok.chunked(matchStream.map {
-              Json.toJson(_)
-            })
+            Ok.chunked(matchStream.map(record => JsonHelpers.toJsonSeq(record)))
           case None => NotFound
         }
       case Left(error) => BadRequest(s"Invalid request: $error")

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -249,6 +249,7 @@ class RulesController(
               .testRule(rule, List(document))
               .map { stream =>
                 Ok.chunked(stream.map(record => JsonHelpers.toJsonSeq(record)))
+                  .withHeaders("Content-Type" -> "application/json-seq")
               }
               .recover { error =>
                 InternalServerError(error.getMessage())
@@ -266,6 +267,7 @@ class RulesController(
           case Some(rule) =>
             val matchStream = ruleTesting.testRuleWithCapiQuery(rule, query)
             Ok.chunked(matchStream.map(record => JsonHelpers.toJsonSeq(record)))
+              .withHeaders("Content-Type" -> "application/json-seq")
           case None => NotFound
         }
       case Left(error) => BadRequest(s"Invalid request: $error")

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -4,6 +4,7 @@ import com.gu.permissions.PermissionDefinition
 import com.gu.typerighter.controllers.PandaAuthController
 import com.gu.typerighter.model.Document
 import com.gu.typerighter.rules.BucketRuleResource
+import com.gu.typerighter.lib.JsonHelpers
 import play.api.libs.json.{JsValue, Json}
 import db.DbRuleDraft
 import model.{BatchUpdateRuleForm, CreateRuleForm, PublishRuleForm, UpdateRuleForm}

--- a/apps/rule-manager/app/service/RuleTesting.scala
+++ b/apps/rule-manager/app/service/RuleTesting.scala
@@ -52,15 +52,16 @@ class RuleTesting(
   def testRuleWithCapiQuery(
       rule: DbRuleDraft,
       query: TestRuleCapiQuery,
-      matchCount: Int = 10,
-      maxPageCount: Int = 100,
       pageSize: Int = 20
   )(implicit ec: ExecutionContext): Source[PaginatedCheckRuleResult, NotUsed] = {
+    val maxPages = query.maxPages.getOrElse(100)
+    val maxMatches = query.maxMatches.getOrElse(10)
+
     class PaginatedContentQuery(pageLimit: Int) {
       var currentPage = 1
       def hasNext = currentPage <= pageLimit
       def nextPage(): Future[(Int, List[Document])] = {
-        log.info(s"Fetching content page $currentPage/$maxPageCount")
+        log.info(s"Fetching content page $currentPage/${maxPages}")
         val pageToFetch = currentPage
         currentPage = currentPage + 1
         contentClient
@@ -72,13 +73,13 @@ class RuleTesting(
             pageSize
           )
           .map { response =>
-            log.info(s"Received content page $pageToFetch/$maxPageCount")
+            log.info(s"Received content page $pageToFetch/${maxPages}")
             (pageToFetch, response.results.map(Document.fromCapiContent).toList)
           }
       }
     }
 
-    val createResource = () => Future.successful(new PaginatedContentQuery(maxPageCount))
+    val createResource = () => Future.successful(new PaginatedContentQuery(maxPages))
     val readFromResource = (paginatedQuery: PaginatedContentQuery) =>
       if (paginatedQuery.hasNext) {
         paginatedQuery.nextPage().map(Some.apply)
@@ -100,13 +101,13 @@ class RuleTesting(
         // The lazy source ensures that we only trigger `testRule` when there is demand
         Source
           .lazyFutureSource(() => testRule(rule, documents))
-          .map(source => PaginatedCheckRuleResult(page, maxPageCount, pageSize, source))
+          .map(source => PaginatedCheckRuleResult(page, maxPages, pageSize, source))
       }
       // Maintain a count of the matches so we can stop once our limit is reached
       .scan((0, Option.empty[PaginatedCheckRuleResult])) { case ((count, _), result) =>
         (count + result.result.matches.size, Some(result))
       }
-      .takeWhile { case (count, _) => count <= matchCount }
+      .takeWhile { case (count, _) => count <= maxMatches }
       .mapConcat { case (_, result) => result }
       // Adding a buffer that accepts a single element ensures that we apply backpressure
       // to the resource that's fetching our CAPI documents when we're checking downstream.

--- a/apps/rule-manager/app/service/RuleTesting.scala
+++ b/apps/rule-manager/app/service/RuleTesting.scala
@@ -15,7 +15,9 @@ import scala.concurrent.{ExecutionContext, Future}
 case class TestRuleCapiQuery(
     queryStr: String,
     tags: Option[List[String]] = None,
-    sections: Option[List[String]] = None
+    sections: Option[List[String]] = None,
+    maxMatches: Option[Int] = None,
+    maxPages: Option[Int] = None
 )
 
 case class PaginatedCheckRuleResult(

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -58,33 +58,40 @@ export const StandaloneRuleForm = ({
 	onClose: () => void;
 	onUpdate?: (id: number) => void;
 }) => {
-  const ruleHooks = useRule(ruleId);
+	const ruleHooks = useRule(ruleId);
 
-  return <RuleForm ruleId={ruleId} onClose={onClose} onUpdate={onUpdate} {...ruleHooks} />
-}
+	return (
+		<RuleForm
+			ruleId={ruleId}
+			onClose={onClose}
+			onUpdate={onUpdate}
+			{...ruleHooks}
+		/>
+	);
+};
 
 export const RuleForm = ({
-  ruleId,
+	ruleId,
 	onClose,
 	onUpdate,
-  updateRule,
-  createRule,
-  isLoading,
-  errors,
-  rule,
-  publishRule,
-  isPublishing,
-  validateRule,
-  publishValidationErrors,
-  resetPublishValidationErrors,
-  archiveRule,
-  unarchiveRule,
-  unpublishRule,
-  ruleStatus,
-  isDiscarding,
-  discardRuleChanges,
-}: ReturnType<typeof useRule> &  {
-  ruleId: number | undefined;
+	updateRule,
+	createRule,
+	isLoading,
+	errors,
+	rule,
+	publishRule,
+	isPublishing,
+	validateRule,
+	publishValidationErrors,
+	resetPublishValidationErrors,
+	archiveRule,
+	unarchiveRule,
+	unpublishRule,
+	ruleStatus,
+	isDiscarding,
+	discardRuleChanges,
+}: ReturnType<typeof useRule> & {
+	ruleId: number | undefined;
 	onClose: () => void;
 	onUpdate?: (id: number) => void;
 }) => {

--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -3,7 +3,6 @@ import {
 	EuiCallOut,
 	EuiFlexGroup,
 	EuiFlexItem,
-	EuiForm,
 	EuiSpacer,
 	EuiText,
 	EuiToolTip,
@@ -50,7 +49,7 @@ export const SpinnerContainer = styled.div`
 
 const formDebounceMs = 1000;
 
-export const RuleForm = ({
+export const StandaloneRuleForm = ({
 	ruleId,
 	onClose,
 	onUpdate,
@@ -59,25 +58,37 @@ export const RuleForm = ({
 	onClose: () => void;
 	onUpdate?: (id: number) => void;
 }) => {
+  const ruleHooks = useRule(ruleId);
+
+  return <RuleForm ruleId={ruleId} onClose={onClose} onUpdate={onUpdate} {...ruleHooks} />
+}
+
+export const RuleForm = ({
+  ruleId,
+	onClose,
+	onUpdate,
+  updateRule,
+  createRule,
+  isLoading,
+  errors,
+  rule,
+  publishRule,
+  isPublishing,
+  validateRule,
+  publishValidationErrors,
+  resetPublishValidationErrors,
+  archiveRule,
+  unarchiveRule,
+  unpublishRule,
+  ruleStatus,
+  isDiscarding,
+  discardRuleChanges,
+}: ReturnType<typeof useRule> &  {
+  ruleId: number | undefined;
+	onClose: () => void;
+	onUpdate?: (id: number) => void;
+}) => {
 	const [showErrors, setShowErrors] = useState(false);
-	const {
-		isLoading,
-		errors,
-		rule,
-		isPublishing,
-		publishRule,
-		updateRule,
-		createRule,
-		validateRule,
-		publishValidationErrors,
-		resetPublishValidationErrors,
-		archiveRule,
-		unarchiveRule,
-		unpublishRule,
-		ruleStatus,
-		isDiscarding,
-		discardRuleChanges,
-	} = useRule(ruleId);
 	const [ruleFormData, setRuleFormData] = useState(rule?.draft ?? baseForm);
 	const debouncedFormData = useDebouncedValue(ruleFormData, formDebounceMs);
 	const [isReasonModalVisible, setIsReasonModalVisible] = useState(false);

--- a/apps/rule-manager/client/src/ts/components/RuleFormSection.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleFormSection.tsx
@@ -1,18 +1,8 @@
 import { EuiFlexItem, EuiTextColor } from '@elastic/eui';
 import { css } from '@emotion/react';
-import styled from '@emotion/styled';
 import React from 'react';
-
-export const SectionHeader = styled.div`
-	display: flex;
-	justify-content: space-between;
-`;
-
-export const Title = styled.h2`
-	font-family: 'Guardian Agate Sans';
-	color: #1a1c21;
-	font-weight: 700;
-`;
+import { SectionHeader } from './form/SectionHeader';
+import { Title } from './form/Title';
 
 export const RuleFormSection = ({
 	title,

--- a/apps/rule-manager/client/src/ts/components/form/SectionHeader.tsx
+++ b/apps/rule-manager/client/src/ts/components/form/SectionHeader.tsx
@@ -1,4 +1,4 @@
-import styled from "@emotion/styled";
+import styled from '@emotion/styled';
 
 export const SectionHeader = styled.div`
 	display: flex;

--- a/apps/rule-manager/client/src/ts/components/form/SectionHeader.tsx
+++ b/apps/rule-manager/client/src/ts/components/form/SectionHeader.tsx
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled";
+
+export const SectionHeader = styled.div`
+	display: flex;
+	justify-content: space-between;
+`;

--- a/apps/rule-manager/client/src/ts/components/form/Title.tsx
+++ b/apps/rule-manager/client/src/ts/components/form/Title.tsx
@@ -1,4 +1,4 @@
-import styled from "@emotion/styled";
+import styled from '@emotion/styled';
 
 export const Title = styled.h2`
 	font-family: 'Guardian Agate Sans';

--- a/apps/rule-manager/client/src/ts/components/form/Title.tsx
+++ b/apps/rule-manager/client/src/ts/components/form/Title.tsx
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+
+export const Title = styled.h2`
+	font-family: 'Guardian Agate Sans';
+	color: #1a1c21;
+	font-weight: 700;
+`;

--- a/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
@@ -4,7 +4,11 @@ import { errorToString } from '../../utils/error';
 import { FormError } from '../RuleForm';
 import { getRuleStatus, RuleStatus } from '../../utils/rule';
 
-export type RuleType = 'regex' | 'languageToolXML' | 'dictionary';
+export type RuleType =
+	| 'regex'
+	| 'languageToolXML'
+	| 'languageToolCore'
+	| 'dictionary';
 
 export type BaseRule = {
 	ruleType: RuleType;

--- a/apps/rule-manager/client/src/ts/components/icons/index.ts
+++ b/apps/rule-manager/client/src/ts/components/icons/index.ts
@@ -38,7 +38,7 @@ import { icon as sortLeft } from '@elastic/eui/src/components/icon/assets/sortLe
 import { icon as sortRight } from '@elastic/eui/src/components/icon/assets/sortRight';
 import { icon as fullScreenExit } from '@elastic/eui/src/components/icon/assets/fullScreenExit';
 import { icon as tokenString } from '@elastic/eui/src/components/icon/assets/tokenString';
-import { icon as bug } from '@elastic/eui/src/components/icon/assets/bug';
+import { icon as wrench } from '@elastic/eui/src/components/icon/assets/wrench';
 
 const cachedIcons = {
 	apps,
@@ -80,7 +80,7 @@ const cachedIcons = {
 	sortRight,
 	expandMini,
 	tokenString,
-	bug,
+	wrench,
 };
 
 appendIconComponentCache(cachedIcons);

--- a/apps/rule-manager/client/src/ts/components/icons/index.ts
+++ b/apps/rule-manager/client/src/ts/components/icons/index.ts
@@ -38,7 +38,7 @@ import { icon as sortLeft } from '@elastic/eui/src/components/icon/assets/sortLe
 import { icon as sortRight } from '@elastic/eui/src/components/icon/assets/sortRight';
 import { icon as fullScreenExit } from '@elastic/eui/src/components/icon/assets/fullScreenExit';
 import { icon as tokenString } from '@elastic/eui/src/components/icon/assets/tokenString';
-import { icon as wrench } from '@elastic/eui/src/components/icon/assets/wrench';
+import { icon as beaker } from '@elastic/eui/src/components/icon/assets/beaker';
 
 const cachedIcons = {
 	apps,
@@ -80,7 +80,7 @@ const cachedIcons = {
 	sortRight,
 	expandMini,
 	tokenString,
-	wrench,
+	beaker,
 };
 
 appendIconComponentCache(cachedIcons);

--- a/apps/rule-manager/client/src/ts/components/icons/index.ts
+++ b/apps/rule-manager/client/src/ts/components/icons/index.ts
@@ -38,6 +38,7 @@ import { icon as sortLeft } from '@elastic/eui/src/components/icon/assets/sortLe
 import { icon as sortRight } from '@elastic/eui/src/components/icon/assets/sortRight';
 import { icon as fullScreenExit } from '@elastic/eui/src/components/icon/assets/fullScreenExit';
 import { icon as tokenString } from '@elastic/eui/src/components/icon/assets/tokenString';
+import { icon as bug } from '@elastic/eui/src/components/icon/assets/bug';
 
 const cachedIcons = {
 	apps,
@@ -79,6 +80,7 @@ const cachedIcons = {
 	sortRight,
 	expandMini,
 	tokenString,
+	bug,
 };
 
 appendIconComponentCache(cachedIcons);

--- a/apps/rule-manager/client/src/ts/components/pages/EditRule.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/EditRule.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useOutletContext, useParams } from 'react-router-dom';
+import {
+	TyperighterChunkedAdapter,
+	PaginatedCheckRuleResult,
+	RuleMatch,
+} from '../../utils/TyperighterChunkedAdapter';
+import styled from '@emotion/styled';
+import {
+	EuiFieldText,
+	EuiFlexGroup,
+	EuiFlexItem,
+	EuiLoadingSpinner,
+	EuiSpacer,
+	EuiTitle,
+	WithEuiThemeProps,
+	useEuiTheme,
+	withEuiTheme,
+	EuiText,
+	EuiButtonEmpty,
+	EuiLink,
+} from '@elastic/eui';
+import { RuleForm, RuleFormContext } from '../RuleForm';
+import { noop } from 'lodash';
+import { useDebouncedValue } from '../hooks/useDebounce';
+
+const MatchContainer = withEuiTheme(styled.div<WithEuiThemeProps>`
+	font-family: 'Guardian Egyptian Text';
+	background-color: white;
+	padding: ${({ theme }) => theme.euiTheme.base}px;
+`);
+
+const ResultText = styled.div`
+	display: flex;
+	align-items: center;
+`;
+
+const ResultActions = styled.div`
+	margin-left: auto;
+`;
+
+const chunkedAdapter = new TyperighterChunkedAdapter();
+
+export const EditRule = () => {
+	const { id: ruleId } = useParams();
+	const { pattern } = useOutletContext() as RuleFormContext;
+	const [matches, setMatches] = useState<RuleMatch[]>([]);
+	const [isLoading, setIsLoading] = useState(false);
+	const [result, setResult] = useState<PaginatedCheckRuleResult | undefined>(
+		undefined,
+	);
+	const [queryStr, setQueryStr] = useState('');
+	const gap = `${useEuiTheme().euiTheme.base}px`;
+	const debouncedQueryStr = useDebouncedValue(queryStr, 1000);
+
+	const fetchMatches = useMemo(
+		() => () => {
+			if (!pattern || !ruleId) {
+				return;
+			}
+
+			setMatches([]);
+			setIsLoading(true);
+
+			chunkedAdapter.fetchMatches({
+				queryStr: debouncedQueryStr,
+				ruleId,
+				onMatchesReceived: (result) => {
+					setMatches((cur) => cur.concat(result.result.matches));
+					setResult(result);
+				},
+				onRequestError: (err) => console.warn(err),
+				onRequestComplete: () => setIsLoading(false),
+			});
+		},
+		[debouncedQueryStr, pattern, ruleId],
+	);
+
+	useEffect(() => {
+		fetchMatches();
+		return () => chunkedAdapter.abort();
+	}, [debouncedQueryStr, pattern]);
+
+	return (
+		<EuiFlexItem style={{ height: '100%' }}>
+			<EuiFlexGroup style={{ height: '100%' }} direction="column">
+				<EuiFlexItem grow={0}>
+					<EuiFlexGroup direction={'column'} gutterSize="s">
+						<EuiFieldText
+							placeholder={
+								'Add a CAPI query to narrow down the content to check'
+							}
+							value={queryStr}
+							onChange={(e) => setQueryStr(e.target.value)}
+							fullWidth={true}
+						/>
+						{result ? (
+							<EuiFlexGroup>
+								<ResultText>
+									<span>
+										Page {result.currentPage} of {result.maxPages} checked (
+										{result.currentPage * result.pageSize} articles),{' '}
+										{matches.length} matches found&nbsp;&nbsp;
+									</span>
+									{isLoading && <EuiLoadingSpinner size="s" />}
+								</ResultText>
+								{isLoading && (
+									<ResultActions>
+										<EuiLink href="#" onClick={() => chunkedAdapter.abort()}>
+											Cancel
+										</EuiLink>
+									</ResultActions>
+								)}
+							</EuiFlexGroup>
+						) : (
+							''
+						)}
+					</EuiFlexGroup>
+				</EuiFlexItem>
+				<EuiFlexItem style={{ overflowY: 'scroll', gap }}>
+					{!matches.length && (
+						<>
+							<EuiSpacer size="xxl" />
+							<EuiText
+								color="subdued"
+								size="s"
+								textAlign="center"
+							>{`No matches found for this search${
+								isLoading ? ' yet.' : '.'
+							}`}</EuiText>
+						</>
+					)}
+					{matches.map(
+						({
+							fromPos,
+							toPos,
+							precedingText,
+							matchedText,
+							subsequentText,
+						}) => {
+							return (
+								<MatchContainer key={`${fromPos}-${toPos}-${matchedText}`}>
+									<p>
+										…{precedingText}
+										<strong>{matchedText}</strong>
+										{subsequentText}…
+									</p>
+								</MatchContainer>
+							);
+						},
+					)}
+				</EuiFlexItem>
+			</EuiFlexGroup>
+		</EuiFlexItem>
+	);
+};

--- a/apps/rule-manager/client/src/ts/components/pages/Rule.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rule.tsx
@@ -27,7 +27,7 @@ export const Rule = () => {
 				{rule?.ruleType !== 'dictionary' ? (
 					<TestRule pattern={testPattern} />
 				) : (
-					<h2>You cannot yet test dictionary rules.</h2>
+					<h2>Testing is not currently supported for dictionary rules.</h2>
 				)}
 			</EuiFlexItem>
 		</EuiFlexGroup>

--- a/apps/rule-manager/client/src/ts/components/pages/Rule.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rule.tsx
@@ -11,6 +11,7 @@ export const Rule = () => {
 	const { id } = useParams() as { id: string };
 	const ruleId = id === newRuleId ? undefined : parseInt(id);
 	const ruleHooks = useRule(ruleId);
+	const rule = ruleHooks.rule?.draft;
 	const testPattern = ruleHooks.rule?.draft.pattern;
 	const navigate = useNavigate();
 	return (
@@ -23,7 +24,11 @@ export const Rule = () => {
 				/>
 			</EuiFlexItem>
 			<EuiFlexItem grow={2}>
-				<TestRule pattern={testPattern} />
+				{rule?.ruleType !== 'dictionary' ? (
+					<TestRule pattern={testPattern} />
+				) : (
+					<h2>You cannot yet test dictionary rules.</h2>
+				)}
 			</EuiFlexItem>
 		</EuiFlexGroup>
 	);

--- a/apps/rule-manager/client/src/ts/components/pages/Rule.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rule.tsx
@@ -9,9 +9,9 @@ export const newRuleId = 'new-rule';
 
 export const Rule = () => {
 	const { id } = useParams() as { id: string };
-  const ruleId = id === newRuleId ? undefined : parseInt(id);
-  const ruleHooks = useRule(ruleId);
-  const testPattern = ruleHooks.rule?.draft.pattern;
+	const ruleId = id === newRuleId ? undefined : parseInt(id);
+	const ruleHooks = useRule(ruleId);
+	const testPattern = ruleHooks.rule?.draft.pattern;
 	const navigate = useNavigate();
 	return (
 		<EuiFlexGroup style={{ height: '100%' }}>
@@ -19,12 +19,12 @@ export const Rule = () => {
 				<RuleForm
 					ruleId={ruleId}
 					onClose={() => navigate('/')}
-          {...ruleHooks}
+					{...ruleHooks}
 				/>
 			</EuiFlexItem>
 			<EuiFlexItem grow={2}>
-         <TestRule pattern={testPattern} />
-      </EuiFlexItem>
+				<TestRule pattern={testPattern} />
+			</EuiFlexItem>
 		</EuiFlexGroup>
 	);
 };

--- a/apps/rule-manager/client/src/ts/components/pages/Rule.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rule.tsx
@@ -2,21 +2,29 @@ import React from 'react';
 import { RuleForm } from '../RuleForm';
 import { useNavigate, useParams } from 'react-router-dom';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { useRule } from '../hooks/useRule';
+import { TestRule } from './TestRule';
 
 export const newRuleId = 'new-rule';
 
 export const Rule = () => {
-	const { id: ruleId } = useParams() as { id: string };
+	const { id } = useParams() as { id: string };
+  const ruleId = id === newRuleId ? undefined : parseInt(id);
+  const ruleHooks = useRule(ruleId);
+  const testPattern = ruleHooks.rule?.draft.pattern;
 	const navigate = useNavigate();
 	return (
 		<EuiFlexGroup style={{ height: '100%' }}>
 			<EuiFlexItem style={{ overflowY: 'scroll' }}>
 				<RuleForm
-					ruleId={ruleId === newRuleId ? undefined : parseInt(ruleId)}
+					ruleId={ruleId}
 					onClose={() => navigate('/')}
+          {...ruleHooks}
 				/>
 			</EuiFlexItem>
-			<EuiFlexItem grow={2}></EuiFlexItem>
+			<EuiFlexItem grow={2}>
+         <TestRule pattern={testPattern} />
+      </EuiFlexItem>
 		</EuiFlexGroup>
 	);
 };

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -4,12 +4,11 @@ import {
 	EuiButton,
 	EuiFlexGroup,
 	EuiButtonIcon,
-	EuiFlexGrid,
 	EuiToolTip,
 	EuiSpacer,
 } from '@elastic/eui';
 import { SortColumns, useRules } from '../hooks/useRules';
-import { RuleForm, StandaloneRuleForm } from '../RuleForm';
+import { StandaloneRuleForm } from '../RuleForm';
 import { PageContext } from '../../utils/window';
 import { hasCreateEditPermissions } from '../helpers/hasCreateEditPermissions';
 import { FeatureSwitchesContext } from '../context/featureSwitches';

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -9,7 +9,7 @@ import {
 	EuiSpacer,
 } from '@elastic/eui';
 import { SortColumns, useRules } from '../hooks/useRules';
-import { RuleForm } from '../RuleForm';
+import { RuleForm, StandaloneRuleForm } from '../RuleForm';
 import { PageContext } from '../../utils/window';
 import { hasCreateEditPermissions } from '../helpers/hasCreateEditPermissions';
 import { FeatureSwitchesContext } from '../context/featureSwitches';
@@ -193,7 +193,7 @@ export const Rules = () => {
 							ruleIds={rowSelectionArray}
 						/>
 					) : (
-						<RuleForm
+						<StandaloneRuleForm
 							onClose={() => {
 								setFormMode('closed');
 								fetchRules(pageIndex, queryStr, sortColumns);

--- a/apps/rule-manager/client/src/ts/components/pages/TestRule.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/TestRule.tsx
@@ -41,35 +41,15 @@ const ResultActions = styled.div`
 
 const chunkedAdapter = new TyperighterChunkedAdapter();
 
-const maxMatchOptions = [
-	{
-		value: 10,
-		text: 'Search for max. 10 matches',
-	},
-	{
-		value: 20,
-		text: 'Search for max. 20 matches',
-	},
-	{
-		value: 50,
-		text: 'Search for max. 50 matches',
-	},
-];
+const maxMatchOptions = [10, 20, 50].map((value) => ({
+	value,
+	text: `Search for max. ${value} matches`,
+}));
 
-const maxPageOptions = [
-	{
-		value: 50,
-		text: 'Across 50 pages of content',
-	},
-	{
-		value: 100,
-		text: 'Across 100 pages of content',
-	},
-	{
-		value: 200,
-		text: 'Across 200 pages of content',
-	},
-];
+const maxPageOptions = [50, 100, 200].map((value) => ({
+	value,
+	text: `across ${value} pages of content`,
+}));
 
 export const TestRule = ({ pattern }: { pattern?: string }) => {
 	const { id: ruleId } = useParams();
@@ -96,8 +76,8 @@ export const TestRule = ({ pattern }: { pattern?: string }) => {
 			chunkedAdapter.fetchMatches({
 				queryStr: debouncedQueryStr,
 				ruleId,
-        maxMatches,
-        maxPages,
+				maxMatches,
+				maxPages,
 				onMatchesReceived: (result) => {
 					setMatches((cur) => cur.concat(result.result.matches));
 					setResult(result);
@@ -106,13 +86,13 @@ export const TestRule = ({ pattern }: { pattern?: string }) => {
 				onRequestComplete: () => setIsLoading(false),
 			});
 		},
-		[debouncedQueryStr, pattern, ruleId],
+		[debouncedQueryStr, pattern, ruleId, maxMatches, maxPages],
 	);
 
 	useEffect(() => {
 		fetchMatches();
 		return () => chunkedAdapter.abort();
-	}, [debouncedQueryStr, pattern]);
+	}, [debouncedQueryStr, pattern, maxMatches, maxPages]);
 
 	return (
 		<EuiFlexItem style={{ height: '100%', paddingTop: '12px' }}>
@@ -139,8 +119,11 @@ export const TestRule = ({ pattern }: { pattern?: string }) => {
 							/>
 						</EuiFlexItem>
 						<EuiFlexItem>
-							<EuiSelect options={maxPageOptions}value={maxPages}
-								onChange={(e) => setMaxPages(parseInt(e.target.value))} />
+							<EuiSelect
+								options={maxPageOptions}
+								value={maxPages}
+								onChange={(e) => setMaxPages(parseInt(e.target.value))}
+							/>
 						</EuiFlexItem>
 						<EuiFlexItem grow={2}>
 							<EuiFieldText
@@ -176,7 +159,6 @@ export const TestRule = ({ pattern }: { pattern?: string }) => {
 						)}
 					</EuiFlexItem>
 				</EuiFlexItem>
-
 				<EuiFlexItem style={{ overflowY: 'scroll', gap }}>
 					{!matches.length && (
 						<>

--- a/apps/rule-manager/client/src/ts/components/pages/TestRule.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/TestRule.tsx
@@ -100,10 +100,30 @@ export const TestRule = ({ pattern }: { pattern?: string }) => {
 				<Title>
 					TEST RULE AGAINST GUARDIAN CONTENT&nbsp;
 					<EuiIconTip
-						content="Test this rule by running it against lots of Guardian content. Any matches found are shown below."
+						content={
+							<>
+								By default, this tool will test your rule against the latest
+								Guardian content from CAPI, our content API.
+								<br />
+								<br />
+								By adding a search query, you can test your rule against content
+								more likely to include your match.
+								<br />
+								<br />
+								For example, to search the following rule, which finds instances
+								of the word 'However' without a comma:
+								<br />
+								<br />
+								{`(?<=. )However(?!,)`}
+								<br />
+								<br />… you may want to search for your match only in articles
+								containing 'However', increasing your chances of finding
+								matches.
+							</>
+						}
 						position="right"
 						type="iInCircle"
-						size="s"
+						size="m"
 					/>
 				</Title>
 			</SectionHeader>
@@ -128,7 +148,7 @@ export const TestRule = ({ pattern }: { pattern?: string }) => {
 						<EuiFlexItem grow={2}>
 							<EuiFieldText
 								placeholder={
-									'Narrow down the content to test with a CAPI query'
+									'Narrow down the content to test with a search phrase for CAPI'
 								}
 								value={queryStr}
 								onChange={(e) => setQueryStr(e.target.value)}

--- a/apps/rule-manager/client/src/ts/components/pages/TestRule.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/TestRule.tsx
@@ -127,7 +127,9 @@ export const TestRule = ({ pattern }: { pattern?: string }) => {
 						</EuiFlexItem>
 						<EuiFlexItem grow={2}>
 							<EuiFieldText
-								placeholder={'Narrow down the search with a CAPI query'}
+								placeholder={
+									'Narrow down the content to test with a CAPI query'
+								}
 								value={queryStr}
 								onChange={(e) => setQueryStr(e.target.value)}
 								fullWidth={true}

--- a/apps/rule-manager/client/src/ts/components/pages/TestRule.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/TestRule.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useOutletContext, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import {
 	TyperighterChunkedAdapter,
 	PaginatedCheckRuleResult,
@@ -12,17 +12,17 @@ import {
 	EuiFlexItem,
 	EuiLoadingSpinner,
 	EuiSpacer,
-	EuiTitle,
 	WithEuiThemeProps,
 	useEuiTheme,
 	withEuiTheme,
 	EuiText,
-	EuiButtonEmpty,
 	EuiLink,
+	EuiIconTip,
 } from '@elastic/eui';
-import { RuleForm } from '../RuleForm';
-import { noop } from 'lodash';
 import { useDebouncedValue } from '../hooks/useDebounce';
+import { Title } from '../form/Title';
+import { SectionHeader } from '../form/SectionHeader';
+import { LineBreak } from '../LineBreak';
 
 const MatchContainer = withEuiTheme(styled.div<WithEuiThemeProps>`
 	font-family: 'Guardian Egyptian Text';
@@ -81,39 +81,55 @@ export const TestRule = ({ pattern }: { pattern?: string }) => {
 	}, [debouncedQueryStr, pattern]);
 
 	return (
-		<EuiFlexItem style={{ height: '100%' }}>
+		<EuiFlexItem style={{ height: '100%', paddingTop: '12px' }}>
+			<SectionHeader>
+				<Title>
+					TEST RULE&nbsp;
+					<EuiIconTip
+						content="Test a rule against Guardian content, showing any matches found."
+						position="right"
+						type="iInCircle"
+						size="s"
+					/>
+				</Title>
+			</SectionHeader>
+			<EuiSpacer size="m" />
 			<EuiFlexGroup style={{ height: '100%' }} direction="column">
 				<EuiFlexItem grow={0}>
-					<EuiFlexGroup direction={'column'} gutterSize="s">
-						<EuiFieldText
-							placeholder={
-								'Add a CAPI query to narrow down the content to check'
-							}
-							value={queryStr}
-							onChange={(e) => setQueryStr(e.target.value)}
-							fullWidth={true}
-						/>
-						{result ? (
-							<EuiFlexGroup>
-								<ResultText>
-									<span>
-										Page {result.currentPage} of {result.maxPages} checked (
-										{result.currentPage * result.pageSize} articles),{' '}
-										{matches.length} matches found&nbsp;&nbsp;
-									</span>
-									{isLoading && <EuiLoadingSpinner size="s" />}
-								</ResultText>
-								{isLoading && (
-									<ResultActions>
-										<EuiLink href="#" onClick={() => chunkedAdapter.abort()}>
-											Cancel
-										</EuiLink>
-									</ResultActions>
-								)}
-							</EuiFlexGroup>
-						) : (
-							''
-						)}
+					<EuiFlexGroup direction={'row'} gutterSize="s">
+						<EuiFlexItem>
+							<EuiFieldText
+								placeholder={
+									'Add a CAPI query to narrow down the content to check'
+								}
+								value={queryStr}
+								onChange={(e) => setQueryStr(e.target.value)}
+								fullWidth={true}
+							/>
+						</EuiFlexItem>
+						<EuiFlexItem>
+							{result ? (
+								<EuiFlexGroup>
+									<ResultText>
+										<span>
+											Page {result.currentPage} of {result.maxPages} checked (
+											{result.currentPage * result.pageSize} articles),{' '}
+											{matches.length} matches found&nbsp;&nbsp;
+										</span>
+										{isLoading && <EuiLoadingSpinner size="s" />}
+									</ResultText>
+									{isLoading && (
+										<ResultActions>
+											<EuiLink href="#" onClick={() => chunkedAdapter.abort()}>
+												Cancel
+											</EuiLink>
+										</ResultActions>
+									)}
+								</EuiFlexGroup>
+							) : (
+								''
+							)}
+						</EuiFlexItem>
 					</EuiFlexGroup>
 				</EuiFlexItem>
 				<EuiFlexItem style={{ overflowY: 'scroll', gap }}>

--- a/apps/rule-manager/client/src/ts/components/pages/TestRule.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/TestRule.tsx
@@ -20,7 +20,7 @@ import {
 	EuiButtonEmpty,
 	EuiLink,
 } from '@elastic/eui';
-import { RuleForm, RuleFormContext } from '../RuleForm';
+import { RuleForm } from '../RuleForm';
 import { noop } from 'lodash';
 import { useDebouncedValue } from '../hooks/useDebounce';
 
@@ -41,9 +41,8 @@ const ResultActions = styled.div`
 
 const chunkedAdapter = new TyperighterChunkedAdapter();
 
-export const EditRule = () => {
+export const TestRule = ({ pattern }: { pattern?: string }) => {
 	const { id: ruleId } = useParams();
-	const { pattern } = useOutletContext() as RuleFormContext;
 	const [matches, setMatches] = useState<RuleMatch[]>([]);
 	const [isLoading, setIsLoading] = useState(false);
 	const [result, setResult] = useState<PaginatedCheckRuleResult | undefined>(

--- a/apps/rule-manager/client/src/ts/components/pages/TestRule.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/TestRule.tsx
@@ -18,11 +18,11 @@ import {
 	EuiText,
 	EuiLink,
 	EuiIconTip,
+	EuiSelect,
 } from '@elastic/eui';
 import { useDebouncedValue } from '../hooks/useDebounce';
 import { Title } from '../form/Title';
 import { SectionHeader } from '../form/SectionHeader';
-import { LineBreak } from '../LineBreak';
 
 const MatchContainer = withEuiTheme(styled.div<WithEuiThemeProps>`
 	font-family: 'Guardian Egyptian Text';
@@ -41,9 +41,41 @@ const ResultActions = styled.div`
 
 const chunkedAdapter = new TyperighterChunkedAdapter();
 
+const maxMatchOptions = [
+	{
+		value: 10,
+		text: 'Search for max. 10 matches',
+	},
+	{
+		value: 20,
+		text: 'Search for max. 20 matches',
+	},
+	{
+		value: 50,
+		text: 'Search for max. 50 matches',
+	},
+];
+
+const maxPageOptions = [
+	{
+		value: 50,
+		text: 'Across 50 pages of content',
+	},
+	{
+		value: 100,
+		text: 'Across 100 pages of content',
+	},
+	{
+		value: 200,
+		text: 'Across 200 pages of content',
+	},
+];
+
 export const TestRule = ({ pattern }: { pattern?: string }) => {
 	const { id: ruleId } = useParams();
 	const [matches, setMatches] = useState<RuleMatch[]>([]);
+	const [maxMatches, setMaxMatches] = useState<number>(10);
+	const [maxPages, setMaxPages] = useState<number>(50);
 	const [isLoading, setIsLoading] = useState(false);
 	const [result, setResult] = useState<PaginatedCheckRuleResult | undefined>(
 		undefined,
@@ -64,6 +96,8 @@ export const TestRule = ({ pattern }: { pattern?: string }) => {
 			chunkedAdapter.fetchMatches({
 				queryStr: debouncedQueryStr,
 				ruleId,
+        maxMatches,
+        maxPages,
 				onMatchesReceived: (result) => {
 					setMatches((cur) => cur.concat(result.result.matches));
 					setResult(result);
@@ -84,9 +118,9 @@ export const TestRule = ({ pattern }: { pattern?: string }) => {
 		<EuiFlexItem style={{ height: '100%', paddingTop: '12px' }}>
 			<SectionHeader>
 				<Title>
-					TEST RULE&nbsp;
+					TEST RULE AGAINST GUARDIAN CONTENT&nbsp;
 					<EuiIconTip
-						content="Test a rule against Guardian content, showing any matches found."
+						content="Test this rule by running it against lots of Guardian content. Any matches found are shown below."
 						position="right"
 						type="iInCircle"
 						size="s"
@@ -98,40 +132,51 @@ export const TestRule = ({ pattern }: { pattern?: string }) => {
 				<EuiFlexItem grow={0}>
 					<EuiFlexGroup direction={'row'} gutterSize="s">
 						<EuiFlexItem>
+							<EuiSelect
+								options={maxMatchOptions}
+								value={maxMatches}
+								onChange={(e) => setMaxMatches(parseInt(e.target.value))}
+							/>
+						</EuiFlexItem>
+						<EuiFlexItem>
+							<EuiSelect options={maxPageOptions}value={maxPages}
+								onChange={(e) => setMaxPages(parseInt(e.target.value))} />
+						</EuiFlexItem>
+						<EuiFlexItem grow={2}>
 							<EuiFieldText
-								placeholder={
-									'Add a CAPI query to narrow down the content to check'
-								}
+								placeholder={'Narrow down the search with a CAPI query'}
 								value={queryStr}
 								onChange={(e) => setQueryStr(e.target.value)}
 								fullWidth={true}
 							/>
 						</EuiFlexItem>
-						<EuiFlexItem>
-							{result ? (
-								<EuiFlexGroup>
-									<ResultText>
-										<span>
-											Page {result.currentPage} of {result.maxPages} checked (
-											{result.currentPage * result.pageSize} articles),{' '}
-											{matches.length} matches found&nbsp;&nbsp;
-										</span>
-										{isLoading && <EuiLoadingSpinner size="s" />}
-									</ResultText>
-									{isLoading && (
-										<ResultActions>
-											<EuiLink href="#" onClick={() => chunkedAdapter.abort()}>
-												Cancel
-											</EuiLink>
-										</ResultActions>
-									)}
-								</EuiFlexGroup>
-							) : (
-								''
-							)}
-						</EuiFlexItem>
 					</EuiFlexGroup>
+					<EuiSpacer size="s" />
+					<EuiFlexItem grow={2}>
+						{result ? (
+							<EuiFlexGroup>
+								<ResultText>
+									<span>
+										Page {result.currentPage}/{result.maxPages} checked (
+										{result.currentPage * result.pageSize} articles),{' '}
+										{matches.length}/{maxMatches} matches found&nbsp;&nbsp;
+									</span>
+									{isLoading && <EuiLoadingSpinner size="s" />}
+								</ResultText>
+								{isLoading && (
+									<ResultActions>
+										<EuiLink href="#" onClick={() => chunkedAdapter.abort()}>
+											Cancel
+										</EuiLink>
+									</ResultActions>
+								)}
+							</EuiFlexGroup>
+						) : (
+							''
+						)}
+					</EuiFlexItem>
 				</EuiFlexItem>
+
 				<EuiFlexItem style={{ overflowY: 'scroll', gap }}>
 					{!matches.length && (
 						<>

--- a/apps/rule-manager/client/src/ts/components/table/PaginatedRulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/table/PaginatedRulesTable.tsx
@@ -25,6 +25,7 @@ import { ConciseRuleStatus } from '../rule/ConciseRuleStatus';
 import { TagsContext } from '../context/tags';
 import { EuiDataGridToolBarVisibilityOptions } from '@elastic/eui/src/components/datagrid/data_grid_types';
 import { useEuiFontSize } from '@elastic/eui/src/global_styling/mixins/_typography';
+import { useNavigate } from 'react-router-dom';
 
 type EditRuleButtonProps = {
 	editIsEnabled: boolean;
@@ -76,7 +77,7 @@ const EditRule = ({
 		<EuiToolTip
 			content={
 				editIsEnabled
-					? ''
+					? 'Edit rule'
 					: 'You do not have the correct permissions to edit a rule. Please contact Central Production if you need to edit rules.'
 			}
 		>
@@ -85,6 +86,35 @@ const EditRule = ({
 				onClick={() => (editIsEnabled ? editRule(Number(rule.id)) : () => null)}
 			>
 				<EuiIcon type="pencil" />
+			</EditRuleButton>
+		</EuiToolTip>
+	);
+};
+
+const TestRule = ({
+	editIsEnabled,
+	rule,
+}: {
+	editIsEnabled: boolean;
+	rule: DraftRule;
+}) => {
+	const navigate = useNavigate();
+
+	return (
+		<EuiToolTip
+			content={
+				editIsEnabled
+					? 'Test rule'
+					: 'You do not have the correct permissions to test a rule. Please contact Central Production if you need to edit rules.'
+			}
+		>
+			<EditRuleButton
+				editIsEnabled={editIsEnabled}
+				onClick={() =>
+					editIsEnabled ? navigate(`/rule/${rule.id}`) : () => null
+				}
+			>
+				<EuiIcon type="wrench" />
 			</EditRuleButton>
 		</EuiToolTip>
 	);
@@ -272,22 +302,29 @@ export const PaginatedRulesTable = ({
 			},
 			{
 				id: 'actions',
-				width: 35,
+				width: 55,
 				headerCellRender: () => <></>,
 				rowCellRender: ({ rowIndex }) =>
 					isLoading ? (
 						<EuiSkeletonText />
 					) : (
-						<EditRule
-							editIsEnabled={canEditRule}
-							editRule={() =>
-								setRowSelection({
-									type: 'set',
-									id: getRuleAtRowIndex(rowIndex).id!,
-								})
-							}
-							rule={getRuleAtRowIndex(rowIndex)}
-						/>
+						<>
+							<EditRule
+								editIsEnabled={canEditRule}
+								editRule={() =>
+									setRowSelection({
+										type: 'set',
+										id: getRuleAtRowIndex(rowIndex).id!,
+									})
+								}
+								rule={getRuleAtRowIndex(rowIndex)}
+							/>
+							&nbsp; &nbsp;
+							<TestRule
+								editIsEnabled={canEditRule}
+								rule={getRuleAtRowIndex(rowIndex)}
+							/>
+						</>
 					),
 			},
 		],

--- a/apps/rule-manager/client/src/ts/components/table/PaginatedRulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/table/PaginatedRulesTable.tsx
@@ -114,7 +114,7 @@ const TestRule = ({
 					editIsEnabled ? navigate(`/rule/${rule.id}`) : () => null
 				}
 			>
-				<EuiIcon type="wrench" />
+				<EuiIcon type="beaker" />
 			</EditRuleButton>
 		</EuiToolTip>
 	);

--- a/apps/rule-manager/client/src/ts/utils/TyperighterChunkedAdapter.ts
+++ b/apps/rule-manager/client/src/ts/utils/TyperighterChunkedAdapter.ts
@@ -48,6 +48,8 @@ interface CAPICheck {
 	tags?: string[];
 	sections?: string[];
 	ruleId: string;
+  maxMatches: number,
+  maxPages: number,
 	onMatchesReceived: (result: PaginatedCheckRuleResult) => void;
 	onRequestError: (msg: string) => void;
 	onRequestComplete: () => void;
@@ -67,6 +69,8 @@ export class TyperighterChunkedAdapter {
 		tags,
 		sections,
 		ruleId,
+    maxMatches,
+    maxPages,
 		onMatchesReceived,
 		onRequestError,
 		onRequestComplete,
@@ -89,6 +93,8 @@ export class TyperighterChunkedAdapter {
 					queryStr,
 					tags,
 					sections,
+          maxMatches,
+          maxPages
 				}),
 				signal: this.abortController.signal,
 			});

--- a/apps/rule-manager/client/src/ts/utils/TyperighterChunkedAdapter.ts
+++ b/apps/rule-manager/client/src/ts/utils/TyperighterChunkedAdapter.ts
@@ -48,8 +48,8 @@ interface CAPICheck {
 	tags?: string[];
 	sections?: string[];
 	ruleId: string;
-  maxMatches: number,
-  maxPages: number,
+	maxMatches: number;
+	maxPages: number;
 	onMatchesReceived: (result: PaginatedCheckRuleResult) => void;
 	onRequestError: (msg: string) => void;
 	onRequestComplete: () => void;
@@ -69,8 +69,8 @@ export class TyperighterChunkedAdapter {
 		tags,
 		sections,
 		ruleId,
-    maxMatches,
-    maxPages,
+		maxMatches,
+		maxPages,
 		onMatchesReceived,
 		onRequestError,
 		onRequestComplete,
@@ -93,8 +93,8 @@ export class TyperighterChunkedAdapter {
 					queryStr,
 					tags,
 					sections,
-          maxMatches,
-          maxPages
+					maxMatches,
+					maxPages,
 				}),
 				signal: this.abortController.signal,
 			});

--- a/apps/rule-manager/client/src/ts/utils/TyperighterChunkedAdapter.ts
+++ b/apps/rule-manager/client/src/ts/utils/TyperighterChunkedAdapter.ts
@@ -1,0 +1,166 @@
+import { throttle, uniqBy } from 'lodash';
+import { readJsonSeqStream } from './jsonSeq';
+
+interface Category {
+	id: string;
+	name: string;
+}
+
+interface Suggestion {
+	type: string;
+	text: string;
+}
+
+interface CheckerRule {
+	id: string;
+	category: Category;
+}
+
+export interface RuleMatch {
+	rule: CheckerRule;
+	fromPos: number;
+	toPos: number;
+	precedingText: string;
+	subsequentText: string;
+	matchedText: string;
+	message: string;
+	shortMessage?: string;
+	suggestions: Suggestion[];
+	replacement?: Suggestion;
+	markAsCorrect: boolean;
+	matchContext: string;
+}
+
+interface CheckSingleRuleResult {
+	matches: RuleMatch[];
+	percentageRequestComplete: number | undefined;
+}
+
+export interface PaginatedCheckRuleResult {
+	currentPage: number;
+	maxPages: number;
+	pageSize: number;
+	result: CheckSingleRuleResult;
+}
+
+interface CAPICheck {
+	queryStr: string;
+	tags?: string[];
+	sections?: string[];
+	ruleId: string;
+	onMatchesReceived: (result: PaginatedCheckRuleResult) => void;
+	onRequestError: (msg: string) => void;
+	onRequestComplete: () => void;
+}
+
+/**
+ * An adapter for the Typerighter service that parses a chunked response returning
+ * [`json-seq`](https://en.wikipedia.org/wiki/JSON_streaming#Record_separator-delimited_JSON).
+ */
+export class TyperighterChunkedAdapter {
+	private responseBuffer: PaginatedCheckRuleResult[] = [];
+	private responseThrottleMs = 100;
+	private abortController: AbortController | undefined = undefined;
+
+	public fetchMatches = async ({
+		queryStr,
+		tags,
+		sections,
+		ruleId,
+		onMatchesReceived,
+		onRequestError,
+		onRequestComplete,
+	}: CAPICheck) => {
+		this.abortController?.abort();
+		this.abortController = new AbortController();
+
+		const onComplete = () => {
+			this.abortController = undefined;
+			onRequestComplete();
+		};
+
+		try {
+			const response = await fetch(`/api/rules/${ruleId}/test-capi`, {
+				method: 'POST',
+				headers: new Headers({
+					'Content-Type': 'application/json',
+				}),
+				body: JSON.stringify({
+					queryStr,
+					tags,
+					sections,
+				}),
+				signal: this.abortController.signal,
+			});
+
+			if (response.status > 399) {
+				onRequestError(`${response.status}: ${response.statusText}`);
+				return onComplete();
+			}
+
+			const reader = response.body?.getReader();
+
+			if (!reader) {
+				onRequestError('Typerighter did not send a response body');
+				return onComplete();
+			}
+
+			const streamReader = readJsonSeqStream(reader, (message) => {
+				this.responseBuffer.push(message);
+				this.throttledHandleResponse(onMatchesReceived);
+			});
+
+			return streamReader
+				.catch((error) => {
+					const isAbortRequest =
+						error instanceof DOMException && error.name === 'AbortError';
+					if (isAbortRequest) {
+						// Necessary, or the stream continues to read
+						reader.cancel();
+					} else {
+						onRequestError(error.message);
+					}
+					return onComplete();
+				})
+				.finally(() => {
+					this.flushResponseBuffer(onMatchesReceived);
+					onComplete();
+				});
+		} catch (e) {
+			console.log(e);
+		}
+	};
+
+	public abort = () => {
+		this.abortController?.abort();
+	};
+
+	private flushResponseBuffer = (
+		onMatchesReceived: (result: PaginatedCheckRuleResult) => void,
+	) => {
+		if (!this.responseBuffer.length) {
+			return;
+		}
+		const matches = this.responseBuffer.flatMap((_) => _.result.matches);
+		const latestResponse = this.responseBuffer[this.responseBuffer.length - 1];
+
+		onMatchesReceived({
+			currentPage: latestResponse.currentPage,
+			maxPages: latestResponse.maxPages,
+			pageSize: latestResponse.pageSize,
+			result: {
+				percentageRequestComplete:
+					latestResponse.result.percentageRequestComplete,
+				matches,
+			},
+		});
+
+		// Clear the buffer
+		this.responseBuffer = [];
+	};
+
+	protected throttledHandleResponse = throttle(
+		this.flushResponseBuffer,
+		this.responseThrottleMs,
+	);
+}

--- a/apps/rule-manager/client/src/ts/utils/jsonSeq.ts
+++ b/apps/rule-manager/client/src/ts/utils/jsonSeq.ts
@@ -1,0 +1,57 @@
+export const RECORD_SEPARATOR = String.fromCharCode(31);
+
+export const readJsonSeqStream = async (
+	reader: ReadableStreamDefaultReader,
+	onMessage: (message: any) => void,
+): Promise<void> => {
+	// window.TextDecoder will not be defined in a NodeJS context (for our tests)..
+	const textDecoder = new window.TextDecoder();
+	const initialChunk = await reader.read();
+	// Chunks do not correspond directly with lines of JSON, so we must buffer
+	// partial lines.
+	let buffer = '';
+
+	const parseAndPushMessage = (json: string) => {
+		const message = JSON.parse(json.trim());
+		onMessage(message);
+	};
+
+	const processStringChunk = (chunk: string) => {
+		const textChunks = (buffer + chunk).split(RECORD_SEPARATOR);
+
+		// Take everything but the tail of the array. This will either be an empty
+		// string, as the preceding line will have been terminated by a newline
+		// character, or a partial line.
+		for (const rawJson of textChunks.slice(0, -1)) {
+			const json = rawJson.trim();
+			if (!json.length) {
+				break;
+			}
+
+			parseAndPushMessage(json);
+		}
+
+		// Add anything that remains to the buffer.
+		buffer = (textChunks[textChunks.length - 1] ?? '').trim();
+	};
+
+	const streamIterator = ({
+		done,
+		value,
+	}: ReadableStreamDefaultReadResult<Uint8Array>): Promise<void> => {
+		if (done) {
+			if (buffer.length) {
+				// Flush anything that remains in the buffer
+				parseAndPushMessage(buffer);
+			}
+			return Promise.resolve();
+		}
+
+		const textChunks = textDecoder.decode(value);
+		processStringChunk(textChunks);
+
+		return reader.read().then(streamIterator);
+	};
+
+	return streamIterator(initialChunk);
+};

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -37,9 +37,9 @@ POST    /api/rules/:id/unarchive        controllers.RulesController.unarchive(id
 +nocsrf
 POST    /api/rules/:id/discard-changes  controllers.RulesController.discardChanges(id: Int)
 +nocsrf
-GET     /api/rules/:id/test-block       controllers.RulesController.testWithBlock(id: Int)
+POST     /api/rules/:id/test-block       controllers.RulesController.testWithBlock(id: Int)
 +nocsrf
-GET     /api/rules/:id/test-capi        controllers.RulesController.testWithCapiQuery(id: Int)
+POST     /api/rules/:id/test-capi        controllers.RulesController.testWithCapiQuery(id: Int)
 
 # Tags
 +nocsrf

--- a/apps/rule-manager/test/service/RuleTestingSpec.scala
+++ b/apps/rule-manager/test/service/RuleTestingSpec.scala
@@ -47,7 +47,7 @@ class RuleTestingSpec extends AnyFlatSpec with Matchers with IdiomaticMockito {
         val hmacClient = new HMACClient("TEST", secretKey = "🤫")
         val contentClient = mock[ContentClient]
         if (searchResponses.nonEmpty) {
-          when(contentClient.searchContent(any, any, any, any)(any)) thenAnswer (_ =>
+          when(contentClient.searchContent(any, any, any, any, any)(any)) thenAnswer (_ =>
             Future.successful(searchResponses.next())
           )
         }
@@ -128,11 +128,11 @@ class RuleTestingSpec extends AnyFlatSpec with Matchers with IdiomaticMockito {
       responses.hasNext shouldBe false
 
       result shouldBe Seq(
-        PaginatedCheckRuleResult(1, 5, CheckSingleRuleResult(List.empty, Some(100))),
-        PaginatedCheckRuleResult(2, 5, CheckSingleRuleResult(List.empty, Some(100))),
-        PaginatedCheckRuleResult(3, 5, CheckSingleRuleResult(List.empty, Some(100))),
-        PaginatedCheckRuleResult(4, 5, CheckSingleRuleResult(List.empty, Some(100))),
-        PaginatedCheckRuleResult(5, 5, CheckSingleRuleResult(List.empty, Some(100)))
+        PaginatedCheckRuleResult(1, 5, 20, CheckSingleRuleResult(List.empty, Some(100))),
+        PaginatedCheckRuleResult(2, 5, 20, CheckSingleRuleResult(List.empty, Some(100))),
+        PaginatedCheckRuleResult(3, 5, 20, CheckSingleRuleResult(List.empty, Some(100))),
+        PaginatedCheckRuleResult(4, 5, 20, CheckSingleRuleResult(List.empty, Some(100))),
+        PaginatedCheckRuleResult(5, 5, 20, CheckSingleRuleResult(List.empty, Some(100)))
       )
     }
   }
@@ -167,7 +167,7 @@ class RuleTestingSpec extends AnyFlatSpec with Matchers with IdiomaticMockito {
       responses.hasNext shouldBe false
 
       val expectedResult = matches.take(2).flatten.zipWithIndex.map { case (result, index) =>
-        PaginatedCheckRuleResult(if (index < 3) 1 else 2, 6, result)
+        PaginatedCheckRuleResult(if (index < 3) 1 else 2, 6, 20, result)
       }
 
       result shouldBe expectedResult

--- a/apps/rule-manager/test/service/RuleTestingSpec.scala
+++ b/apps/rule-manager/test/service/RuleTestingSpec.scala
@@ -114,9 +114,7 @@ class RuleTestingSpec extends AnyFlatSpec with Matchers with IdiomaticMockito {
         client
           .testRuleWithCapiQuery(
             rule = exampleRule,
-            query = exampleQuery,
-            matchCount = 5,
-            maxPageCount = desiredPageCount
+            query = exampleQuery.copy(maxMatches = Some(5), maxPages = Some(desiredPageCount))
           )
           .runWith(Sink.seq)
       val result = Await.result(eventualResult, 60 seconds)
@@ -153,9 +151,7 @@ class RuleTestingSpec extends AnyFlatSpec with Matchers with IdiomaticMockito {
         client
           .testRuleWithCapiQuery(
             rule = exampleRule,
-            query = exampleQuery,
-            matchCount = desiredMatchCount,
-            maxPageCount = 6
+            query = exampleQuery.copy(maxPages = Some(6), maxMatches = Some(desiredMatchCount))
           )
           .runWith(Sink.seq)
       val result = Await.result(eventualResult, 60 seconds)


### PR DESCRIPTION
NB: depends on #445 – please review that first!

## What does this change?

A first pass at a rule checking UI.

The intent is to provide a rule creator with quick feedback by checking lots of content with their rule. By showing these matches, it should be possible to surface false positives without resorting to other tooling, or publishing the rule and checking content in our CMS.

![test-rule](https://github.com/guardian/typerighter/assets/7767575/c2886fa2-3b9c-4248-9be5-29270a4933f1)

A few notes:
- I've added it on a separate page, accessible via the 'wrench' icon in the rules table, per #445. My feeling is that this page should probably just be the edit mode, and we should remove the sidebar for rule editing, but I haven't done that in this PR as it didn't feel necessary to get this work in. WDYT?
- Aware that the matches could do with more behaviour – correct/review/amend semantics, see suggestions, etc., as well as links to the relevant article, etc. More to come.

## How to test

Have a play with a few rules, changing the CAPI query and the rule pattern. Does the testing behave as expected?

You'll need to run both checker and manager services for this to work – `./script/start` should do the job.