### PR TITLE
Add new property `groupKey` to `RuleMatch`

### DIFF
--- a/apps/checker/app/matchers/DictionaryMatcher.scala
+++ b/apps/checker/app/matchers/DictionaryMatcher.scala
@@ -36,7 +36,16 @@ class DictionaryMatcher(
   override def check(
       request: MatcherRequest
   )(implicit ec: ExecutionContext) = {
-    matcher.check(request)
+    // groupKey is used to control how rules are grouped in the client when they produces matches.
+    // This is needed for dictionary matches as they all share a common rule ID (MORFOLOGIK_RULE_COLLINS)
+    // groupKeys for dictionary matches have the format `MORFOLOGIK_RULE_COLLINS-{matchedText}`
+    matcher
+      .check(request)
+      .map(ruleMatches =>
+        ruleMatches.map(ruleMatch =>
+          ruleMatch.copy(groupKey = Some(ruleMatch.rule.id + '-' + ruleMatch.matchedText))
+        )
+      )
   }
 
   def getCategories() = instance.getAllActiveRules.asScala.toList.map { rule =>

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/fixtures/RuleMatchFixtures.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/fixtures/RuleMatchFixtures.scala
@@ -16,6 +16,7 @@ object RuleMatchFixtures {
     subsequentText = "",
     matchedText = "placeholder text",
     message = "placeholder message",
-    matchContext = "[placeholder text]"
+    matchContext = "[placeholder text]",
+    groupKey = Option("group-key")
   )
 }


### PR DESCRIPTION
## What does this change?

Adds a new property `groupKey` to a rule match which indicates how the rule should be grouped when it produces matches. 

This is needed because currently all Collins Dictionary rules are confusingly grouped together by the Typewriter client as they all share the same rule ID (`MORFOLOGIK_RULE_COLLINS`). This motivated the creation of a new field to control grouping. 

- For non-dictionary rules, it's just the rule ID.
- For dictionary rules, it's a combination of the rule ID and the matched text.

Publishing this change in isolation won't have any effect, but once this PR is merged the the Typerighter client can then be updated to use `groupKey` to group rules in the sidebar, instead of `ruleId`.

## How to test

Run typerighter and composer locally, ensuring composer is pointing at the local typerighter instance as per [the docs](https://github.com/guardian/typerighter/blob/main/docs/03-composer-integration.md). Ensure the Collins Dictionary feature switch is enabled. Create an article, open the browser network tab, make a spelling mistake and click "Check document". When you inspect the response from the HTTP request, the JSON should contain the new property `groupKey`. Something like:

```
{
    "matches": [
            {
                "rule": {
                    "id": "MORFOLOGIK_RULE_COLLINS",
                    "category": {
                        "id": "Collins Dictionary",
                        "name": "Collins Dictionary"
                    },
                    ...
                },
                ...
                "groupKey": "MORFOLOGIK_RULE_COLLINS-sherbert"
            }
        ]
...
}
```