### PR TITLE
Only use Prout on endpoints without heavy caching

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,6 +1,5 @@
 {
   "checkpoints": {
-    "Checker": { "url": "https://checker.typerighter.gutools.co.uk/healthcheck", "overdue": "15M" },
     "Rule Manager": { "url": "https://manager.typerighter.gutools.co.uk/healthcheck", "overdue": "15M" }
   }
 }


### PR DESCRIPTION
Following on from #465, of these two checkpoint endpoints:

* https://manager.typerighter.gutools.co.uk/healthcheck - goes direct to ELB, no caching
* https://checker.typerighter.gutools.co.uk/healthcheck - is behind Cloudfront, and seems to have 1-hour cache time

...because of the long cache time on Checker, I think it's going to be too confusing to point Prout at it?

![image](https://github.com/guardian/typerighter/assets/52038/1e073743-7475-4d17-9b42-eb55ec500592)
https://prout-bot.herokuapp.com/view/guardian/typerighter

I think if Prout was making a POST request to checker.typerighter.gutools.co.uk, it would presumably get a fresh response from the cache, but it would probably also need to authenticate, for which in Prout there's no mechanism available at the moment.
