### PR TITLE
Update jackson dependency to remove vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,16 +38,6 @@ def javaVersionNumber = {
   IO.read(new File(".java-version"))
 }
 
-val jackson = {
-  val version = "2.14.2"
-  Seq(
-    "com.fasterxml.jackson.module" %% "jackson-module-scala" % version,
-    "com.fasterxml.jackson.core" % "jackson-core" % version,
-    "com.fasterxml.jackson.core" % "jackson-databind" % version,
-    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % version
-  )
-}
-
 val commonSettings = Seq(
   Test / fork := false, // Enables attaching debugger in tests
   buildInfoPackage := "typerighter",
@@ -62,8 +52,6 @@ val commonSettings = Seq(
       BuildInfoKey.constant("gitCommitId", buildInfo.revision)
     )
   },
-  // Necessary to override jackson versions due to AWS and Play incompatibility
-  dependencyOverrides ++= jackson,
   // Necessary to override json to resolve vulnerabilities introduced by languagetool-core
   dependencyOverrides ++= Seq("org.json" % "json" % "20231013"),
   dependencyOverrides ++= Seq("com.google.guava" % "guava" % "32.1.1-jre"),


### PR DESCRIPTION
## What does this change?

This PR updates the app’s transitive dependency on jackson past 2.15.0 to resolve [a vulnerability reported by
dependabot](https://github.com/guardian/typerighter/security/dependabot/244).

Removing the outdated jackson overrides causes the AWS SDK’s transitive dependency on jackson (at 2.17.2) to evict play’s dependency (currently at 2.14.3).

We know that sometimes there are runtime errors (not accompanied by compile-time errors) when updating jackson versions, so we should test this thoroughly in CODE to make sure it’s not going to break in PROD.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
