### PR TITLE
Introduce`/api/rules/csv-import` endpoint

### DIFF
--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -279,4 +279,24 @@ class RulesController(
       case Left(error) => BadRequest(s"Invalid request: $error")
     }
   }
+
+  def csvImport() = Action { implicit request =>
+    val rules = for {
+      formData <- request.body.asMultipartFormData.toRight("No form data found in request")
+      file <- formData.file("file").toRight("No file found in request")
+      tag = formData.dataParts.get("tag") match {
+        case Some(tag) => tag.head
+        case None      => ""
+      }
+    } yield RuleManager.csvImport(
+      file.ref.path.toFile,
+      tag,
+      bucketRuleResource
+    )
+
+    rules match {
+      case Right(int)    => Ok(Json.toJson(int))
+      case Left(message) => BadRequest(message)
+    }
+  }
 }

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -285,12 +285,12 @@ class RulesController(
       formData <- request.body.asMultipartFormData.toRight("No form data found in request")
       file <- formData.file("file").toRight("No file found in request")
       tag = formData.dataParts.get("tag") match {
-        case Some(tag) => tag.head
-        case None      => ""
+        case Some(tag) => Some(tag.head)
+        case None      => None
       }
       category = formData.dataParts.get("category") match {
-        case Some(category) => category.head
-        case None           => ""
+        case Some(category) => Some(category.head)
+        case None           => None
       }
     } yield RuleManager.csvImport(
       file.ref.path.toFile,

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -288,9 +288,14 @@ class RulesController(
         case Some(tag) => tag.head
         case None      => ""
       }
+      category = formData.dataParts.get("category") match {
+        case Some(category) => category.head
+        case None           => ""
+      }
     } yield RuleManager.csvImport(
       file.ref.path.toFile,
       tag,
+      category,
       bucketRuleResource
     )
 

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -280,7 +280,7 @@ class RulesController(
     }
   }
 
