### PR TITLE
Don't cache the checker healthcheck endpoint

### DIFF
--- a/cdk/lib/__snapshots__/index.test.ts.snap
+++ b/cdk/lib/__snapshots__/index.test.ts.snap
@@ -1767,39 +1767,6 @@ exports[`The typerighter stack matches the snapshot 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
-    "checkercloudfrontcachepolicyC5791389": {
-      "Properties": {
-        "CachePolicyConfig": {
-          "DefaultTTL": 86400,
-          "MaxTTL": 31536000,
-          "MinTTL": 0,
-          "Name": "checker-cloudfront-cache-policy-TEST",
-          "ParametersInCacheKeyAndForwardedToOrigin": {
-            "CookiesConfig": {
-              "CookieBehavior": "all",
-            },
-            "EnableAcceptEncodingBrotli": false,
-            "EnableAcceptEncodingGzip": false,
-            "HeadersConfig": {
-              "HeaderBehavior": "whitelist",
-              "Headers": [
-                "Host",
-                "Origin",
-                "Access-Control-Request-Headers",
-                "Access-Control-Request-Method",
-                "X-Gu-Tools-HMAC-Token",
-                "X-Gu-Tools-HMAC-Date",
-                "X-Gu-Tools-Service-Name",
-              ],
-            },
-            "QueryStringsConfig": {
-              "QueryStringBehavior": "all",
-            },
-          },
-        },
-      },
-      "Type": "AWS::CloudFront::CachePolicy",
-    },
     "checkerdnsrecords": {
       "Properties": {
         "Name": "checker.test.dev-gutools.co.uk",
@@ -2325,9 +2292,7 @@ EOF
               "POST",
               "DELETE",
             ],
-            "CachePolicyId": {
-              "Ref": "checkercloudfrontcachepolicyC5791389",
-            },
+            "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
             "Compress": true,
             "TargetOriginId": "typerightertyperightercloudfrontOrigin1DFFB56FA",
             "ViewerProtocolPolicy": "allow-all",

--- a/cdk/lib/__snapshots__/index.test.ts.snap
+++ b/cdk/lib/__snapshots__/index.test.ts.snap
@@ -2294,6 +2294,7 @@ EOF
             ],
             "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
             "Compress": true,
+            "OriginRequestPolicyId": "216adef6-5c7f-47e4-b989-5492eafa07d3",
             "TargetOriginId": "typerightertyperightercloudfrontOrigin1DFFB56FA",
             "ViewerProtocolPolicy": "allow-all",
           },

--- a/cdk/lib/index.ts
+++ b/cdk/lib/index.ts
@@ -3,7 +3,6 @@ import {
   Duration,
   RemovalPolicy,
   SecretValue,
-  Tags,
 } from "aws-cdk-lib";
 import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core/stack";
@@ -22,12 +21,10 @@ import { InstanceType, Port, SubnetType } from "aws-cdk-lib/aws-ec2";
 import { GuS3Bucket } from "@guardian/cdk/lib/constructs/s3";
 import {
   AllowedMethods,
-  CacheCookieBehavior,
-  CacheHeaderBehavior,
   CachePolicy,
-  CacheQueryStringBehavior,
   Distribution,
   OriginProtocolPolicy,
+  OriginRequestPolicy,
 } from "aws-cdk-lib/aws-cloudfront";
 import { LoadBalancerV2Origin } from "aws-cdk-lib/aws-cloudfront-origins";
 import {
@@ -225,7 +222,8 @@ EOF
         defaultBehavior: {
           origin: checkerOrigin,
           allowedMethods: AllowedMethods.ALLOW_ALL,
-          cachePolicy: CachePolicy.CACHING_DISABLED
+          cachePolicy: CachePolicy.CACHING_DISABLED,
+          originRequestPolicy: OriginRequestPolicy.ALL_VIEWER
         },
         domainNames: [checkerDomain],
         logBucket: cloudfrontBucket,

--- a/cdk/lib/index.ts
+++ b/cdk/lib/index.ts
@@ -225,33 +225,14 @@ EOF
         defaultBehavior: {
           origin: checkerOrigin,
           allowedMethods: AllowedMethods.ALLOW_ALL,
-          cachePolicy: new CachePolicy(
-            this,
-            "checker-cloudfront-cache-policy",
-            {
-              cachePolicyName: `checker-cloudfront-cache-policy-${this.stage}`,
-              cookieBehavior: CacheCookieBehavior.all(),
-              headerBehavior: CacheHeaderBehavior.allowList(
-                "Host",
-                "Origin",
-                "Access-Control-Request-Headers",
-                "Access-Control-Request-Method",
-                "X-Gu-Tools-HMAC-Token",
-                "X-Gu-Tools-HMAC-Date",
-                "X-Gu-Tools-Service-Name"
-              ),
-              queryStringBehavior: CacheQueryStringBehavior.all(),
-            }
-          ),
+          cachePolicy: CachePolicy.CACHING_DISABLED
         },
         domainNames: [checkerDomain],
         logBucket: cloudfrontBucket,
         certificate: checkerCertificate,
       }
     );
-
-    checkerCloudFrontDistro.addBehavior("/healthcheck", checkerOrigin, { cachePolicy: CachePolicy.CACHING_DISABLED });
-
+    
     const checkerDnsRecord = new GuDnsRecordSet(this, "checker-dns-records", {
       name: checkerDomain,
       recordType: RecordType.CNAME,

--- a/cdk/lib/index.ts
+++ b/cdk/lib/index.ts
@@ -214,14 +214,16 @@ EOF
       parameters.CheckerCertificate.valueAsString
     );
 
+    const checkerOrigin = new LoadBalancerV2Origin(checkerApp.loadBalancer, {
+      protocolPolicy: OriginProtocolPolicy.HTTPS_ONLY,
+    });
+
     const checkerCloudFrontDistro = new Distribution(
       this,
       "typerighter-cloudfront",
       {
         defaultBehavior: {
-          origin: new LoadBalancerV2Origin(checkerApp.loadBalancer, {
-            protocolPolicy: OriginProtocolPolicy.HTTPS_ONLY,
-          }),
+          origin: checkerOrigin,
           allowedMethods: AllowedMethods.ALLOW_ALL,
           cachePolicy: new CachePolicy(
             this,
@@ -247,6 +249,8 @@ EOF
         certificate: checkerCertificate,
       }
     );
+
+    checkerCloudFrontDistro.addBehavior("/healthcheck", checkerOrigin, { cachePolicy: CachePolicy.CACHING_DISABLED });
 
     const checkerDnsRecord = new GuDnsRecordSet(this, "checker-dns-records", {
       name: checkerDomain,


### PR DESCRIPTION
## What does this change?

Don't use caching for the Checker service, to enable the lovely Prout-bot to do its work (#465.)

We use Cloudfront to improve service latency for global users by removing TCP slowstart and reducing TLS handshake latency – we don't care about caching content.

(Initially this PR just removed caching for the healthcheck endpoint (620eb3719971b45860a945ea17ac6794cad54a06), but on reflection I think removing caching entirely is more appropriate.)

## How to test

Deploy to CODE or PROD. You should no longer see `X-Cache: Hit from cloudfront` headers on requests.

