### PR TITLE
Introduce `/api/rules/archive-by-tag` endpoint

### DIFF
--- a/apps/rule-manager/app/controllers/RulesController.scala
+++ b/apps/rule-manager/app/controllers/RulesController.scala
@@ -299,7 +299,27 @@ class RulesController(
 
         rules match {
           case Right(noOfRulesAdded) => Ok(Json.toJson(noOfRulesAdded))
-          case Left(message) => BadRequest(message)
+          case Left(message)         => BadRequest(message)
+        }
+    }
+  }
+
+  def archiveRulesByTag() = APIAuthAction { implicit request =>
+    hasPermission(request.user, PermissionDefinition("manage_rules", "typerighter")) match {
+      case false => Unauthorized("You don't have permission to edit rules")
+      case true =>
+        val rules = for {
+          formData <- request.body.asMultipartFormData.toRight("No form data found in request")
+          tag = formData.dataParts.get("tag").flatMap(_.headOption)
+        } yield RuleManager.archiveRulesByTag(
+          tag,
+          request.user.email,
+          bucketRuleResource
+        )
+
+        rules match {
+          case Right(noOfRulesArchived) => Ok(Json.toJson(noOfRulesArchived))
+          case Left(message)            => BadRequest(message)
         }
     }
   }

--- a/apps/rule-manager/app/service/RuleManager.scala
+++ b/apps/rule-manager/app/service/RuleManager.scala
@@ -38,6 +38,7 @@ object RuleManager extends Loggable {
       toFile: File,
       maybeTagName: Option[String],
       category: Option[String],
+      user: String,
       bucketRuleResource: BucketRuleResource
   ) = {
     val reader = CSVReader.open(toFile)
@@ -59,7 +60,7 @@ object RuleManager extends Loggable {
         description = Some(description),
         ignore = false,
         replacement = Some(replacement),
-        user = "CSV Import",
+        user = user,
         ruleOrder = initialRuleOrder + index
       )
     }

--- a/apps/rule-manager/conf/routes
+++ b/apps/rule-manager/conf/routes
@@ -23,6 +23,8 @@ POST    /api/rules/batch                controllers.RulesController.batchUpdate(
 +nocsrf
 POST    /api/rules/csv-import           controllers.RulesController.csvImport()
 +nocsrf
+POST    /api/rules/archive-by-tag        controllers.RulesController.archiveRulesByTag()
++nocsrf
 GET     /api/rules/:id                  controllers.RulesController.get(id: Int)
 +nocsrf
 POST    /api/rules/:id                  controllers.RulesController.update(id: Int)

--- a/apps/rule-manager/test/db/RuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/RuleManagerSpec.scala
@@ -571,6 +571,7 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
         file,
         Some("testTag"),
         Some("Style guide and names"),
+        "test@example.com",
         bucketRuleResource
       )
 
@@ -583,6 +584,7 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
       draftRule1.replacement shouldBe Some("Damien Egan")
       draftRule1.description shouldBe Some("MP last elected in 2024: Labour, Bristol North East")
       draftRule1.category shouldBe Some("Style guide and names")
+      draftRule1.createdBy shouldBe "test@example.com"
 
       draftRule1.tags.length shouldBe 1
       draftRule1.tags(0) shouldBe tagToApply.get.id.get
@@ -596,6 +598,7 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
       liveRule1.replacement shouldBe Some("Damien Egan")
       liveRule1.description shouldBe Some("MP last elected in 2024: Labour, Bristol North East")
       liveRule1.category shouldBe Some("Style guide and names")
+      liveRule1.createdBy shouldBe "test@example.com"
 
       liveRule1.tags.length shouldBe 1
       liveRule1.tags(0) shouldBe tagToApply.get.id.get

--- a/apps/rule-manager/test/db/RuleManagerSpec.scala
+++ b/apps/rule-manager/test/db/RuleManagerSpec.scala
@@ -11,7 +11,7 @@ import com.gu.typerighter.model.{
   TextSuggestion
 }
 import com.gu.typerighter.rules.BucketRuleResource
-import db.{DBTest, DbRuleDraft, DbRuleLive, Tags}
+import db.{DBTest, DbRuleDraft, DbRuleLive, RuleTagDraft, Tags}
 import org.scalatest.flatspec.FixtureAnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import scalikejdbc.scalatest.AutoRollback
@@ -602,5 +602,29 @@ class RuleManagerSpec extends FixtureAnyFlatSpec with Matchers with AutoRollback
 
       liveRule1.tags.length shouldBe 1
       liveRule1.tags(0) shouldBe tagToApply.get.id.get
+  }
+
+  "archiveRulesByTag" should "archive all draft and live rules with a given tag" in { () =>
+    val tag = Tags.create(name = "testTag")
+
+    val draftRule = createPublishableRule
+    val liveRule = createPublishableRule
+    // create third rule to verify that only rules with the tag are archived
+    createPublishableRule
+
+    RuleTagDraft.batchInsert(
+      List(
+        RuleTagDraft(draftRule.id.get, tag.get.id.get),
+        RuleTagDraft(liveRule.id.get, tag.get.id.get)
+      )
+    )
+
+    liveRule.toLive("test")
+
+    RuleManager.archiveRulesByTag(Option("testTag"), "test@example.com", bucketRuleResource)
+
+    val archivedRules = DbRuleDraft.findAll().filter(_.isArchived)
+    archivedRules.length shouldBe 2
+    archivedRules(0).updatedBy shouldBe "test@example.com"
   }
 }


### PR DESCRIPTION
## What does this change?

Does two things:

1) adds some handling to the `/api/rules/csv-import` endpoint to ensure the user making the request has the correct permissions. Also stores their email address against the change instead of the dummy value `"CSV Import"` (see: https://github.com/guardian/typerighter/commit/b71cd93596dad8f5accb460bd9ede51e4cc386b8)
2) introduces a new endpoint `/api/rules/archive-by-tag` which can be used to bulk-archive rules based on a given tag (see: https://github.com/guardian/typerighter/commit/e62afe13cc6c4bf5edcde9d28cc078224ff0fbbd)

The new endpoint `/api/rules/archive-by-tag` accepts one parameter encoded as form-data:

- `tag` (required): the tag accociated with the rules to archive.

For example:

```
curl --location 'https://manager.typerighter.gutools.co.uk/api/rules/archive-by-tag' \
--header 'accept: */*' \
--header 'content-type: application/json' \
--form 'tag="MP"'
```

## How to test

It's slightly more complicated than the above. See these notes on the previous PR: https://github.com/guardian/typerighter/pull/477#how-to-test