### PR TITLE
Add test for `DictionaryMatcher`

### DIFF
--- a/apps/checker/test/scala/matchers/DictionaryMatcherTest.scala
+++ b/apps/checker/test/scala/matchers/DictionaryMatcherTest.scala
@@ -1,0 +1,22 @@
+package matchers
+
+import com.gu.typerighter.model.{Category, DictionaryRule, TextBlock}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import services.MatcherRequest
+
+class DictionaryMatcherTest extends AsyncFlatSpec with Matchers {
+  "check" should "include groupKey" in {
+    val exampleRule = DictionaryRule("123", "hello", Category("id", "desc"))
+    val dictionaryValidator = new DictionaryMatcher(List(exampleRule))
+
+    val text = "text"
+
+    val eventuallyMatches = dictionaryValidator.check(
+      MatcherRequest(List(TextBlock("text-block-id", text, 0, text.length)))
+    )
+    eventuallyMatches.map { matches =>
+      matches.map(_.groupKey) shouldBe List(Some("MORFOLOGIK_RULE_COLLINS-text"))
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?

Quick follow-up to https://github.com/guardian/typerighter/pull/436

Adds a unit test to ensure `groupKey` is included in the response to `check`.