### PR TITLE
Reinstate auth  grace period

### DIFF
--- a/apps/common-lib/src/main/scala/com/gu/typerighter/controllers/PandaAuthController.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/controllers/PandaAuthController.scala
@@ -24,6 +24,8 @@ abstract class PandaAuthController(
     with HMACAuthActions
     with BaseController
     with Loggable {
+  override val apiGracePeriod: Long = 2 * 60 * 60 * 10000 // two hours worth of milliseconds
+
   override def validateUser(authedUser: AuthenticatedUser): Boolean = {
     log.info(s"Validating user $authedUser")
     PanDomain.guardianValidation(authedUser)

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/controllers/PandaAuthController.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/controllers/PandaAuthController.scala
@@ -24,7 +24,7 @@ abstract class PandaAuthController(
     with HMACAuthActions
     with BaseController
     with Loggable {
-  override val apiGracePeriod: Long = 2 * 60 * 60 * 10000 // two hours worth of milliseconds
+  override val apiGracePeriod: Long = 2 * 60 * 60 * 1000 // two hours worth of milliseconds
 
   override def validateUser(authedUser: AuthenticatedUser): Boolean = {
     log.info(s"Validating user $authedUser")


### PR DESCRIPTION
## What does this change?

Reinstates an auth grace period, introduced in https://github.com/guardian/typerighter/pull/66 and lost I think in the refactor in https://github.com/guardian/typerighter/pull/383.

See the original PR for the rationale.

## How to test

Bit of a long'un – leave a Composer tab open for longer than an hour, and attempt to run a check. Does it still work?