### PR TITLE
Fix edit rule button

### DIFF
--- a/apps/rule-manager/client/src/ts/components/table/PaginatedRulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/table/PaginatedRulesTable.tsx
@@ -302,7 +302,7 @@ export const PaginatedRulesTable = ({
 			return {};
 		}
 		const ruleId = [...rowSelection].pop();
-		const rowIndex = ruleData.data.findIndex((rule) => rule.id === ruleId);
+		const rowIndex = ruleData.data.findIndex((rule) => rule?.id === ruleId);
 
 		if (rowIndex === -1) {
 			return {};


### PR DESCRIPTION
## What does this change?

Previously, the "edit rule" button was broken from page 2 and onwards:

![before](https://github.com/guardian/typerighter/assets/7423751/a5ea7493-8573-4457-a67d-d67db44395dc)

This was happening because it attempts to lookup the rule by `id` in a sparse array (one padded with many `null` values). From page 2 and onwards, the array looks something like:

```
[
   null,
   null,
   null,
   null,
   null,
   ...
   {
      id: 1,
      ruleType: "dictionary",
      pattern: "(c)"
      ...
   }
]
```

So it freaks out when `id` doesn't exist as a property. We can use optional chaining to avoid this. 

## How to test

Run the rule manager locally, navigate to page 2, and attempt to edit any rule. It should work.

## Images

![after](https://github.com/guardian/typerighter/assets/7423751/79d6856c-13bf-4b1b-8fce-5a464ccf9b4a)

