### PR TITLE
Read and write core LT rules

### DIFF
--- a/apps/rule-manager/app/db/DbRuleDraft.scala
+++ b/apps/rule-manager/app/db/DbRuleDraft.scala
@@ -10,6 +10,8 @@ import scalikejdbc._
 
 import java.time.OffsetDateTime
 import scala.util.{Failure, Success, Try}
+import utils.StringHelpers
+import service.RuleManager.RuleType
 
 case class DbRuleDraft(
     id: Option[Int],
@@ -280,7 +282,8 @@ object DbRuleDraft extends SQLSyntaxSupport[DbRuleDraft] {
     val orderByClause = {
       val maybeSimilarityCol = maybeWord.map { _ => SQLSyntax.createUnsafely(similarityCol) }
       val orderStmts = maybeSimilarityCol.toList ++ sortBy.map { sortByStr =>
-        val col = rd.column(sortByStr.slice(1, sortByStr.length))
+        val colName = StringHelpers.camelToSnakeCase(sortByStr.slice(1, sortByStr.length))
+        val col = rd.column(colName)
         sortByStr.slice(0, 1) match {
           case "+" => sqls"$col ASC"
           case "-" => sqls"$col DESC"

--- a/apps/rule-manager/app/model/CreateRuleForm.scala
+++ b/apps/rule-manager/app/model/CreateRuleForm.scala
@@ -37,7 +37,8 @@ object CreateRuleForm {
       "ignore" -> boolean,
       "notes" -> optional(text()),
       "forceRedRule" -> optional(boolean),
-      "advisoryRule" -> optional(boolean)
+      "advisoryRule" -> optional(boolean),
+      "externalId" -> optional(text())
     )(CreateRuleForm.apply)(CreateRuleForm.unapply)
   )
 }
@@ -52,5 +53,6 @@ case class CreateRuleForm(
     ignore: Boolean,
     notes: Option[String] = None,
     forceRedRule: Option[Boolean] = None,
-    advisoryRule: Option[Boolean] = None
+    advisoryRule: Option[Boolean] = None,
+    externalId: Option[String] = None
 )

--- a/apps/rule-manager/app/model/UpdateRuleForm.scala
+++ b/apps/rule-manager/app/model/UpdateRuleForm.scala
@@ -35,7 +35,8 @@ object UpdateRuleForm {
       "category" -> optional(text()),
       "tags" -> list(number()),
       "description" -> optional(text()),
-      "advisoryRule" -> optional(boolean)
+      "advisoryRule" -> optional(boolean),
+      "externalId" -> optional(text())
     )(UpdateRuleForm.apply)(UpdateRuleForm.unapply)
   )
 }
@@ -47,5 +48,6 @@ case class UpdateRuleForm(
     category: Option[String] = None,
     tags: List[Int],
     description: Option[String] = None,
-    advisoryRule: Option[Boolean] = None
+    advisoryRule: Option[Boolean] = None,
+    externalId: Option[String] = None
 )

--- a/apps/rule-manager/app/utils/StringHelpers.scala
+++ b/apps/rule-manager/app/utils/StringHelpers.scala
@@ -1,0 +1,10 @@
+package utils
+
+object StringHelpers {
+  def camelToSnakeCase(name: String) = "[A-Z\\d]".r.replaceAllIn(
+    name,
+    { m =>
+      "_" + m.group(0).toLowerCase()
+    }
+  )
+}

--- a/apps/rule-manager/client/src/ts/components/RuleContent.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleContent.tsx
@@ -47,13 +47,6 @@ export const ruleTypeOptions: RuleTypeOption[] = [
 	},
 ];
 
