### PR TITLE
Make artefact creation and read more efficient

### DIFF
--- a/apps/common-lib/src/main/scala/com/gu/typerighter/lib/JsonHelpers.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/lib/JsonHelpers.scala
@@ -14,6 +14,9 @@ object JsonHelpers {
   def toJsonSeq[T](serializable: T)(implicit tjs: Writes[T]) =
     Json.toJson(serializable).toString() + recordSeparatorChar
 
+  def toNewlineDeliniatedJson[T](serializable: T)(implicit tjs: Writes[T]) =
+    Json.toJson(serializable).toString() + "\n"
+
   val JsonSeqFraming: Flow[ByteString, ByteString, NotUsed] =
     Framing.delimiter(ByteString(recordSeparatorChar), Int.MaxValue, true)
 }

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/lib/JsonHelpers.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/lib/JsonHelpers.scala
@@ -14,7 +14,7 @@ object JsonHelpers {
   def toJsonSeq[T](serializable: T)(implicit tjs: Writes[T]) =
     Json.toJson(serializable).toString() + recordSeparatorChar
 
-  def toNewlineDeliniatedJson[T](serializable: T)(implicit tjs: Writes[T]) =
+  def toNewlineDelineatedJson[T](serializable: T)(implicit tjs: Writes[T]) =
     Json.toJson(serializable).toString() + "\n"
 
   val JsonSeqFraming: Flow[ByteString, ByteString, NotUsed] =

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/rules/BucketRuleResource.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/rules/BucketRuleResource.scala
@@ -18,7 +18,7 @@ class BucketRuleResource(s3: AmazonS3, bucketName: String, stage: String) extend
   def putRules(ruleResource: CheckerRuleResource): Either[Exception, Unit] = {
     val ruleJsonBytes = ArrayBuffer[Byte]();
     ruleResource.rules.foreach(rule => {
-      ruleJsonBytes ++= JsonHelpers.toNewlineDeliniatedJson(rule).getBytes()
+      ruleJsonBytes ++= JsonHelpers.toNewlineDelineatedJson(rule).getBytes()
     })
     logOnError(
       s"writing ${ruleResource.rules.length} rules to S3 at $bucketName/$RULES_KEY"

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/rules/BucketRuleResource.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/rules/BucketRuleResource.scala
@@ -72,8 +72,17 @@ class BucketRuleResource(s3: AmazonS3, bucketName: String, stage: String) extend
 
   def getRulesLastModified: Either[Exception, Date] = {
     logOnError("getting the lastModified date from S3") {
-      val rulesMeta = s3.getObjectMetadata(bucketName, RULES_KEY)
-      rulesMeta.getLastModified
+      val lastModified =
+        try {
+          val rulesMeta = s3.getObjectMetadata(bucketName, RULES_KEY)
+          rulesMeta.getLastModified
+        } catch {
+          case _: Throwable =>
+            logger.info("Failed to find new artefact, trying legacy artefact")
+            val rulesMeta = s3.getObjectMetadata(bucketName, LEGACY_RULES_KEY)
+            rulesMeta.getLastModified
+        }
+      lastModified
     }
   }
 

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/rules/BucketRuleResource.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/rules/BucketRuleResource.scala
@@ -21,7 +21,7 @@ class BucketRuleResource(s3: AmazonS3, bucketName: String, stage: String) extend
       ruleJsonBytes ++= JsonHelpers.toNewlineDeliniatedJson(rule).getBytes()
     })
     logOnError(
-      s"writing rules to S3 at $bucketName/$RULES_KEY with JSON hash ${ruleResource.rules.hashCode}"
+      s"writing ${ruleResource.rules.length} rules to S3 at $bucketName/$RULES_KEY with JSON hash ${ruleResource.rules.hashCode}"
     ) {
       val stream: java.io.InputStream = new java.io.ByteArrayInputStream(ruleJsonBytes.toArray)
       val metaData = new ObjectMetadata()
@@ -44,7 +44,7 @@ class BucketRuleResource(s3: AmazonS3, bucketName: String, stage: String) extend
           rulesArray += Json.parse(line).as[CheckerRule]
         })
         val rulesList = rulesArray.toList
