### PR TITLE
Update actions-riff-raff to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,14 +11,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
-
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
 
       - name: Setup Scala
         uses: guardian/setup-scala@v1
@@ -60,11 +56,13 @@ jobs:
         run: mv apps/rule-manager/target/rule-manager_1.0-SNAPSHOT_all.deb target/typerighter-rule-manager.deb
 
       - name: upload to riff-raff
-        uses: guardian/actions-riff-raff@v2
+        uses: guardian/actions-riff-raff@v4
         with:
           configPath: riff-raff.yaml
           projectName: Editorial Tools::Typerighter
           buildNumberOffset: 1280 # This is the last build number from TeamCity
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           contentDirectories: |
             typerighter-checker:
             - target/typerighter-checker.deb


### PR DESCRIPTION
## What does this change?

This PR updates [actions-riff-raff](https://github.com/guardian/actions-riff-raff/) to [v4](https://github.com/guardian/actions-riff-raff/releases/tag/v4.0.0). V4 is more secure, because the aws credentials are only available to the actions-riff-raff step itself, not to the whole workflow. Also, you get a handy comment on the PR for deploying to CODE.

## How to test

- [X] does Riff Raff run without error on this PR?
- [X] does it add a nice comment?