### PR TITLE
Remove whitespace-only patterns from dictionary rules

### DIFF
--- a/apps/common-lib/src/main/scala/com/gu/typerighter/rules/Dictionary.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/rules/Dictionary.scala
@@ -5,9 +5,10 @@ import scala.xml.{Elem, Node}
 object Dictionary {
   def lemmaOrInflListToText(node: Node): List[String] = {
     node match {
-      case node if node.label == "lemma"     => List(node.text)
-      case node if node.label == "infl_list" => node.child.toList.map(infl => infl.text)
-      case _                                 => Nil
+      case node if node.label == "lemma" => List(node.text)
+      case node if node.label == "infl_list" =>
+        node.child.filter(_.label == "infl").map(_.text).toList
+      case _ => Nil
     }
   }
 
@@ -25,7 +26,6 @@ object Dictionary {
       lemmaOrInflList <- lemmaOrInfl.toList
       word <- lemmaOrInflListToText(lemmaOrInflList)
     } yield word
-    words.distinct.filterNot(_ == "")
+    words.distinct.filterNot(_.filterNot(_.isWhitespace) == "")
   }
-
 }

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/rules/Dictionary.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/rules/Dictionary.scala
@@ -26,6 +26,6 @@ object Dictionary {
       lemmaOrInflList <- lemmaOrInfl.toList
       word <- lemmaOrInflListToText(lemmaOrInflList)
     } yield word
-    words.distinct.filterNot(_.filterNot(_.isWhitespace) == "")
+    words.distinct.filterNot(_.forall(_.isWhitespace))
   }
 }

--- a/apps/common-lib/src/test/scala/com/gu/typerighter/rules/DictionaryTest.scala
+++ b/apps/common-lib/src/test/scala/com/gu/typerighter/rules/DictionaryTest.scala
@@ -19,6 +19,22 @@ class DictionaryTest extends AnyFlatSpec with Matchers {
     expected should be(actual)
   }
 
+  "dictionaryXmlToWordList" should "not include strings that only contain whitespace" in {
+    val node = <lemma_list language="english">
+      <entry id="00099801">
+        <lemma hyph="sto+ry">
+          <!-- This node contains whitespace -->
+        </lemma>
+      </entry>
+    </lemma_list>
+
+    val expected = Nil
+
+    val actual = dictionaryXmlToWordList(node)
+
+    expected should be(actual)
+  }
+
   "lemmaOrInflListToText" should "convert infl_list nodes into the text of their infl child nodes" in {
     val inflList =
       <infl_list><infl hyph="Type+righter">Typerighter</infl><infl hyph="type+writer">typewriter</infl></infl_list>

--- a/apps/common-lib/src/test/scala/com/gu/typerighter/rules/DictionaryTest.scala
+++ b/apps/common-lib/src/test/scala/com/gu/typerighter/rules/DictionaryTest.scala
@@ -45,7 +45,7 @@ class DictionaryTest extends AnyFlatSpec with Matchers {
     expected should be(actual)
   }
 
-  "lemmaOrInflListToText" should "convert only accept infl nodes within an infl_list" in {
+  "lemmaOrInflListToText" should "only accept infl nodes within an infl_list" in {
     val inflList =
       <infl_list>
         <infl hyph="Type+righter">Typerighter</infl>

--- a/apps/common-lib/src/test/scala/com/gu/typerighter/rules/DictionaryTest.scala
+++ b/apps/common-lib/src/test/scala/com/gu/typerighter/rules/DictionaryTest.scala
@@ -45,6 +45,19 @@ class DictionaryTest extends AnyFlatSpec with Matchers {
     expected should be(actual)
   }
 
+  "lemmaOrInflListToText" should "convert only accept infl nodes within an infl_list" in {
+    val inflList =
+      <infl_list>
+        <infl hyph="Type+righter">Typerighter</infl>
+        <some_other_tag>This should not show up</some_other_tag>
+      </infl_list>
+    val expected = List("Typerighter")
+
+    val actual = lemmaOrInflListToText(inflList)
+
+    expected should be(actual)
+  }
+
   "lemmaOrInflListToText" should "convert unrelated nodes into Nil" in {
     val unrelatedNode = <typey>Typerighter</typey>
     val expected = Nil


### PR DESCRIPTION
## What does this change?

We've a couple of dictionary rules that are imported but not published after import. That's because they just contain whitespace, and as such they fail the form validation checks (`nonEmptyString`).

The whitespace is caused by the formatted XML.

This PR aims to be a bit more specific in which nodes it retrieves words from, and as a fallback removes any empty words from the XML output, so dictionary rules are published immediately on import.

## How to test

The current DEV XML will produce this sort of whitespace, so running locally, try importing the dictionary. Previous to this PR, it would fail. It should now succeed and all dictionary rules should be marked live.