### PR TITLE
docker-compose -> docker compose

### DIFF
--- a/script/citest
+++ b/script/citest
@@ -32,11 +32,11 @@ setupTestDeps() {
   nvm install
   nvm use
 
-  docker-compose up -d
+  docker compose up -d
   # Ensure containers are up
   for ATTEMPT in $(seq 1 $MAX_DB_ATTEMPTS)
   do
-    HEALTH_STATUS=$(docker inspect --format "{{json .State.Health }}" $(docker-compose ps -q) | jq .Status | tr -d '\n')
+    HEALTH_STATUS=$(docker inspect --format "{{json .State.Health }}" $(docker compose ps -q) | jq .Status | tr -d '\n')
     echo "Start"
     echo $HEALTH_STATUS
     echo "End"
@@ -56,7 +56,7 @@ setupTestDeps() {
 }
 
 teardownTestDeps() {
-  docker-compose down
+  docker compose down
 }
 
 buildCDK() {

--- a/script/start-manager
+++ b/script/start-manager
@@ -23,12 +23,12 @@ makeChecks() {
 }
 
 setupDependencies() {
-  docker-compose up -d
+  docker compose up -d
   (cd $APP_FOLDER/rule-manager/client && npm i && npm run start &)
 }
 
 teardownDependencies() {
-  docker-compose down
+  docker compose down
   pids="$(lsof -ti:9100)"
   if [[ -n "$pids" ]]; then
     # terminates the rule manager app


### PR DESCRIPTION
## What does this change?

docker-compose -> docker compose, as the newest versions of docker have removed docker-compose.

## How to test

Run our setup scripts (e.g. `script/start`) with an up-to-date version of Docker enabled. It should work as expected.