-        logger.info(s"Got rules from S3. JSON hash: ${rulesList.hashCode()}")
+        logger.info(s"Got ${rulesList.length} rules from S3. JSON hash: ${rulesList.hashCode()}")
         Right((rulesList, lastModified))
       } catch {
         case e: Exception => Left(e)
@@ -65,7 +65,9 @@ class BucketRuleResource(s3: AmazonS3, bucketName: String, stage: String) extend
       val lastModified = rules.getObjectMetadata.getLastModified
       rules.close()
       val rulesList = rulesJson.as[CheckerRuleResource].rules
-      logger.info(s"Got legacy rules from S3. JSON hash: ${rulesList.hashCode()}")
+      logger.info(
+        s"Got ${rulesList.length} legacy rules from S3. JSON hash: ${rulesList.hashCode()}"
+      )
       (rulesList, lastModified)
     }
   }

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/rules/BucketRuleResource.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/rules/BucketRuleResource.scala
@@ -2,41 +2,58 @@ package com.gu.typerighter.rules
 
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest}
-import com.gu.typerighter.model.CheckerRuleResource
+import com.gu.typerighter.lib.JsonHelpers
+import com.gu.typerighter.model.{CheckerRule, CheckerRuleResource}
 import play.api.Logging
-import play.api.libs.json.Json
+import play.api.libs.json.{Json}
 
+import java.io.{BufferedReader, InputStreamReader}
 import java.util.Date
+import scala.collection.mutable.ArrayBuffer
 
