### PR TITLE
Add filters to search

### DIFF
--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -40,7 +40,7 @@ class RulesController(
             .map(toFormError("refresh-sheet"))
           _ <- RuleManager.destructivelyPublishRules(dbRules, bucketRuleResource)
         } yield {
-          RuleManager.searchDraftRules(1, None, List.empty)
+          RuleManager.searchDraftRules(1)
         }
 
         maybeWrittenRules match {
@@ -72,9 +72,15 @@ class RulesController(
     }
   }
 
-  def list(page: Int = 1, word: Option[String] = None, sortBy: List[String] = List.empty) =
+  def list(
+      page: Int = 1,
+      word: Option[String] = None,
+      tags: List[Int] = List.empty,
+      ruleTypes: List[String] = List.empty,
+      sortBy: List[String] = List.empty
+  ) =
     APIAuthAction {
-      Ok(Json.toJson(RuleManager.searchDraftRules(page, word, sortBy)))
+      Ok(Json.toJson(RuleManager.searchDraftRules(page, word, tags, ruleTypes, sortBy)))
     }
 
   def get(id: Int) = APIAuthAction {

--- a/apps/rule-manager/app/db/DbRuleDraft.scala
+++ b/apps/rule-manager/app/db/DbRuleDraft.scala
@@ -291,7 +291,8 @@ object DbRuleDraft extends SQLSyntaxSupport[DbRuleDraft] {
         }
       }
 
