### PR TITLE
Update scala and sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sys.process._
 
 name := "typerighter"
 ThisBuild / organization := "com.gu"
-ThisBuild / scalaVersion := "2.13.11"
+ThisBuild / scalaVersion := "2.13.16"
 ThisBuild / version := "1.0-SNAPSHOT"
 ThisBuild / scalacOptions := Seq(
   "-encoding",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.9.9
+sbt.version=1.10.11
 


### PR DESCRIPTION
## What does this change?

This PR cherry-picks out the scala and sbt updates from https://github.com/guardian/typerighter/pull/509, as the CI has failed on that PR and these dependencies seem most likely to be easy to update.

## How to test

- deploy to CODE
- visit https://checker.typerighter.code.dev-gutools.co.uk/ and https://manager.typerighter.code.dev-gutools.co.uk/ and click around a bit, make sure everything seems to work ok