-class BucketRuleResource(s3: AmazonS3, bucketName: String, stage: String) extends Logging {
-  private val RULES_KEY = s"$stage/rules/typerighter-rules.json"
+class BucketRuleResource(s3: AmazonS3, bucketName: String, stage: String) extends Logging  {
+  private val RULES_KEY = s"$stage/rules/typerighter-rules-seq.json"
 
   def putRules(ruleResource: CheckerRuleResource): Either[Exception, Unit] = {
-    val ruleJson = Json.toJson(ruleResource)
-    val bytes = Json.toBytes(ruleJson)
-
+    val ruleJsonBytes = ArrayBuffer[Byte]();
+    ruleResource.rules.foreach(rule => {
+      ruleJsonBytes ++= JsonHelpers.toNewlineDeliniatedJson(rule).getBytes()
+    })
     logOnError(
-      s"writing rules to S3 at $bucketName/$RULES_KEY with JSON hash ${ruleJson.hashCode}"
+    logOnError(
+      s"writing rules to S3 at $bucketName/$RULES_KEY with JSON hash ${ruleJsonBytes.hashCode}"
     ) {
-      val stream: java.io.InputStream = new java.io.ByteArrayInputStream(bytes)
+      val stream: java.io.InputStream = new java.io.ByteArrayInputStream(ruleJsonBytes.toArray)
       val metaData = new ObjectMetadata()
-      metaData.setContentLength(bytes.length)
+      metaData.setContentLength(ruleJsonBytes.length)
       val putObjectRequest = new PutObjectRequest(bucketName, RULES_KEY, stream, metaData)
       s3.putObject(putObjectRequest)
+      logger.info(s"${ruleJsonBytes.length} bytes written to bucket")
     }
   }
 
-  def getRules(): Either[Exception, (CheckerRuleResource, Date)] = {
-    logOnError(s"getting rules from S3 at $bucketName/$RULES_KEY") {
+  def getRules(): Either[Exception, (List[CheckerRule], Date)] = {
       val rules = s3.getObject(bucketName, RULES_KEY)
-      val rulesStream = rules.getObjectContent()
-      val rulesJson = Json.parse(rulesStream)
       val lastModified = rules.getObjectMetadata.getLastModified
-      rules.close()
+      val rulesStream = rules.getObjectContent()
+      val rulesArray = ArrayBuffer[CheckerRule]()
+      val reader = new BufferedReader(new InputStreamReader(rulesStream))
+      val error = try {
+        reader.lines.forEach(line => {
+          rulesArray += Json.parse(line).as[CheckerRule]
+        })
+        None
+      } catch {
+        case e: Exception =>
+          logger.error(s"BucketRuleManager: error whilst reading rules - ${e.getMessage}", e)
+          Some(e)
+      }
 
-      logger.info(s"Got rules from S3. JSON hash: ${rulesJson.hashCode()}")
-      (rulesJson.as[CheckerRuleResource], lastModified)
-    }
+      logger.info(s"Got rules from S3. JSON hash: ${rules.hashCode()}")
+      error match {
+        case None => Right((rulesArray.toList, lastModified))
+        case Some(error) => Left(error)
+      }
   }
 
   def getRulesLastModified: Either[Exception, Date] = {

--- a/apps/common-lib/src/main/scala/com/gu/typerighter/rules/BucketRuleResource.scala
+++ b/apps/common-lib/src/main/scala/com/gu/typerighter/rules/BucketRuleResource.scala
@@ -28,8 +28,9 @@ class BucketRuleResource(s3: AmazonS3, bucketName: String, stage: String) extend
       metaData.setContentLength(ruleJsonBytes.length)
       val putObjectRequest = new PutObjectRequest(bucketName, RULES_KEY, stream, metaData)
       val s3Object = s3.putObject(putObjectRequest)
-      logger.info(s"artefact created with entity tag: ${s3Object.getMetadata.getETag}")
-      logger.info(s"${ruleJsonBytes.length} bytes written to bucket")
+      logger.info(
+        s"Artefact created with entity tag: ${s3Object.getMetadata.getETag} - ${ruleJsonBytes.length} bytes written to bucket"
+      )
     }
   }
 

--- a/localstack/init-aws.sh
+++ b/localstack/init-aws.sh
@@ -2,9 +2,9 @@
 
 awslocal s3 mb s3://typerighter-app-local
 
-json='{"rules": []}'
-echo "$json" > typerighter-rules.json
-awslocal s3 cp typerighter-rules.json s3://typerighter-app-local/local/rules/typerighter-rules.json
+json=''
+echo "$json" > typerighter-rules-seq.json
+awslocal s3 cp typerighter-rules-seq.json s3://typerighter-app-local/local/rules/typerighter-rules-seq.json
 # Copying from the location in the localstack instance that Docker writes the dictionary file to
 awslocal s3 cp /etc/gu/typerighter/collins-dictionary.xml s3://typerighter-app-local/local/dictionary/collins-dictionary.xml
 awslocal s3 cp /etc/gu/typerighter/collins-lemmatised-list.xml s3://typerighter-app-local/local/dictionary/collins-lemmatised-list.xml

--- a/localstack/init-aws.sh
+++ b/localstack/init-aws.sh
@@ -2,8 +2,7 @@
 
 awslocal s3 mb s3://typerighter-app-local
 
-json=''
-echo "$json" > typerighter-rules-seq.json
+touch typerighter-rules-seq.json
 awslocal s3 cp typerighter-rules-seq.json s3://typerighter-app-local/local/rules/typerighter-rules-seq.json
 # Copying from the location in the localstack instance that Docker writes the dictionary file to
 awslocal s3 cp /etc/gu/typerighter/collins-dictionary.xml s3://typerighter-app-local/local/dictionary/collins-dictionary.xml


### PR DESCRIPTION
## What does this change?

The Checker and Rule Manager services frequently crash due to `OutOfMemory` errors, especially locally. Watching the service run while measuring memory usage, we have seen that memory spikes correlate with the point at which the artefact is serialised to JSON by the Rule Manager and read by the Checker.

At this point, the services potentially have quite a lot in memory - the `List[CheckerRule]` - containing >250,000 entries, the `JsValue` representation of that list, and the string representation of that JSON (~50mb in size).

This PR writes the artefact as newline-delineated JSON, iterating through the rules and writing bytes to the artefact for each individual rule, so that we don't need to have as many objects in memory at any one time, and giving the JVM garbage collector more opportunities to reclaim memory.

This should resolve the `OutOfMemory` errors on artefact write. Time from publishing in the Rule Manager to receiving the new match in Composer seems a lot faster - from around 14 seconds in testing, but I've been unable to benchmark against existing times because the Checker crashes too often on older branches for me to measure on those branches.

The PR should be backwards compatible, checking first for the new (newline delineated JSON) artefact and falling back to the old (standard JSON) artefact if it's not found.

(We should be able to remove this in the future and move only to the new style).

## How to test

1. It's a good idea to deploy to CODE and check the backwards compatibility. Make sure the new artefact (`typerighter-rules-seq.json`) is not present in the Typerighter CODE S3 bucket for a fair test of the backwards compatibility (you may need to manually delete it from S3 via the AWS console). Does the deploy complete?
2. Once successfully deployed, create a new regex rule and publish it. 
3. Does it show up in Composer CODE against matching text in a timely manner? (It should).
4. Does the checker service crash with an `OutOfMemory` error? (It shouldn't).

## How can we measure success?

1. No OutOfMemory errors on artefact publication
2. Faster time from publication in the Rule Manager to matches appearing in Composer
