### PR TITLE
Upgrade to Play 2.9, fix Scala Steward

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ val languageToolVersion = "6.0"
 val awsSdkVersion = "1.12.576"
 val capiModelsVersion = "17.5.1"
 val capiClientVersion = "19.2.1"
+val pandaVersion = "3.0.1"
 val circeVersion = "0.14.1"
 val scalikejdbcVersion = scalikejdbc.ScalikejdbcBuildInfo.version
 val scalikejdbcPlayVersion = "2.8.0-scalikejdbc-3.5"
@@ -35,15 +36,6 @@ val appsFolder = "apps"
 
 def javaVersionNumber = {
   IO.read(new File(".java-version"))
-}
-
-def removeStartingOne(javaVersionString: String): String = {
-  val startsWithOne = "^1\\.".r
-  startsWithOne.replaceAllIn(javaVersionString, "")
-}
-
-def parseJavaVersionNumber(javaVersionString: String): String = {
-  removeStartingOne(javaVersionString).split('.').head
 }
 
 val jackson = {
@@ -77,11 +69,11 @@ val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "com.amazonaws" % "aws-java-sdk-secretsmanager" % awsSdkVersion,
     "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
-    "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
+    "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.1" % Test,
     "com.softwaremill.diffx" %% "diffx-scalatest-should" % "0.8.2" % Test,
-    "org.mockito" %% "mockito-scala-scalatest" % "1.17.12",
+    "org.mockito" %% "mockito-scala-scalatest" % "1.17.30",
     "com.gu" %% "simple-configuration-ssm" % "1.6.4",
-    "com.gu" %% "pan-domain-auth-play_2-8" % "1.2.1",
+    "com.gu" %% "pan-domain-auth-play_2-9" % pandaVersion,
     "com.google.api-client" % "google-api-client" % "2.0.1",
     "com.google.apis" % "google-api-services-sheets" % "v4-rev20221216-2.0.0",
     "org.languagetool" % "languagetool-core" % languageToolVersion,
@@ -90,7 +82,7 @@ val commonSettings = Seq(
     "com.gu" %% "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "content-api-client-aws" % "0.7",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
-    "com.gu" %% "panda-hmac-play_2-8" % "2.2.0",
+    "com.gu" %% "panda-hmac-play_2-9" % pandaVersion,
     "net.sourceforge.htmlcleaner" % "htmlcleaner" % "2.29",
     "com.scalawilliam" %% "xs4s-core" % "0.9.1",
     "ch.qos.logback" % "logback-classic" % "1.4.4", // manually overwriting logback-classic to resolve issue in Play framework: https://github.com/playframework/playframework/issues/11499
@@ -105,7 +97,7 @@ val commonLib = (project in file(s"$appsFolder/common-lib"))
     libraryDependencies ++= Seq(
       ws,
       // @todo – we're repeating ourselves. Can we derive this from the plugin?
-      "com.typesafe.play" %% "play" % "2.8.19",
+      "com.typesafe.play" %% "play" % "2.9.2",
     )
   )
 
@@ -126,15 +118,6 @@ def playProject(label: String, projectName: String, domainPrefix: String, devHtt
         s"-J-Xloggc:/var/log/${packageName.value}/gc.log"
       ),
       commonSettings,
-      initialize := {
-        val _ = initialize.value
-        val expectedJavaVersion = parseJavaVersionNumber(javaVersionNumber)
-        val actualJavaVersion = removeStartingOne(sys.props("java.specification.version"))
-        assert(
-          expectedJavaVersion.equals(actualJavaVersion),
-          s"Java $expectedJavaVersion is required for this project. You are using Java $actualJavaVersion."
-        )
-      },
     )
 
 val checker = playProject(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
-sbt.version=1.7.1
+sbt.version=1.9.9
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.2")
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 addSbtPlugin("io.gatling" % "gatling-sbt" % "3.0.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")


### PR DESCRIPTION
This upgrade to Play 2.9 was prompted by https://github.com/guardian/scala-steward-public-repos/pull/67 which requires that all projects that want to have Scala Steward updates (like this one) need to be able to _build_ under Java 21 (even if the projects are still _running_ in production on Java 11).

Building under Java 21 [requires](https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html#jdk-21-compatibility-notes) a recent version of sbt, and that leads to a version bump for `scala-xml` that gives version-compatibility errors:

```
[error] 	* org.scala-lang.modules:scala-xml_2.12:2.1.0 (early-semver) is selected over {1.2.0, 1.1.1}
[error] 	    +- org.scala-lang:scala-compiler:2.12.18              (depends on 2.1.0)
[error] 	    +- com.typesafe.sbt:sbt-native-packager:1.5.2 (scalaVersion=2.12, sbtVersion=1.0) (depends on 1.1.1)
[error] 	    +- com.typesafe.play:twirl-api_2.12:1.5.1             (depends on 1.2.0)
```

...the nicest way to fix these errors is to upgrade to Play 2.9 or above, so here we are!

https://github.com/guardian/pan-domain-authentication didn't get Play 2.9 artifacts until relatively recently, so upgrading the Panda version was also necessary.

See also:
* https://github.com/guardian/maintaining-scala-projects/issues/1

_(unfortunately the Scala Steward run failing affects everyone, see https://github.com/guardian/scala-steward-public-repos/issues/60 - so I've removed `typerighter` from Scala Steward until this PR is merged)_