### PR TITLE
Get rule count, not rule list, when only the count is needed

### DIFF
--- a/apps/checker/app/controllers/HomeController.scala
+++ b/apps/checker/app/controllers/HomeController.scala
@@ -20,9 +20,9 @@ class HomeController(
 
   def healthcheck() = Action {
     {
-      val rules = matcherPool.getCurrentRules
+      val ruleCount = matcherPool.getCurrentRuleCount
 
-      if (rules.isEmpty) {
+      if (ruleCount == 0) {
         val errorMsg = "No rules found in S3"
         log.error(errorMsg)
         InternalServerError(

--- a/apps/checker/app/services/MatcherPool.scala
+++ b/apps/checker/app/services/MatcherPool.scala
@@ -237,6 +237,10 @@ class MatcherPool(
     matchers.values.flatMap { matcher => matcher.getRules() }.toList
   }
 
+  def getCurrentRuleCount: Int = {
+    matchers.values.map { _.getRules().size }.sum
+  }
+
   private def createJobsFromPartialJobs(
       requestId: String,
       documentId: Option[String],

--- a/apps/checker/app/services/MatcherProvisionerService.scala
+++ b/apps/checker/app/services/MatcherProvisionerService.scala
@@ -60,7 +60,7 @@ class MatcherProvisionerService(
       }
 
     lastModified = date
-    cloudWatchClient.putMetric(Metrics.RulesIngested, matcherPool.getCurrentRules.size)
+    cloudWatchClient.putMetric(Metrics.RulesIngested, matcherPool.getCurrentRuleCount)
 
     coreRulesErrors ++ addedRulesErrors match {
       case Nil => Right(())

--- a/apps/checker/test/scala/services/MatcherPoolTest.scala
+++ b/apps/checker/test/scala/services/MatcherPoolTest.scala
@@ -6,7 +6,9 @@ import com.gu.typerighter.model.{
   Category,
   CheckSingleRule,
   CheckSingleRuleResult,
+  CheckerRule,
   ComparableRegex,
+  DictionaryRule,
   Document,
   RegexRule,
   RuleMatch,
@@ -38,7 +40,7 @@ class MockMatcher(id: Int) extends Matcher {
 
   def getType() = s"mock-matcher-$id"
   def getCategories() = Set(Category(s"mock-category-$id", "Mock category"))
-  def getRules() = List.empty
+  def getRules(): List[CheckerRule] = List.empty
 
   def check(request: MatcherRequest)(implicit ec: ExecutionContext) = {
     val promise = Promise[List[RuleMatch]]()
@@ -80,6 +82,12 @@ class MockMatcherThatThrows(e: Throwable) extends Matcher {
       throw e
     }
   }
+}
+
+class MockMatcherWithRules(id: Int, ruleCount: Int) extends MockMatcher(id) {
+  override def getRules() = (1 to ruleCount).map { ruleId =>
+    DictionaryRule(ruleId.toString, s"word-${ruleId}", Category("category", "category"))
+  }.toList
 }
 
 class MatcherPoolTest extends AsyncFlatSpec with Matchers {
@@ -188,6 +196,19 @@ class MatcherPoolTest extends AsyncFlatSpec with Matchers {
     val pool = getPool(matchers)
     pool.removeAllMatchers()
     pool.getCurrentCategories should be(Set.empty)
+  }
+
+  behavior of "getCurrentRuleCount"
+
+  it should "return the number of rules across all matches" in {
+    val matchers = getPool(
+      List(
+        new MockMatcherWithRules(1, 2),
+        new MockMatcherWithRules(1, 3)
+      )
+    )
+
+    matchers.getCurrentRuleCount shouldBe 5
   }
 
   behavior of "check"


### PR DESCRIPTION
## What does this change?

We publish a rule count when we ingest rules artefact (and run a healthcheck), and that operation needlessly creates another complete list of rules, which is likely a fair amount of memory (there are ~338,000 rules at time of writing.) We seem to be crashing at the point of getting that list (after publication): https://logs.gutools.co.uk/s/editorial-tools/app/discover#/doc/67604290-baa6-11e9-bea2-633437abb232/logstash-ed-tools-2023.10.16?id=C9d6N4sBMaZrWQ-DVxC1

This PR adds a new method to the MatcherPool that avoids creating the intermediate list of rules, which should reduce the memory footprint of those operations.

## How to test

- The automated tests should pass, and should convince you that the method is correct.
- (re)publish a rule in CODE with this branch deployed. Does the resulting re-ingest knock over the box?