### PR TITLE
Correct asset paths

### DIFF
--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -54,8 +54,8 @@ POST    /api/tags/:id                   controllers.TagsController.update(id: In
 DELETE  /api/tags/:id                   controllers.TagsController.delete(id: Int)
 
 # Map static resources from the /public folder to the correct URL path
-GET     /build/*file                    controllers.Assets.versioned(path="/public/", file: Asset)
-GET     /static/*file                   controllers.Assets.versioned(path="/public/", file: Asset)
+GET     /build/*file                   controllers.Assets.versioned(path="/public/build", file: Asset)
+GET     /static/*file                  controllers.Assets.at(path="/public/static", file)
 
 # Pass all other top level paths to the client-side app
 GET     /*path                          controllers.HomeController.index(path)


### PR DESCRIPTION
## What does this change?

#445 introduced a routing change that broke the site assets. This PR fixes.

## How to test

Run locally, and in CODE. You should see:

- [x] the site content load as normal (JS, CSS and asset files like fonts are correct)
- [ ] the favicon appear as normal

Tested:

- [x] locally
- [x] on CODE

NB: I had to check in Firefox for the favicon to appear correctly – there appears to be some weird favicon caching in Chrome! Checking the path in the markup manually should verify if it's not appearing straight away in Chrome and you're unsure.