### PR TITLE
Bumps AMI recipes to Ubuntu 22 versions

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -19,10 +19,10 @@ deployments:
       prependStackToCloudFormationStackName: false
       amiParametersToTags:
         AMITyperighterchecker:
-          Recipe: editorial-tools-focal-java11-ngrams-ARM-cdk-base
+          Recipe: editorial-tools-jammy-java11-ngrams-ARM-cdk-base
           BuiltBy: amigo
         AMITyperighterrulemanager:
-          Recipe: editorial-tools-focal-java11-ARM-WITH-cdk-base
+          Recipe: editorial-tools-jammy-java11
           BuiltBy: amigo
       amiEncrypted: true
       templateStagePaths:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As described, addressing https://github.com/guardian/typerighter/issues/516.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
[Deployable](https://riffraff.gutools.co.uk/deployment/view/89e26325-bdfe-4f05-b3f0-67da21eda7c4) and testable on CODE.

Check [Composer plugin](https://composer.code.dev-gutools.co.uk/) and [rule-manager](https://manager.typerighter.code.dev-gutools.co.uk/) service. 