-const formDisplayRules = (ruleType: RuleType) => ({
-	displayDescription: ruleType !== 'dictionary',
-	displayDattern: ruleType !== 'dictionary' && ruleType !== 'languageToolCore',
-	displayDeplacement:
-		ruleType !== 'dictionary' && ruleType !== 'languageToolCore',
-});
-
 export const RuleContent = ({
 	ruleData,
 	ruleFormData,

--- a/apps/rule-manager/client/src/ts/components/RuleContent.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleContent.tsx
@@ -47,6 +47,13 @@ export const ruleTypeOptions: RuleTypeOption[] = [
 	},
 ];
 
+const formDisplayRules = (ruleType: RuleType) => ({
+	displayDescription: ruleType !== 'dictionary',
+	displayDattern: ruleType !== 'dictionary' && ruleType !== 'languageToolCore',
+	displayDeplacement:
+		ruleType !== 'dictionary' && ruleType !== 'languageToolCore',
+});
+
 export const RuleContent = ({
 	ruleData,
 	ruleFormData,
@@ -72,7 +79,14 @@ export const RuleContent = ({
 	};
 
 	const patternErrors = getErrorPropsForField('pattern', validationErrors);
-	const isDictionaryRule = ruleFormData.ruleType === 'dictionary';
+	const idErrors = getErrorPropsForField('externalId', validationErrors);
+	const { ruleType } = ruleFormData;
+	const displayDescription = ruleType !== 'dictionary';
+	const displayPattern =
+		ruleType !== 'dictionary' && ruleType !== 'languageToolCore';
+	const displayReplacement =
+		ruleType !== 'dictionary' && ruleType !== 'languageToolCore';
+	const displayExternalId = ruleType === 'languageToolCore';
 
 	return (
 		<RuleFormSection
@@ -89,7 +103,7 @@ export const RuleContent = ({
 		>
 			<LineBreak />
 			<EuiFlexItem>
-				{!isDictionaryRule && (
+				{displayDescription && (
 					<EuiFormRow
 						label={
 							<div>
@@ -115,7 +129,6 @@ export const RuleContent = ({
 						}
 						helpText="What will the users see in Composer?"
 						fullWidth={true}
-						isDisabled={isDictionaryRule}
 					>
 						{!showMarkdownPreview ? (
 							<EuiTextArea
@@ -153,30 +166,50 @@ export const RuleContent = ({
 						display: flex;
 						gap: 1rem;
 						align-items: flex-end;
+						white-space: nowrap;
 					`}
 				/>
 				<EuiSpacer size="s" />
-				<EuiFormRow
-					label={<Label text="Pattern" required={true} />}
-					fullWidth={true}
-					{...patternErrors}
-				>
-					<TextField
-						value={ruleFormData.pattern || ''}
-						onChange={(_) =>
-							partiallyUpdateRuleData({ pattern: _.target.value })
-						}
-						required={true}
+				{displayExternalId && (
+					<EuiFormRow
+						label={<Label text="LanguageTool ID" required={true} />}
+						helpText="The ID of the built-in LanguageTool rule"
+						fullWidth={true}
+						{...idErrors}
+					>
+						<TextField
+							value={ruleFormData.externalId || ''}
+							onChange={(_) =>
+								partiallyUpdateRuleData({ externalId: _.target.value })
+							}
+							required={true}
+							fullWidth={true}
+							{...patternErrors}
+						/>
+					</EuiFormRow>
+				)}
+				{displayPattern && (
+					<EuiFormRow
+						label={<Label text="Pattern" required={true} />}
 						fullWidth={true}
 						{...patternErrors}
-					/>
-				</EuiFormRow>
-				{!isDictionaryRule && (
+					>
+						<TextField
+							value={ruleFormData.pattern || ''}
+							onChange={(_) =>
+								partiallyUpdateRuleData({ pattern: _.target.value })
+							}
+							required={true}
+							fullWidth={true}
+							{...patternErrors}
+						/>
+					</EuiFormRow>
+				)}
+				{displayReplacement && (
 					<EuiFormRow
 						label="Replacement"
 						helpText="What is the ideal term as per the house style?"
 						fullWidth={true}
-						isDisabled={isDictionaryRule}
 					>
 						<EuiFieldText
 							value={ruleFormData.replacement || ''}

--- a/apps/rule-manager/client/src/ts/components/RuleContent.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleContent.tsx
@@ -34,12 +34,16 @@ export const ruleTypeOptions: RuleTypeOption[] = [
 		label: 'Regex',
 	},
 	{
+		id: 'dictionary',
+		label: 'Dictionary',
+	},
+	{
 		id: 'languageToolXML',
 		label: 'LanguageTool',
 	},
 	{
-		id: 'dictionary',
-		label: 'Dictionary',
+		id: 'languageToolCore',
+		label: 'LT built-in',
 	},
 ];
 

--- a/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRule.ts
@@ -26,6 +26,7 @@ export type BaseRule = {
 	updatedBy: string;
 	updatedAt: string;
 	id?: number;
+	externalId?: string;
 	isArchived: boolean;
 	isPublished: boolean;
 	hasUnpublishedChanges: boolean;

--- a/apps/rule-manager/client/src/ts/components/table/PaginatedRulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/table/PaginatedRulesTable.tsx
@@ -26,6 +26,7 @@ import { TagsContext } from '../context/tags';
 import { EuiDataGridToolBarVisibilityOptions } from '@elastic/eui/src/components/datagrid/data_grid_types';
 import { useEuiFontSize } from '@elastic/eui/src/global_styling/mixins/_typography';
 import { useNavigate } from 'react-router-dom';
+import { ruleTypeOptions } from '../RuleContent';
 
 type EditRuleButtonProps = {
 	editIsEnabled: boolean;
@@ -121,6 +122,12 @@ const TestRule = ({
 };
 
 const columns: EuiDataGridColumn[] = [
+	{
+		id: 'ruleType',
+		display: 'Rule type',
+		isSortable: true,
+		initialWidth: 120,
+	},
 	{
 		id: 'description',
 		display: 'Description',
@@ -338,7 +345,15 @@ export const PaginatedRulesTable = ({
 				if (!rule || isLoading) {
 					return <EuiSkeletonText />;
 				}
-				return getRuleAtRowIndex(rowIndex)[columnId as keyof BaseRule] || '';
+
+				const value =
+					getRuleAtRowIndex(rowIndex)[columnId as keyof BaseRule] || '';
+
+				if (columnId === 'ruleType') {
+					return ruleTypeOptions.find(({ id }) => id === value)?.label ?? '';
+				}
+
+				return value;
 			},
 		[ruleData, isLoading],
 	);

--- a/apps/rule-manager/conf/evolutions/default/16.sql
+++ b/apps/rule-manager/conf/evolutions/default/16.sql
@@ -1,0 +1,7 @@
+-- !Ups
+
+UPDATE rules_draft SET description = external_id WHERE rule_type = 'languageToolCore'
+
+-- !Downs
+
+UPDATE rules_draft SET description = '' WHERE rule_type = 'languageToolCore'

--- a/apps/rule-manager/test/db/DbRuleDraftSpec.scala
+++ b/apps/rule-manager/test/db/DbRuleDraftSpec.scala
@@ -323,6 +323,44 @@ class DbRuleDraftSpec extends RuleFixture with Matchers with DBTest {
     dbRule should not be (null)
   }
 
+  it should s"store external IDs when creating rules of type ${RuleType.languageToolCore}" in {
+    implicit session =>
+      val formRule = CreateRuleForm(
+        ruleType = "languageToolCore",
+        pattern = None,
+        replacement = None,
+        category = None,
+        tags = None,
+        description = None,
+        ignore = false,
+        notes = None,
+        forceRedRule = None,
+        advisoryRule = None,
+        externalId = Some("EXTERNAL_ID")
+      )
+      val dbRule = DbRuleDraft.createFromFormRule(formRule, user = "test.user")
+      dbRule.toOption.get.externalId shouldBe Some("EXTERNAL_ID")
+  }
+
+  it should s"generate a friendly placeholder for external ID when creating rules of type ${RuleType.languageToolCore}" in {
+    implicit session =>
+      val formRule = CreateRuleForm(
+        ruleType = "languageToolCore",
+        pattern = None,
+        replacement = None,
+        category = None,
+        tags = None,
+        description = None,
+        ignore = false,
+        notes = None,
+        forceRedRule = None,
+        advisoryRule = None,
+        externalId = None
+      )
+      val dbRule = DbRuleDraft.createFromFormRule(formRule, user = "test.user")
+      dbRule.toOption.get.externalId shouldBe Some("CHANGE_ME")
+  }
+
   it should "edit an existing record using a form rule, updating the user and updated datetime" in {
     implicit session =>
       val existingRule = DbRuleDraft
@@ -340,6 +378,32 @@ class DbRuleDraftSpec extends RuleFixture with Matchers with DBTest {
 
       dbRule.id should be(Some(existingId))
       dbRule.pattern should be(Some("NewString"))
+      dbRule.updatedBy should be("another.user")
+      dbRule.updatedAt.toInstant.toEpochMilli should be >= existingRule.updatedAt.toInstant.toEpochMilli
+  }
+
+  it should s"update external IDs for rules of type ${RuleType.languageToolCore}" in {
+    implicit session =>
+      val existingRule = DbRuleDraft
+        .create(
+          ruleType = "languageToolCore",
+          externalId = Some("EXTERNAL_ID"),
+          user = "test.user",
+          ignore = false
+        )
+        .get
+      val existingId = existingRule.id.get
+      val formRule = UpdateRuleForm(
+        ruleType = Some("languageToolCore"),
+        externalId = Some("EXTERNAL_ID_UPDATE"),
+        tags = List.empty
+      )
+
+      val dbRule =
+        DbRuleDraft.updateFromFormRule(formRule, existingId, "another.user").getOrElse(null)
+
+      dbRule.id should be(Some(existingId))
+      dbRule.externalId should be(Some("EXTERNAL_ID_UPDATE"))
       dbRule.updatedBy should be("another.user")
       dbRule.updatedAt.toInstant.toEpochMilli should be >= existingRule.updatedAt.toInstant.toEpochMilli
   }

--- a/apps/rule-manager/test/db/DbRuleDraftSpec.scala
+++ b/apps/rule-manager/test/db/DbRuleDraftSpec.scala
@@ -8,6 +8,7 @@ import scalikejdbc._
 import play.api.mvc.Results.NotFound
 
 import java.time.OffsetDateTime
+import service.RuleManager.RuleType
 
 class DbRuleDraftSpec extends RuleFixture with Matchers with DBTest {
 


### PR DESCRIPTION
## What does this change?

Adds proper support for reading and writing `languageToolCore` rules — rules which come bundled with LanguageTool. They are enabled by adding a rule with a LanguageTool ID. The total list of rules is available in a [reference spreadsheet](https://docs.google.com/spreadsheets/d/1bLCD7CrGMDAuuk76e0MTF1-DUNgmXrvTc1d5n2UMZR8/edit?gid=1482142974#gid=1482142974) — many (most?) are also available in the [LanguageTool XML for `en`](https://raw.githubusercontent.com/languagetool-org/languagetool/refs/heads/master/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml) and [en-GB](https://github.com/languagetool-org/languagetool/blob/master/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-GB/grammar.xml), although I think some rules are also defined exclusively [in code](https://github.com/languagetool-org/languagetool/tree/master/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en), too.

Support for reading and writing rules means:

- Listing the ruleType property in the table, with filtering/sorting
- Copying the 'ID' property into the 'description' for existing rules (there are only a dozen or so in production), making them identifiable (at the moment, there are blank rows for these rules, which makes them impossible to identify without selecting them.)

![built-in rules](https://github.com/user-attachments/assets/79c66792-58b7-4046-8865-b1ce39096f88)

- Permitting create and update operations for these rules in the relevant form. Note that I've autopopulated the ID field with 'CHANGE_ME' to avoid a UUID appearing when the rule is first created on the server. (We could also leave it blank?)

![create](https://github.com/user-attachments/assets/2a3d9b8e-5a66-4863-bf81-609e2c857f63)

## How to test

- The automated tests should pass. I've added tests for create and update ops.
- Try working through the list of features above. Everything should work as expected.

## How can we measure success?

More editorial control over these sorts of rules.