### PR TITLE
Fix prout

### DIFF
--- a/apps/checker/app/controllers/HomeController.scala
+++ b/apps/checker/app/controllers/HomeController.scala
@@ -5,6 +5,7 @@ import com.gu.typerighter.controllers.PandaAuthController
 import com.gu.typerighter.lib.CommonConfig
 import play.api.libs.json.Json
 import services._
+import typerighter.BuildInfo
 
 /** The controller for the index pages.
   */
@@ -32,7 +33,7 @@ class HomeController(
           )
         )
       } else {
-        Ok(Json.obj("healthy" -> true))
+        Ok(Json.obj("healthy" -> true, "gitCommitId" -> BuildInfo.gitCommitId))
       }
     }
   }

--- a/apps/checker/app/controllers/HomeController.scala
+++ b/apps/checker/app/controllers/HomeController.scala
@@ -29,7 +29,8 @@ class HomeController(
         InternalServerError(
           Json.obj(
             "healthy" -> false,
-            "error" -> errorMsg
+            "error" -> errorMsg,
+            "gitCommitId" -> BuildInfo.gitCommitId
           )
         )
       } else {

--- a/apps/rule-manager/app/controllers/HomeController.scala
+++ b/apps/rule-manager/app/controllers/HomeController.scala
@@ -41,7 +41,8 @@ class HomeController(
         InternalServerError(
           Json.obj(
             "healthy" -> false,
-            "error" -> e.getMessage()
+            "error" -> e.getMessage(),
+            "gitCommitId" -> BuildInfo.gitCommitId
           )
         )
     }


### PR DESCRIPTION
## What does this change?

This PR fixes [Prout](https://github.com/guardian/prout) on this repo. There are two commits on the PR:

### 3d1043e2 Add commit ID to Checker healthcheck to fix prout

As of [pull 465](https://github.com/guardian/typerighter/pull/465), prout is configured to check both Rule Manager and Checker when pulls are merged. However, that pull only added the commit ID to Rule Manager, meaning every PR currently gets tagged by Prout with `Overdue on Checker`. (Probably it wasn’t added because of the caching that used to be on Checker, as described in [pull 466](https://github.com/guardian/typerighter/pull/466), though the prout configuration probably should’ve been removed for that URL.)

Anyway, the caching was removed in [pull 468](https://github.com/guardian/typerighter/pull/468), so we can just add the commit ID to the Checker healthcheck to fix prout: that’s what this commit does.

### 4433c5d9 origin/fix-prout Add commit ID to healthcheck error responses

When there’s an error in the healthcheck, I reckon we still want to know what version is deployed and want prout to return quickly telling us to check our changes rather than wait until it times out.

## How to test

- deploy to CODE
- visit https://checker.typerighter.code.dev-gutools.co.uk/healthcheck and confirm the commit ID from the PR is visible
- after merge, confirm prout removes all the Overdue on Checker labels
  - also check [the status page for this app](https://prout-bot.herokuapp.com/view/guardian/typerighter) and see that it can see the newest commit for checker as well as rule manager