-      sqls"ORDER BY ${sqls.join(orderStmts, sqls",")}${if (orderStmts.nonEmpty) sqls", " else sqls.empty}${rd.ruleType} ASC"
+      sqls"ORDER BY ${sqls.join(orderStmts, sqls",")}${if (orderStmts.nonEmpty) sqls", "
+        else sqls.empty}${rd.ruleType} ASC"
     }
 
     val data = sql"""

--- a/apps/rule-manager/app/db/DbRuleDraft.scala
+++ b/apps/rule-manager/app/db/DbRuleDraft.scala
@@ -223,7 +223,13 @@ object DbRuleDraft extends SQLSyntaxSupport[DbRuleDraft] {
       .apply()
   }
 
-  def searchRules(page: Int, maybeWord: Option[String], sortBy: List[String] = List.empty)(implicit
+  def searchRules(
+      page: Int,
+      maybeWord: Option[String] = None,
+      tags: List[Int] = List.empty,
+      ruleTypes: List[String] = List.empty,
+      sortBy: List[String] = List.empty
+  )(implicit
       session: DBSession = autoSession
   ): PaginatedResponse[DbRuleDraft] = {
     val pageSize = 200
@@ -274,11 +280,9 @@ object DbRuleDraft extends SQLSyntaxSupport[DbRuleDraft] {
           LEFT JOIN ${RuleTagDraft.as(rt)}
               ON ${rd.id} = ${rt.ruleId}
           $searchClause
-          GROUP BY $draftRuleColumns, ${rl.externalId}, ${rl.revisionId} ${
-            maybeWord
-              .map { _ => sqls"," + SQLSyntax.createUnsafely(subClauseSimilarityCol) }
-              .getOrElse(sqls.empty)
-          }
+          GROUP BY $draftRuleColumns, ${rl.externalId}, ${rl.revisionId} ${maybeWord
+        .map { _ => sqls"," + SQLSyntax.createUnsafely(subClauseSimilarityCol) }
+        .getOrElse(sqls.empty)}
           ${orderByClause(subClauseSimilarityCol)}
           LIMIT $pageSize
           OFFSET ${(page - 1) * pageSize}

--- a/apps/rule-manager/app/service/RuleManager.scala
+++ b/apps/rule-manager/app/service/RuleManager.scala
@@ -165,10 +165,16 @@ object RuleManager extends Loggable {
     }
   }
 
-  def searchDraftRules(page: Int, queryStr: Option[String], sortBy: List[String])(implicit
+  def searchDraftRules(
+      page: Int,
+      queryStr: Option[String] = None,
+      tags: List[Int] = List.empty,
+      ruleTypes: List[String] = List.empty,
+      sortBy: List[String] = List.empty
+  )(implicit
       session: DBSession = autoSession
   ): PaginatedResponse[DbRuleDraft] =
-    DbRuleDraft.searchRules(page, queryStr, sortBy)
+    DbRuleDraft.searchRules(page, queryStr, tags = tags, ruleTypes = ruleTypes, sortBy = sortBy)
 
   def getDraftDictionaryRules(word: Option[String], page: Int)(implicit
       session: DBSession = autoSession

--- a/apps/rule-manager/client/src/ts/components/hooks/useRules.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRules.ts
@@ -31,6 +31,8 @@ export function useRules() {
 		pageIndex: number = 0,
 		queryStr: string = '',
 		sortColumns: SortColumns = [],
+		tags: number[] = [],
+		ruleTypes: string[] = [],
 	): Promise<void> => {
 		setIsLoading(true);
 		try {
@@ -39,6 +41,12 @@ export function useRules() {
 				page: page.toString(),
 				...(queryStr ? { queryStr } : {}),
 			});
+
+			tags.forEach((tag) => queryParams.append('tags', tag.toString()));
+			ruleTypes.forEach((ruleType) =>
+				queryParams.append('ruleTypes', ruleType),
+			);
+
 			sortColumns.forEach((colAndDir) =>
 				queryParams.append(
 					'sortBy',

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -165,30 +165,26 @@ export const Rules = () => {
 								onChange={(e) => setQueryStr(e.target.value)}
 							/>
 						</EuiFlexItem>
-						<EuiFlexItem>
-							<EuiComboBox<string>
-								fullWidth
-								placeholder="Filter by rule type"
-								options={ruleTypeOptionsWithId}
-								selectedOptions={selectedRuleTypeOptions}
-								onChange={(ids) =>
-									setSelectedRuleTypeOptions(
-										ids as { label: string; value: string }[],
-									)
-								}
-							/>
-						</EuiFlexItem>
-						<EuiFlexItem>
-							<EuiComboBox<number>
-								fullWidth
-								placeholder="Filter by tag"
-								options={tagOptions}
-								selectedOptions={selectedTags}
-								onChange={(ids) =>
-									setSelectedTags(ids as { label: string; value: number }[])
-								}
-							/>
-						</EuiFlexItem>
+						<EuiComboBox<string>
+							style={{ maxWidth: '200px' }}
+							placeholder="Filter by rule type"
+							options={ruleTypeOptionsWithId}
+							selectedOptions={selectedRuleTypeOptions}
+							onChange={(ids) =>
+								setSelectedRuleTypeOptions(
+									ids as { label: string; value: string }[],
+								)
+							}
+						/>
+						<EuiComboBox<number>
+							style={{ maxWidth: '200px' }}
+							placeholder="Filter by tag"
+							options={tagOptions}
+							selectedOptions={selectedTags}
+							onChange={(ids) =>
+								setSelectedTags(ids as { label: string; value: number }[])
+							}
+						/>
 					</EuiFlexGroup>
 				</EuiFlexItem>
 				<EuiFlexItem grow={0}>

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -6,6 +6,7 @@ import {
 	EuiButtonIcon,
 	EuiToolTip,
 	EuiSpacer,
+	EuiComboBox,
 } from '@elastic/eui';
 import { SortColumns, useRules } from '../hooks/useRules';
 import { StandaloneRuleForm } from '../RuleForm';
@@ -17,6 +18,8 @@ import { EuiFieldSearch } from '@elastic/eui/src/components/form/field_search';
 import { PaginatedRulesTable } from '../table/PaginatedRulesTable';
 import { useDebouncedValue } from '../hooks/useDebounce';
 import { FullHeightContentWithFixedHeader } from '../layout/FullHeightContentWithFixedHeader';
+import { Tag, TagsContext } from '../context/tags';
+import { ruleTypeOptions } from '../RuleContent';
 
 export const useCreateEditPermissions = () => {
 	const permissions = useContext(PageContext).permissions;
@@ -24,8 +27,25 @@ export const useCreateEditPermissions = () => {
 	return useMemo(() => hasCreateEditPermissions(permissions), [permissions]);
 };
 
+const ruleTypeOptionsWithId = ruleTypeOptions.map((opt) => ({
+	label: opt.label,
+	value: opt.id,
+}));
+
 export const Rules = () => {
 	const [queryStr, setQueryStr] = useState<string>('');
+	const [selectedRuleTypeOptions, setSelectedRuleTypeOptions] = useState<
+		{ label: string; value: string }[]
+	>([]);
+	const [selectedTags, setSelectedTags] = useState<
+		{ label: string; value: number }[]
+	>([]);
+	const { tags } = useContext(TagsContext);
+	const tagOptions = useMemo(
+		() =>
+			Object.values(tags).map((tag) => ({ label: tag.name, value: tag.id })),
+		[tags],
+	);
 	const debouncedQueryStr = useDebouncedValue(queryStr, 200);
 	const {
 		ruleData,
@@ -58,8 +78,20 @@ export const Rules = () => {
 	};
 
 	useEffect(() => {
-		fetchRules(pageIndex, debouncedQueryStr, sortColumns);
-	}, [pageIndex, debouncedQueryStr, sortColumns]);
+		fetchRules(
+			pageIndex,
+			debouncedQueryStr,
+			sortColumns,
+			selectedTags.map((_) => _.value),
+			selectedRuleTypeOptions.map((_) => _.value),
+		);
+	}, [
+		pageIndex,
+		debouncedQueryStr,
+		sortColumns,
+		selectedTags,
+		selectedRuleTypeOptions,
+	]);
 
 	useEffect(() => {
 		if (rowSelection.size === 0) {
@@ -124,11 +156,40 @@ export const Rules = () => {
 			) : null}
 			<EuiFlexGroup>
 				<EuiFlexItem>
-					<EuiFieldSearch
-						fullWidth
-						value={queryStr}
-						onChange={(e) => setQueryStr(e.target.value)}
-					/>
+					<EuiFlexGroup gutterSize="s">
+						<EuiFlexItem grow={3}>
+							<EuiFieldSearch
+								placeholder="Search tag description, pattern, or replacement"
+								fullWidth
+								value={queryStr}
+								onChange={(e) => setQueryStr(e.target.value)}
+							/>
+						</EuiFlexItem>
+						<EuiFlexItem>
+							<EuiComboBox<string>
+								fullWidth
+								placeholder="Filter by rule type"
+								options={ruleTypeOptionsWithId}
+								selectedOptions={selectedRuleTypeOptions}
+								onChange={(ids) =>
+									setSelectedRuleTypeOptions(
+										ids as { label: string; value: string }[],
+									)
+								}
+							/>
+						</EuiFlexItem>
+						<EuiFlexItem>
+							<EuiComboBox<number>
+								fullWidth
+								placeholder="Filter by tag"
+								options={tagOptions}
+								selectedOptions={selectedTags}
+								onChange={(ids) =>
+									setSelectedTags(ids as { label: string; value: number }[])
+								}
+							/>
+						</EuiFlexItem>
+					</EuiFlexGroup>
 				</EuiFlexItem>
 				<EuiFlexItem grow={0}>
 					<EuiToolTip

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -13,7 +13,7 @@ POST    /api/refresh                    controllers.RulesController.refresh()
 +nocsrf
 POST    /api/refreshDictionary          controllers.RulesController.refreshDictionaryRules()
 +nocsrf
-GET     /api/rules                      controllers.RulesController.list(page: Int, queryStr: Option[String], sortBy: List[String])
+GET     /api/rules                      controllers.RulesController.list(page: Int, queryStr: Option[String], tags: List[Int], ruleTypes: List[String], sortBy: List[String])
 +nocsrf
 POST    /api/rules                      controllers.RulesController.create()
 +nocsrf

--- a/apps/rule-manager/test/db/DraftRulesSpec.scala
+++ b/apps/rule-manager/test/db/DraftRulesSpec.scala
@@ -155,7 +155,12 @@ class DraftRulesSpec extends RuleFixture with Matchers with DBTest {
     Tags.create("Tag 2")
     val rule = insertRule(ruleType = "dictionary", pattern = Some("findme"), tags = List(2))
 
-    val results = DbRuleDraft.searchRules(1, ruleTypes = List("dictionary"), maybeWord = Some("findme"), tags = List(2))
+    val results = DbRuleDraft.searchRules(
+      1,
+      ruleTypes = List("dictionary"),
+      maybeWord = Some("findme"),
+      tags = List(2)
+    )
     results.data.map(_.pattern) shouldBe List(rule).map(_.pattern)
   }
 

--- a/apps/rule-manager/test/db/RuleFixture.scala
+++ b/apps/rule-manager/test/db/RuleFixture.scala
@@ -39,8 +39,9 @@ trait RuleFixture extends FixtureAnyFlatSpec with AutoRollback {
 
   def insertRule(
       ruleType: String = "regex",
-      pattern: Option[String] = None,
-      description: Option[String] = None
+      pattern: Option[String] = Some("Example"),
+      description: Option[String] = None,
+      tags: List[Int] = List.empty
   )(implicit session: DBSession = autoSession) = DbRuleDraft
     .create(
       ruleType = ruleType,
@@ -48,7 +49,8 @@ trait RuleFixture extends FixtureAnyFlatSpec with AutoRollback {
       description,
       description,
       user = "test.user",
-      ignore = false
+      ignore = false,
+      tags = tags
     )
     .get
 }


### PR DESCRIPTION
## What does this change?

Adds search filters for tags and rule type.

![filter-by-tag](https://github.com/guardian/typerighter/assets/7767575/9be8e3c4-20c9-4331-a771-6a489c3fd3b3)

## Implementation notes

In altering the search query for this I realised we didn't need the subquery – see [fb130e3](https://github.com/guardian/typerighter/pull/469/commits/fb130e39d2221e26c19ee9ca2e70fb640a642102). Minor complexity reduction.

## How to test

- The automated test should pass.
- Run locally or (better) in CODE, and have a play with the filters. They should behave as expected in combination with the text search.

## What about a filter for publication status? Or source?

Wouldn't that be nice? PRs welcome!

There's a question of how we manage an expanding set of filters.