### PR TITLE
Add Prout to know when PRs are deployed or overdue

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,0 +1,6 @@
+{
+  "checkpoints": {
+    "Checker": { "url": "https://checker.typerighter.gutools.co.uk/healthcheck", "overdue": "15M" },
+    "Rule Manager": { "url": "https://manager.typerighter.gutools.co.uk/healthcheck", "overdue": "15M" }
+  }
+}

--- a/apps/rule-manager/app/controllers/HomeController.scala
+++ b/apps/rule-manager/app/controllers/HomeController.scala
@@ -7,6 +7,7 @@ import db.DB
 import utils.PermissionsHandler
 import com.gu.permissions.PermissionDefinition
 import com.gu.typerighter.controllers.PandaAuthController
+import typerighter.BuildInfo
 import utils.RuleManagerConfig
 
 class HomeController(
@@ -33,7 +34,7 @@ class HomeController(
   def healthcheck() = Action {
     try {
       db.connectionHealthy()
-      Ok(Json.obj("healthy" -> true))
+      Ok(Json.obj("healthy" -> true, "gitCommitId" -> BuildInfo.gitCommitId))
     } catch {
       case e: Throwable =>
         log.error("Healthcheck failed", e)


### PR DESCRIPTION
Adds [Prout](https://www.theguardian.com/info/developer-blog/2015/feb/03/prout-is-your-pull-request-out), to let us know when our changes don't ship as expected, or when they are ready to check in Production!

Some other recents PRs enabling Prout on repos:

* https://github.com/guardian/permissions/pull/174
* https://github.com/guardian/dotcom-rendering/pull/9692
