### PR TITLE
Add configuration for Hikari connection pool for database evolutions

### DIFF
--- a/apps/rule-manager/conf/application.conf
+++ b/apps/rule-manager/conf/application.conf
@@ -11,6 +11,14 @@ db.default.poolInitialSize=5
 db.default.poolMaxSize=7
 db.default.poolConnectionTimeoutMillis=1000
 
+# Hikari connection pool settings for database evolutions
+play.db.prototype.hikaricp = {
+    poolName = "hikaricp"
+    maximumPoolSize = 2
+    idleTimeout = 1000
+    connectionTimeout = 1000
+}
+
 scalikejdbc.global.loggingSQLAndTime.enabled=true
 scalikejdbc.global.loggingSQLAndTime.singleLineMode=false
 scalikejdbc.global.loggingSQLAndTime.logLevel=debug


### PR DESCRIPTION
Out Typerighter PROD deployments have been failing. Upon investigation, the last instance in the auto-scaling group doesn't pass health checks, failing with the following exception:

```
org.postgresql.util.PSQLException: FATAL: remaining connection slots are reserved for non-replication superuser connections
```

The PROD RDS database is currently a `db.t4g.micro` which has `max_connections` of 81, with at least 5 of those connections reserved for internal Postgres processes.

The max pool size for database operations is set to 7, so you would think even when doubling the auto-scaling group to 6 instances during deployment, we would be under the threshold. However the app, also uses `applicationEvolutions` to run database evolutions when the app starts. This uses a separate Hikari connection pool which defaults to 10. The initial connections per instance then becomes up to 17 which is TOO MANY :)

## What does this change?

This sets the Hikari connection pool to something small and sensible, given the size of the database.

## How to test

When deployed to CODE we should see the number of connections in the RDS dashboard not spike as highly during deployment. The total number of connections should also decrease. The Rule Manager app should still come up and work as expected (https://manager.typerighter.code.dev-gutools.co.uk/) - we haven't touched the connection pool size for regular database operations, so performance of the app should be unaffected.

## How can we measure success?

PROD deploys no longer fail
