### PR TITLE
Use new docker compose syntax

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build the stack
         run: |
-          docker-compose up -d
+          docker compose up -d
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## What does this change?

Typerighter CI is currently failing on the "Build the stack" step:

https://github.com/guardian/typerighter/actions/runs/10262013969/job/28409557859

```
line 1: docker-compose: command not found
```

This is because GitHub actions has started using a newer version of Docker Compose:

https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/

Switching to the new syntax should hopefully fix the issue.