### PR TITLE
Run CI on pull_request trigger, not push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,10 @@ name: Typerighter CI
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
+  push: # Do not rely on `push` for PR CI - see https://github.com/guardian/mobile-apps-api/pull/2741#issuecomment-1777653733
+    branches:
+      - main # Optimal for GHA workflow caching - see https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
 
 jobs:
   CI:


### PR DESCRIPTION
## What does this change?

When running on the `push` trigger, CI can provide misleading info in the Github UI that makes it look like it has passed when in fact there are failures. (See https://github.com/guardian/mobile-apps-api/pull/2741#issuecomment-1777653733 and https://github.com/guardian/mobile-apps-api/pull/2760 for more details.)

This PR updates the CI to instead run on `pull_request`, except for the main branch.

## How to test

- see that the CI on this PR runs on the `pull_request` trigger rather than the `push` trigger
- after merge, confirm that the CI still runs on `push` on main