### PR TITLE
New route for editing rules

### DIFF
--- a/apps/rule-manager/client/src/ts/components/RuleForm.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleForm.tsx
@@ -57,7 +57,7 @@ export const RuleForm = ({
 }: {
 	ruleId: number | undefined;
 	onClose: () => void;
-	onUpdate: (id: number) => void;
+	onUpdate?: (id: number) => void;
 }) => {
 	const [showErrors, setShowErrors] = useState(false);
 	const {
@@ -123,7 +123,7 @@ export const RuleForm = ({
 	}, [debouncedFormData]);
 
 	useEffect(() => {
-		rule?.draft.id && onUpdate(rule.draft.id);
+		rule?.draft.id && onUpdate?.(rule.draft.id);
 	}, [rule?.draft.id]);
 
 	const maybePublishRuleHandler = () => {
@@ -143,7 +143,7 @@ export const RuleForm = ({
 		if (isReasonModalVisible) {
 			setIsReasonModalVisible(false);
 		}
-		onUpdate(ruleId);
+		onUpdate?.(ruleId);
 	};
 
 	const PublishTooltip: React.FC<{ children: ReactElement }> = ({
@@ -181,7 +181,7 @@ export const RuleForm = ({
 		}
 
 		await archiveRule(ruleId);
-		onUpdate(ruleId);
+		onUpdate?.(ruleId);
 	};
 
 	const unarchiveRuleHandler = async () => {
@@ -190,7 +190,7 @@ export const RuleForm = ({
 		}
 
 		await unarchiveRule(ruleId);
-		onUpdate(ruleId);
+		onUpdate?.(ruleId);
 	};
 
 	const unpublishRuleHandler = async () => {
@@ -199,7 +199,7 @@ export const RuleForm = ({
 		}
 
 		await unpublishRule(ruleId);
-		onUpdate(ruleId);
+		onUpdate?.(ruleId);
 	};
 
 	const showRuleRevertModal = () => {
@@ -215,7 +215,7 @@ export const RuleForm = ({
 		if (isRevertModalVisible) {
 			setIsRevertModalVisible(false);
 		}
-		onUpdate(ruleId);
+		onUpdate?.(ruleId);
 	};
 
 	const hasUnsavedChanges = ruleFormData !== rule?.draft;

--- a/apps/rule-manager/client/src/ts/components/layout/Breadcrumbs.tsx
+++ b/apps/rule-manager/client/src/ts/components/layout/Breadcrumbs.tsx
@@ -1,10 +1,11 @@
 import { EuiBreadcrumbs } from '@elastic/eui';
 import { useMatches } from 'react-router-dom';
+import { getNameFromRouteMatch, RouteHandle, RouteNameFn } from './Page';
 
 export const Breadcrumbs = () => {
 	const matches = useMatches();
 	const crumbs = matches.map((match) => ({
-		text: (match.handle as { name: string })?.name || '',
+		text: getNameFromRouteMatch(match),
 		href: match.pathname,
 	}));
 

--- a/apps/rule-manager/client/src/ts/components/pages/Rule.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rule.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { RuleForm } from '../RuleForm';
+import { useNavigate, useParams } from 'react-router-dom';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+
+export const newRuleId = 'new-rule';
+
+export const Rule = () => {
+	const { id: ruleId } = useParams() as { id: string };
+	const navigate = useNavigate();
+	return (
+		<EuiFlexGroup style={{ height: '100%' }}>
+			<EuiFlexItem style={{ overflowY: 'scroll' }}>
+				<RuleForm
+					ruleId={ruleId === newRuleId ? undefined : parseInt(ruleId)}
+					onClose={() => navigate('/')}
+				/>
+			</EuiFlexItem>
+			<EuiFlexItem grow={2}></EuiFlexItem>
+		</EuiFlexGroup>
+	);
+};

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -43,7 +43,9 @@ export const Rules = () => {
 		'closed',
 	);
 	const [pageIndex, setPageIndex] = useState(0);
-	const [sortColumns, setSortColumns] = useState<SortColumns>([]);
+	const [sortColumns, setSortColumns] = useState<SortColumns>([
+		{ id: 'pattern', direction: 'asc' },
+	]);
 	const [currentRuleId, setCurrentRuleId] = useState<number | undefined>(
 		undefined,
 	);

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -53,11 +53,9 @@ POST    /api/tags/:id                   controllers.TagsController.update(id: In
 +nocsrf
 DELETE  /api/tags/:id                   controllers.TagsController.delete(id: Int)
 
+# Map static resources from the /public folder to the correct URL path
+GET     /build/*file                    controllers.Assets.versioned(path="/public/", file: Asset)
+GET     /static/*file                   controllers.Assets.versioned(path="/public/", file: Asset)
 
 # Pass all other top level paths to the client-side app
-GET     /:path                          controllers.HomeController.index(path)
-+nocsrf
-
-# Map static resources from the /public folder to the correct URL path
-GET     /*file                          controllers.Assets.versioned(path="/public/", file: Asset)
-
+GET     /*path                          controllers.HomeController.index(path)


### PR DESCRIPTION
## What does this change?

Adds client-side routing for rule editing, with page that lets you edit the rule. It's a bit blank yet, but there's space for testing to be added by #434. 

<img width="1353" alt="Screenshot 2023-10-09 at 11 12 01" src="https://github.com/guardian/typerighter/assets/7767575/09b5f942-f886-42bf-8275-96ca383c38e4">

There's no way to access it from the UI, yet, but you can get to it via the URL.

## How to test

Try navigating to the URL in the screenshot, filling in the relevant rule ID as necessary. The client should look like the screenshot above.