### PR TITLE
Bump languagetool to 6.4

### DIFF
--- a/apps/checker/app/matchers/LanguageToolMatcher.scala
+++ b/apps/checker/app/matchers/LanguageToolMatcher.scala
@@ -1,8 +1,10 @@
 package matchers
 
 import com.gu.typerighter.model.{Category, LTRule, LTRuleXML, RuleMatch}
+
 import java.io.File
 import org.languagetool._
+import org.languagetool.language.{BritishEnglish}
 import org.languagetool.rules.spelling.morfologik.suggestions_ordering.SuggestionsOrdererConfig
 import org.languagetool.rules.{Rule => LanguageToolRule}
 import play.api.Logging
@@ -13,7 +15,8 @@ import scala.concurrent.{ExecutionContext, Future}
 import org.languagetool.rules.patterns.PatternRuleLoader
 import org.languagetool.rules.patterns.AbstractPatternRule
 import utils.{Matcher, MatcherCompanion}
-import scala.xml.{XML, Attribute, Null, Text}
+
+import scala.xml.{Attribute, Null, Text, XML}
 import scala.util.Try
 import scala.util.Success
 import scala.util.Failure
@@ -111,7 +114,12 @@ class LanguageToolFactory(
         val loader = new PatternRuleLoader()
         getXMLStreamFromLTRules(rules) flatMap { xmlStream =>
           {
-            Try(loader.getRules(xmlStream, "languagetool-generated-xml").asScala.toList)
+            Try(
+              loader
+                .getRules(xmlStream, "languagetool-generated-xml", new BritishEnglish())
+                .asScala
+                .toList
+            )
           }
         }
       }

--- a/apps/checker/test/scala/matchers/LanguageToolMatcherTest.scala
+++ b/apps/checker/test/scala/matchers/LanguageToolMatcherTest.scala
@@ -218,7 +218,7 @@ class LanguageToolMatcherTest extends AsyncFlatSpec with Matchers {
     val eventuallyMatches = instance.check(request)
 
     val expectedMatchMessages =
-      List("Did you mean <suggestion>fewer</suggestion>? The noun tests is countable.")
+      List("Did you mean <suggestion>fewer</suggestion>? The noun \"tests\" is countable.")
     val expectedMatchCategoryIds = List("GRAMMAR")
     eventuallyMatches map { matches =>
       matches.map(_.message) shouldBe expectedMatchMessages

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ ThisBuild / scalacOptions := Seq(
 // See https://support.snyk.io/hc/en-us/articles/9590215676189-Deeply-nested-Scala-projects-have-dependencies-truncated
 ThisBuild / asciiGraphWidth := 999999999
 
-val languageToolVersion = "6.0"
+val languageToolVersion = "6.1"
 val awsSdkVersion = "1.12.749"
 val capiModelsVersion = "17.5.1"
 val capiClientVersion = "19.2.1"

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ ThisBuild / scalacOptions := Seq(
 // See https://support.snyk.io/hc/en-us/articles/9590215676189-Deeply-nested-Scala-projects-have-dependencies-truncated
 ThisBuild / asciiGraphWidth := 999999999
 
-val languageToolVersion = "6.3"
+val languageToolVersion = "6.4"
 val awsSdkVersion = "1.12.749"
 val capiModelsVersion = "17.5.1"
 val capiClientVersion = "19.2.1"

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ ThisBuild / scalacOptions := Seq(
 // See https://support.snyk.io/hc/en-us/articles/9590215676189-Deeply-nested-Scala-projects-have-dependencies-truncated
 ThisBuild / asciiGraphWidth := 999999999
 
-val languageToolVersion = "6.1"
+val languageToolVersion = "6.3"
 val awsSdkVersion = "1.12.749"
 val capiModelsVersion = "17.5.1"
 val capiClientVersion = "19.2.1"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This bumps [`languagetool`](https://www.google.com/search?q=languagetool+github&rlz=1C5CHFA_enGB1056GB1056&oq=languagetool+github&gs_lcrp=EgZjaHJvbWUyCQgAEEUYORiABDIHCAEQABiABDIHCAIQABiABDIHCAMQABiABDIHCAQQABiABDIGCAUQRRg8MgYIBhBFGDwyBggHEEUYPNIBCDI1ODJqMGo3qAIAsAIA&sourceid=chrome&ie=UTF-8) to version 6.4. There are a few high priority vulnerabilities in our sbt dependency, and some of them are sub-dependencies of `languagetool`.

The newest `languagetool` version [according to maven is 6.6](https://mvnrepository.com/artifact/org.languagetool/languagetool-core), but sbt wasn't able to find it. I've only bumped to Version `6.4` because `6.5` introduced a fiddly-looking error (though it compiles successfully) and I'm hoping that `6.4` will be sufficient to solve some of our dependency woes.

`languagetool` does not appear to be semantically versioned as there were breaking changes in `6.1` and `6.3` as well as `6.5`. I've had to make a couple of small changes to address the changes in the `6.1` and `6.3`, namely:
- Updating the grammar used in a test
- Providing a language to `getRules`

It's definitely worth testing this PR in CODE Composer and seeing if checks from our rule manage show up successfully!

I'd be especially keen to check some dictionary rules, because they rely on some slightly [arcane workarounds](https://github.com/guardian/typerighter/pull/449), and undocumented changes in the structure of `languagetool` could affect them.

## How to test

1. Deploy this branch to CODE.
2. Find a couple of rules representing each rule type in the [CODE rule manager](https://manager.typerighter.code.dev-gutools.co.uk/)(i.e. Dictionary, LT Built-In, Regex).
3. Test those rules in CODE Composer. Is the Checker service working as intended, and surfacing them in Composer? E.g. do you see a red or orange underline where you would expect to?

I can advise on any aspects of testing Typerighter if you're not familiar with the tool, please reach out if you require some help
