### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,8 +10,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v2
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: cdk synth
         working-directory: ./cdk
         run: |
-          yarn
+          yarn install --frozen-lockfile
           yarn synth
       - name: test and build sbt
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,25 @@ jobs:
       - name: test and build sbt
         run: |
           set -e
-          # Ensure we don't overwrite existing (Teamcity) builds.
-          LAST_TEAMCITY_BUILD=1280
-          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt clean compile test scalafmtCheckAll riffRaffUpload
+          sbt clean compile test scalafmtCheckAll Debian/packageBin
+
+      - name: rename checker debian artifact
+        run: mv apps/checker/target/checker_1.0-SNAPSHOT_all.deb target/typerighter-checker.deb
+
+      - name: rename rule manager debian artifact
+        run: mv apps/rule-manager/target/rule-manager_1.0-SNAPSHOT_all.deb target/typerighter-rule-manager.deb
+
+      - name: upload to riff-raff
+        uses: guardian/actions-riff-raff@v2
+        with:
+          configPath: riff-raff.yaml
+          projectName: Editorial Tools::Typerighter
+          buildNumberOffset: 1280 # This is the last build number from TeamCity
+          contentDirectories: |
+            typerighter-checker:
+            - target/typerighter-checker.deb
+            typerighter-rule-manager:
+            - target/typerighter-rule-manager.deb
+            typerighter-cloudformation:
+            - cdk/cdk.out/typerighter-PROD.template.json
+            - cdk/cdk.out/typerighter-CODE.template.json

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,5 @@
 name: Typerighter CI
+
 on:
   workflow_dispatch:
   push:
@@ -6,28 +7,35 @@ on:
 jobs:
   CI:
     runs-on: ubuntu-latest
+
     permissions:
       id-token: write
       contents: read
+
     steps:
       - uses: actions/checkout@v4
+
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
+
       - uses: actions/setup-java@v3
         with:
           java-version: "11"
           distribution: "corretto"
           cache: "sbt"
+
       - name: Build the stack
         run: |
           docker-compose up -d
+
       - uses: actions/setup-node@v3
         with:
           node-version: 16.13.1
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
+
       - name: build rule-manager-client
         working-directory: ./apps/rule-manager/client
         run: |
@@ -35,11 +43,13 @@ jobs:
           npm run format:check
           npm run test
           npm run build
+
       - name: cdk synth
         working-directory: ./cdk
         run: |
           yarn install --frozen-lockfile
           yarn synth
+
       - name: test and build sbt
         run: |
           set -e

--- a/build.sbt
+++ b/build.sbt
@@ -177,14 +177,4 @@ val ruleManager = playProject(
     libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
   )
 
-val root = (project in file(".")).aggregate(commonLib, checker, ruleManager).enablePlugins(RiffRaffArtifact)
-
-riffRaffArtifactResources := Seq(
-  (checker / Debian / packageBin).value  -> s"${(checker / packageName).value}/${(checker / packageName).value}.deb",
-  (ruleManager / Debian / packageBin).value  -> s"${(ruleManager / packageName).value}/${(ruleManager / packageName).value}.deb",
-  baseDirectory.value / "riff-raff.yaml" -> "riff-raff.yaml",
-  baseDirectory.value / "cdk/cdk.out/typerighter-CODE.template.json" -> "typerighter-cloudformation/typerighter-CODE.template.json",
-  baseDirectory.value / "cdk/cdk.out/typerighter-PROD.template.json" -> "typerighter-cloudformation/typerighter-PROD.template.json"
-)
-
-riffRaffManifestProjectName := s"Editorial Tools::Typerighter"
+val root = (project in file(".")).aggregate(commonLib, checker, ruleManager)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This updates the GitHub Actions CI workflow to address things being deprecated.

We were getting a couple of warnings in the Actions tab:
<img width="1200" alt="Screenshot 2023-10-13 at 18 47 33" src="https://github.com/guardian/typerighter/assets/7883129/9d99225b-02a9-43b2-9bb8-eda9f30d24d9">

Upgrading versions of the `actions/checkout` and `aws-actions/configure-aws-credentials` actions addressses these warnings and they are no longer appearing.

I have changed how the bundling and uploading to RiffRaff works. Previously the deprecated `sbt-riffraff-artifact` plugin was being used to compress the bundled file into a `.deb` file and upload files to RiffRaff. This moves to using `actions-riffraff` instead.

As part of this PR I have also added the `--frozen-lockfile` flat when running `yarn install`, to ensure different versions of dependencies are not installed during CI.

### Future work
The `sbt-riffraff-artifact` is still being used to define build information (build number, build time and git commit ID). This doesn't seem to be used at the moment. This could either be removed (in which case we could fully remove the deprecated `sbt-riffraff-artifact` plugin) or an endpoint could be added to surface this information (similarly to [cdk playground](https://cdk-playground.gutools.co.uk/)) using the `sbt-buildinfo` plugin instead of `sbt-riffraff-artifact`.

## How to test

This has been tested by comparing the zip files from a [previous successful build](https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=Editorial+Tools%3A%3ATyperighter&id=2448) to a [new build](https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=Editorial+Tools%3A%3ATyperighter&id=2467). The size of the .deb files are slightly different, but I imagine this is as a result of how it's being packaged.

This has been deployed to CODE and can be tested by making sure Typerighter [rule manager](https://manager.typerighter.code.dev-gutools.co.uk/) and [checker](https://checker.typerighter.code.dev-gutools.co.uk/) both work as usual.