### PR TITLE
Update com.gu:simple-configuration-ssm to 5.0.2 to resolve vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,7 @@ val commonSettings = Seq(
     "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.1" % Test,
     "com.softwaremill.diffx" %% "diffx-scalatest-should" % "0.8.2" % Test,
     "org.mockito" %% "mockito-scala-scalatest" % "1.17.30",
-    "com.gu" %% "simple-configuration-ssm" % "1.6.4",
+    "com.gu" %% "simple-configuration-ssm" % "5.0.2",
     "com.gu" %% "pan-domain-auth-play_2-9" % pandaVersion,
     "com.google.api-client" % "google-api-client" % "2.0.1",
     "com.google.apis" % "google-api-services-sheets" % "v4-rev20221216-2.0.0",


### PR DESCRIPTION
## What does this change?

We’re currently getting [a vulnerability alert for io.netty:netty-handler](https://github.com/guardian/typerighter/security/dependabot/221) that is coming from a transitive dependency of simple-configuration. This commit updates the dependency on simple-configuration to its newest version, which resolves the vulnerability by updating the transitive version to 4.1.118.Final.

## How to test

- deploy to CODE
- confirm app still works
  - TBC exactly how this check works: I plan to click around the UI a bunch
- run `sbt dependencyBrowseTree` locally, see that the transitive dependency on netty-handler is at `4.1.118.Final`, which the vulnerability alert says resolves the vulnerability