### PR TITLE
Update languagetool to fix vulnerability from protobuf-java

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java corretto-17.0.13
+java corretto-11.0.17.8.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java corretto-11.0.17.8.1
+java corretto-17.0.13

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ ThisBuild / scalacOptions := Seq(
 // See https://support.snyk.io/hc/en-us/articles/9590215676189-Deeply-nested-Scala-projects-have-dependencies-truncated
 ThisBuild / asciiGraphWidth := 999999999
 
-val languageToolVersion = "6.4"
+val languageToolVersion = "6.5"
 val awsSdkVersion = "1.12.782"
 val capiModelsVersion = "17.5.1"
 val capiClientVersion = "19.2.1"

--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,7 @@ val commonSettings = Seq(
   dependencyOverrides ++= jackson,
   // Necessary to override json to resolve vulnerabilities introduced by languagetool-core
   dependencyOverrides ++= Seq("org.json" % "json" % "20231013"),
+  dependencyOverrides ++= Seq("com.google.guava" % "guava" % "32.1.1-jre"),
   libraryDependencies ++= Seq(
     "com.amazonaws" % "aws-java-sdk-secretsmanager" % awsSdkVersion,
     "net.logstash.logback" % "logstash-logback-encoder" % "7.2",

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ ThisBuild / scalacOptions := Seq(
 // See https://support.snyk.io/hc/en-us/articles/9590215676189-Deeply-nested-Scala-projects-have-dependencies-truncated
 ThisBuild / asciiGraphWidth := 999999999
 
-val languageToolVersion = "6.6"
+val languageToolVersion = "6.5"
 val awsSdkVersion = "1.12.782"
 val capiModelsVersion = "17.5.1"
 val capiClientVersion = "19.2.1"

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ ThisBuild / scalacOptions := Seq(
 // See https://support.snyk.io/hc/en-us/articles/9590215676189-Deeply-nested-Scala-projects-have-dependencies-truncated
 ThisBuild / asciiGraphWidth := 999999999
 
-val languageToolVersion = "6.5"
+val languageToolVersion = "6.6"
 val awsSdkVersion = "1.12.782"
 val capiModelsVersion = "17.5.1"
 val capiClientVersion = "19.2.1"


### PR DESCRIPTION
## What does this change?

Dependabot has flagged [a vulnerability](https://github.com/guardian/typerighter/security/dependabot/212) in a transitive dependency this app has on protobuf-java, which comes via languagetool. Updating languagetool to 6.5 raises the version of protobuf-java that we depend on to 3.25.5, which is no longer vulnerable.

## How to test

- confirm CI passes
- deploy to CODE, click around the rule manager and checker UIs, confirm nothing is obviously broken