-  def csvImport() = Action { implicit request =>
+  def csvImport() = APIAuthAction { implicit request =>
     val rules = for {
       formData <- request.body.asMultipartFormData.toRight("No form data found in request")
       file <- formData.file("file").toRight("No file found in request")

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -294,8 +294,8 @@ class RulesController(
     )
 
     rules match {
-      case Right(int)    => Ok(Json.toJson(int))
-      case Left(message) => BadRequest(message)
+      case Right(noOfRulesAdded) => Ok(Json.toJson(noOfRulesAdded))
+      case Left(message)         => BadRequest(message)
     }
   }
 }

--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -284,14 +284,8 @@ class RulesController(
     val rules = for {
       formData <- request.body.asMultipartFormData.toRight("No form data found in request")
       file <- formData.file("file").toRight("No file found in request")
-      tag = formData.dataParts.get("tag") match {
-        case Some(tag) => Some(tag.head)
-        case None      => None
-      }
-      category = formData.dataParts.get("category") match {
-        case Some(category) => Some(category.head)
-        case None           => None
-      }
+      tag = formData.dataParts.get("tag").flatMap(_.headOption)
+      category = formData.dataParts.get("category").flatMap(_.headOption)
     } yield RuleManager.csvImport(
       file.ref.path.toFile,
       tag,

--- a/apps/rule-manager/app/service/RuleManager.scala
+++ b/apps/rule-manager/app/service/RuleManager.scala
@@ -42,6 +42,7 @@ object RuleManager extends Loggable {
   ) = {
     val reader = CSVReader.open(toFile)
     val rules = reader.all()
+    reader.close()
 
     val initialRuleOrder = DbRuleDraft.getLatestRuleOrder() + 1
 

--- a/apps/rule-manager/app/service/RuleManager.scala
+++ b/apps/rule-manager/app/service/RuleManager.scala
@@ -34,7 +34,12 @@ case class AllRuleData(
 )
 
 object RuleManager extends Loggable {
-  def csvImport(toFile: File, tagName: String, bucketRuleResource: BucketRuleResource) = {
+  def csvImport(
+      toFile: File,
+      tagName: String,
+      category: String,
+      bucketRuleResource: BucketRuleResource
+  ) = {
     val reader = CSVReader.open(toFile)
     val rules = reader.all()
 
@@ -49,7 +54,7 @@ object RuleManager extends Loggable {
         id = None,
         ruleType = RuleType.regex,
         pattern = Some(pattern),
-        category = Some("Imported from CSV"),
+        category = Some(category),
         description = Some(description),
         ignore = false,
         replacement = Some(replacement),

--- a/apps/rule-manager/app/service/RuleManager.scala
+++ b/apps/rule-manager/app/service/RuleManager.scala
@@ -18,6 +18,8 @@ import model.{DictionaryForm, LTRuleCoreForm, LTRuleXMLForm, PaginatedResponse, 
 import play.api.data.FormError
 import play.api.libs.json.{Json, OWrites}
 import scalikejdbc.DBSession
+import com.github.tototoshi.csv.CSVReader
+import java.io.File
 
 object AllRuleData {
   implicit val writes: OWrites[AllRuleData] = Json.writes[AllRuleData]
@@ -32,6 +34,49 @@ case class AllRuleData(
 )
 
 object RuleManager extends Loggable {
+  def csvImport(toFile: File, tagName: String, bucketRuleResource: BucketRuleResource) = {
+    val reader = CSVReader.open(toFile)
+    val rules = reader.all()
+
+    val initialRuleOrder = DbRuleDraft.getLatestRuleOrder() + 1
+
+    val draftRules = rules.zipWithIndex.map { case (rule, index) =>
+      val pattern = rule(0)
+      val replacement = rule(1)
+      val description = rule(2)
+
+      DbRuleDraft.withUser(
+        id = None,
+        ruleType = RuleType.regex,
+        pattern = Some(pattern),
+        category = Some("Imported from CSV"),
+        description = Some(description),
+        ignore = false,
+        replacement = Some(replacement),
+        user = "CSV Import",
+        ruleOrder = initialRuleOrder + index
+      )
+    }
+    val ruleIds = DbRuleDraft.batchInsert(draftRules, true)
+
+    // Apply tag
+    val allTags = Tags.findAll()
+    allTags.find(tag => tag.name == tagName).map(_.id) match {
+      case Some(tagId) =>
+        RuleTagDraft.batchInsert(ruleIds.map(id => RuleTagDraft(id, tagId.getOrElse(-1))))
+      case None => log.error(s"Tag $tagName not found")
+    }
+
+    val rulesWithIds = DbRuleDraft.findRules(ruleIds)
+    val liveRulesWithIds = rulesWithIds.map(_.toLive("Imported from CSV", true))
+
+    DbRuleLive.batchInsert(liveRulesWithIds)
+
+    publishLiveRules(bucketRuleResource)
+
+    liveRulesWithIds.size
+  }
+
   object RuleType {
     val regex = "regex"
     val languageToolXML = "languageToolXML"

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -21,6 +21,8 @@ GET     /api/rules/batch/:ids           controllers.RulesController.getRules(ids
 +nocsrf
 POST    /api/rules/batch                controllers.RulesController.batchUpdate()
 +nocsrf
+POST    /api/rules/csv-import           controllers.RulesController.csvImport()
++nocsrf
 GET     /api/rules/:id                  controllers.RulesController.get(id: Int)
 +nocsrf
 POST    /api/rules/:id                  controllers.RulesController.update(id: Int)

--- a/apps/rule-manager/test/resources/csv/mps.csv
+++ b/apps/rule-manager/test/resources/csv/mps.csv
@@ -1,0 +1,3 @@
+Dami(e|a)n Egan,Damien Egan,"MP last elected in 2024: Labour, Bristol North East"
+Clive Efford,Clive Efford,"MP last elected in 2024: Labour, Eltham and Chislehurst"
+Maya Ellis,Maya Ellis,"MP last elected in 2024: Labour, Ribble Valley"

--- a/build.sbt
+++ b/build.sbt
@@ -172,6 +172,7 @@ val ruleManager = playProject(
       "org.scalikejdbc" %% "scalikejdbc-test" % scalikejdbcVersion % Test,
       "org.scalikejdbc" %% "scalikejdbc-syntax-support-macro" % scalikejdbcVersion,
       "com.gu" %% "editorial-permissions-client" % "2.14",
+      "com.github.tototoshi" %% "scala-csv" % "2.0.0",
     ),
     libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
   )


### PR DESCRIPTION
## What does this change?

Introduces a new endpoint `/api/rules/csv-import` which enables the bulk import of regex rules via a CSV file. In particular, this will provide a useful method to quickly populate typerighter with the names of incoming MPs after an election.

The endpoint accepts three parameters encoded as `form-data`:

- `file` (required): the CSV file containing the rules data
- `tag` (optional): a tag to be applied to all imported rules. The tag must already exist in typerighter.
- `category` (optional): a category to be applied to all imported rules. Category is also known as "source" in the UI.

For example:

```
curl --location 'https://manager.typerighter.gutools.co.uk/api/rules/csv-import' \
--header 'accept: */*' \
--header 'content-type: application/json' \
--form 'file=@"/Users/Simon_Byford/Downloads/mps.csv"' \
--form 'tag="MP"'
--form 'category="Style guide and names"'
```

Note: this won't actually work for reasons I'll get to..

The CSV file should not contain headers, and the columns must appear in the following order: `pattern,replacement,description`

For example, the following CSV file is valid:

```
Diann?e Abbott?,Diane Abbott,"MP last elected in 2024: Labour, Hackney North and Stoke Newington"
Debbie Abrahams,Debbie Abrahams,"MP last elected in 2024: Labour, Oldham East and Saddleworth"
Rebecca Long-? ?Bailey,Rebecca Long-Bailey,"MP last elected in 2024: Labour, Salford"
```

If the operation is successful, the API will return the number of rules added.

## How to test

For the first iteration, we decided not to expose this in the UI, instead the endpoint must be queried manually. This is a bit fiddly because it requires a cookie for authentication. The best way to get around this is to interact with the manager interface (manager.typerighter.gutools.co.uk) - for example, start creating a rule - and inspect any network request to `/api/rules`. You can then copy the request as cURL:

![Screenshot 2024-07-23 at 16 11 56](https://github.com/user-attachments/assets/11445edb-edf9-4881-8907-916765f2c1f3)

You can then either make the necessary edits and run it directly on the command line (scary), or import it into a client like Postman:

![Screenshot 2024-07-23 at 16 30 28](https://github.com/user-attachments/assets/339fc073-ce0f-40bd-b314-9e0884a34654)

![Screenshot 2024-07-24 at 14 28 14](https://github.com/user-attachments/assets/8922983b-9320-4c1d-9c63-f5277f77a962)



## Images

Using the above method, I tested this on CODE with [Max's spreadsheet of 2024 MPs](https://docs.google.com/spreadsheets/d/1bLCD7CrGMDAuuk76e0MTF1-DUNgmXrvTc1d5n2UMZR8/edit?usp=sharing). I used the tag "CSV import" and category "Imported from CSV".

![Screenshot 2024-07-23 at 14 52 01](https://github.com/user-attachments/assets/5eeecc53-bca7-4408-a7fe-ab7ab4c71a59)

