### PR TITLE
Add devx backup tag to ruleDB

### DIFF
--- a/cdk/lib/__snapshots__/index.test.ts.snap
+++ b/cdk/lib/__snapshots__/index.test.ts.snap
@@ -1484,6 +1484,10 @@ exports[`The typerighter stack matches the snapshot 1`] = `
             "Value": "rule-manager-db",
           },
           {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },

--- a/cdk/lib/index.ts
+++ b/cdk/lib/index.ts
@@ -3,6 +3,7 @@ import {
   Duration,
   RemovalPolicy,
   SecretValue,
+  Tags,
 } from "aws-cdk-lib";
 import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core/stack";
@@ -335,5 +336,6 @@ EOF
       storageType: StorageType.GP2,
       removalPolicy: RemovalPolicy.SNAPSHOT,
     });
+    Tags.of(ruleDB).add("devx-backup-enabled", "true");
   }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Part of [RDS Backups](https://trello.com/c/ZQ2cQWQD/2032-rds-backups-devx-pairing) 

Enables more robust backup processes powered by AWS backup service for the RDS database, as per this [FAQ](https://docs.google.com/document/d/1VDCSxYFlWs4R6g0Waa6OmmfytV60AROyHxfIGho7cLA/edit#heading=h.vwt7syo8ng40).

## How to test

This was added to code, and we could verify this successfully enabled the desired backup in the AWS console. 

