### PR TITLE
Invalidate Morfologik dictionary cache on DictionaryMatcher instantiation

### DIFF
--- a/apps/checker/app/matchers/DictionaryMatcher.scala
+++ b/apps/checker/app/matchers/DictionaryMatcher.scala
@@ -1,6 +1,8 @@
 package matchers
 
 import com.gu.typerighter.model.{Category, DictionaryRule, RuleMatch}
+import com.google.common.cache.LoadingCache
+import morfologik.stemming.Dictionary
 import org.languagetool.{JLanguageTool, Language, ResultCache, UserConfig}
 import play.api.Logging
 import services.collins.{CollinsEnglish, MorfologikCollinsSpellerRule, SpellDictionaryBuilder}
@@ -19,10 +21,26 @@ class DictionaryMatcher(
   val cache: ResultCache = new ResultCache(10000)
   val userConfig: UserConfig = new UserConfig()
 
-  val instance = new JLanguageTool(language, cache, userConfig)
-
   // As a side effect, make sure the .dict artefact is available to languageTool
   new SpellDictionaryBuilder().buildDictionary(rules.map(rule => rule.word))
+
+  // This is an undesirable hack to force the MorfologikSpeller dictionary cache to invalidate. MorfologikSpeller
+  // is quite deep in a series of classes:
+  //   - MorfologikCollinsSpellerRule extends AbstractSpellerRule extends MorfologikSpellerRule which uses an
+  //     instance of MorfologikMultiSpeller which uses an instance of Morfologik Speller
+  // We don't want to re-implement all of those classes.
+  // Without invalidating the dictionary cache expires every 10 minutes, changes to dictionary rules will not be
+  // reflected in the DictionaryMatcher until a future re-compile of the dictionary when at least 10 minutes
+  // have expired. We want to invalidate the cache as soon as our DictionaryRules change.
+  // Ideally we would make changes to the LanguageTool library to allow this, but as a temporary hack, this allows
+  // our DictionaryMatcher to react to new or edited DictionaryRules.
+  val SpellerClass = Class.forName("org.languagetool.rules.spelling.morfologik.MorfologikSpeller")
+  val field = SpellerClass.getDeclaredField("dictCache")
+  field.setAccessible(true)
+  val dictionaryCache = field.get(field.getType()).asInstanceOf[LoadingCache[String, Dictionary]]
+  dictionaryCache.invalidateAll()
+
+  val instance = new JLanguageTool(language, cache, userConfig)
 
   // Disable default LanguageTool rules in the instance, i.e. anything that
   // isn't a MORFOLOGIK_RULE_COLLINS


### PR DESCRIPTION
Co-authored with @jonathonherbert 

## What does this change?

Changes to dictionary rules (additions, edits, or unpublish actions) don't cause any user-facing changes in the DictionaryMatcher, or at least take a long time to surface if they do - for example - creating a new dictionary rules doesn't cause that word to be recognised as valid in the matches sent to Composer by the Checker service. This is due to dictionary caching behaviour in [`MorfologikSpeller`](url), used indirectly as part of LanguageTool.

This PR makes two changes:

1. Ensures that the `JLanguageTool` instance created as part of a new `DictionaryMatcher` is only instantiated **after** the `collins.dict` binary has been created (i.e. after we call `new SpellDictionaryBuilder().buildDictionary` - otherwise there's a chance that the matcher will reflect an older version of our dictionary rules corpus.
2. Invalidate the dictionary `LoaderCache` from `MorfologikSpeller` when a `DictionaryMatcher` is instantiated. The cache is constructed quite deep in the Morfologik class hierarchy, and we don't want to recreate our own versions of all those classes to allow us to access it because we'll have to add thousands of lines to Typerighter and not benefit from maintenance to their equivalent files in `LanguageTool`. Currently, the dictionary binary is cached for ten minutes, and any changes made to DictionaryRules within those ten minutes won't be reflected in the matches we send to Composer - until we re-instantiate the dictionary matcher due to an unrelated rule change after those ten minutes have elapsed. This makes local testing of DictionaryRules especially difficult.

Our cache invalidation is a pretty unpleasant hack using Java reflection - circumventing the [`LoadingCache`](https://github.com/languagetool-org/languagetool/blob/d3a82b7e8b7c3bb66602c3ee61bcd38d94843566/languagetool-core/src/main/java/org/languagetool/rules/spelling/morfologik/MorfologikSpeller.java#L47) being a private property of `MorfologikSpeller`. It would be good to raise a PR in LanguageTool in the future to surface a way to invalidated the dictionary cache, and use that mechanism instead of this one, but (for now) this will help us make DictionaryRules editable and reach our KR.

## How to test

1. Run the Typerighter Checker and Rule Manager services and flexible-content (i.e. Composer) locally, according to the instructions in the readmes.
2. Make sure you have the following line in Composer's config in `~/.gu/flexible-composerbackend.properties` in order to use local Typerighter Checker rather than CODE: `typerighter.url=https://checker.typerighter.local.dev-gutools.co.uk/`
3. Create, edit, and unpublish dictionary rules.
4. Are your changes reflected in matches to Composer, with the Collins feature switch and toggle active?