### PR TITLE
Add cors origin for vite config to fix cors errors when running locally

### DIFF
--- a/apps/rule-manager/client/vite.config.ts
+++ b/apps/rule-manager/client/vite.config.ts
@@ -39,6 +39,9 @@ export default defineConfig({
 		origin: 'http://localhost:5173',
 		// We depend upon this port number in a few places, so fail fast if we cannot allocate it.
 		strictPort: true,
+		cors: {
+			origin: 'https://manager.typerighter.local.dev-gutools.co.uk',
+		},
 		fs: {
 			allow: ['../public/fonts', './'],
 		},


### PR DESCRIPTION
## What does this change?

https://github.com/guardian/typerighter/pull/491 broke local development, as fixing https://github.com/vitejs/vite/security/advisories/GHSA-vg6x-rcgg-rjx6 meant that is necessary to specify an origin. This PR adds the origin.

## How to test

After setting up the app, run the manager locally with `./script/start-manager`, and navigate to manager.typerighter.local.dev-gutools.co.uk. Does the app appear as expected?
