### PR TITLE
Add sbt check for incompatible versions of jackson-module-scala and jackson-databind

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,9 +98,9 @@ val commonSettings = Seq(
       )
     }
     jacksonModules
-  }
+  },
+  (Compile / compile) := ((Compile / compile) dependsOn checkJackson).value
 )
-
 val commonLib = (project in file(s"$appsFolder/common-lib"))
   .enablePlugins(BuildInfoPlugin)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,12 @@ val commonSettings = Seq(
       .map(_.revision.split('.').take(2).mkString("."))
       .toSet
     if (jacksonVersions.size > 1) {
-      sys.error("Found conflicting jackson-databind and jackson-module scala versions!")
+      sys.error(
+        s"""Found conflicting jackson-databind and jackson-module scala versions, which will break at runtime:
+
+      |${jacksonModules.map(m => s"- ${m.name}: ${m.revision}").mkString("\n")}
+      """.stripMargin
+      )
     }
     jacksonModules
   }

--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,8 @@ def javaVersionNumber = {
   IO.read(new File(".java-version"))
 }
 
+val checkJackson = taskKey[Vector[ModuleID]]("Checks jackson versions")
+
 val commonSettings = Seq(
   Test / fork := false, // Enables attaching debugger in tests
   buildInfoPackage := "typerighter",
@@ -80,7 +82,18 @@ val commonSettings = Seq(
     // dependencies.
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.17.2"
   ),
-  libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+  libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always,
+  checkJackson := {
+    val jacksonModules = update.value.allModules
+      .filter(m => m.name == "jackson-databind" || m.name.startsWith("jackson-module-scala"))
+    val jacksonVersions = jacksonModules
+      .map(_.revision.split('.').take(2).mkString("."))
+      .toSet
+    if (jacksonVersions.size > 1) {
+      sys.error("Found conflicting jackson-databind and jackson-module scala versions!")
+    }
+    jacksonModules
+  }
 )
 
 val commonLib = (project in file(s"$appsFolder/common-lib"))

--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ val commonSettings = Seq(
       .toSet
     if (jacksonVersions.size > 1) {
       sys.error(
-        s"""Found conflicting jackson-databind and jackson-module scala versions, which will break at runtime:
+        s"""Found conflicting jackson-databind and jackson-module-scala versions, which will break at runtime:
 
       |${jacksonModules.map(m => s"- ${m.name}: ${m.revision}").mkString("\n")}
       """.stripMargin


### PR DESCRIPTION
## What does this change?

Recently, [I tried to update the version of jackson used by this app in a way that updated jackson-databind but didn’t update jackson-module-scala](https://github.com/guardian/typerighter/pull/519/commits/697e0506a6b60e66d4473f6c30fa217727306702). This [caused a runtime check in the latter to fail when the tests were run in CI](https://github.com/guardian/typerighter/pull/519#issuecomment-3088606212). However, it’d be nice to be able to fail earlier, since we always know those versions are incompatible: this is helpful for users locally and also (if we add it to more projects) helpful in projects whose tests don’t exercise the jackson-module-scala code.

This PR adds a new sbt task that errors if incomptaible versions of jackson-databind and jackson-module-scala are used (i.e., [ones that differ in the two leading version digits](https://github.com/FasterXML/jackson-module-scala/blob/a386101982edb996fb04e42e8631c34c2b707793/src/main/scala/com/fasterxml/jackson/module/scala/JacksonModule.scala#L59)). To make sure checkJackson is run without people needing to remember it, it also sets it as a dependency of the compile task: any time compile is run, checkJackson will be run first.

## How to test

I pushed a revert commit to this PR to get back to the broken state from https://github.com/guardian/typerighter/pull/519, resulting in [this CI run](https://github.com/guardian/typerighter/actions/runs/16374665612/job/46271467362?pr=520). Happily, it failed (before running any tests!) with a clear error message:

> [error] java.lang.RuntimeException: Found conflicting jackson-databind and jackson-module scala versions, which will break at runtime:
> [error] 
> [error] - jackson-databind: 2.17.2
> [error] - jackson-module-scala_2.13: 2.14.3
> [error]       
> [error] 	at scala.sys.package$.error(package.scala:30)
> [error] 	at $0f6a2a91e7c769359234$.$anonfun$commonSettings$8(build.sbt:92)
> [error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
> [error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:63)
> [error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:69)
> [error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:283)
> [error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:24)
> [error] 	at sbt.Execute.work(Execute.scala:292)
> [error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:283)
> [error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
> [error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:65)
> [error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
> [error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
> [error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
> [error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
> [error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
> [error] 	at java.base/java.lang.Thread.run(Thread.java:829)
> [error] java.lang.RuntimeException: Found conflicting jackson-databind and jackson-module scala versions, which will break at runtime:
> [error] 
> [error] - jackson-databind: 2.17.2
> [error] - jackson-module-scala_2.13: 2.14.3
> [error]       
> [error] 	at scala.sys.package$.error(package.scala:30)
> [error] 	at $0f6a2a91e7c769359234$.$anonfun$commonSettings$8(build.sbt:92)
> [error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
> [error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:63)
> [error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:69)
> [error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:283)
> [error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:24)
> [error] 	at sbt.Execute.work(Execute.scala:292)
> [error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:283)
> [error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
> [error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:65)
> [error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
> [error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
> [error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
> [error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
> [error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
> [error] 	at java.base/java.lang.Thread.run(Thread.java:829)
> [error] java.lang.RuntimeException: Found conflicting jackson-databind and jackson-module scala versions, which will break at runtime:
> [error] 
> [error] - jackson-databind: 2.17.2
> [error] - jackson-module-scala_2.13: 2.14.3
> [error]       
> [error] 	at scala.sys.package$.error(package.scala:30)
> [error] 	at $0f6a2a91e7c769359234$.$anonfun$commonSettings$8(build.sbt:92)
> [error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
> [error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:63)
> [error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:69)
> [error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:283)
> [error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:24)
> [error] 	at sbt.Execute.work(Execute.scala:292)
> [error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:283)
> [error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
> [error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:65)
> [error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
> [error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
> [error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
> [error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
> [error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
> [error] 	at java.base/java.lang.Thread.run(Thread.java:829)
> [error] (commonLib / checkJackson) Found conflicting jackson-databind and jackson-module scala versions, which will break at runtime:
> [error] 
> [error] - jackson-databind: 2.17.2
> [error] - jackson-module-scala_2.13: 2.14.3
> [error]       
> [error] (checker / checkJackson) Found conflicting jackson-databind and jackson-module scala versions, which will break at runtime:
> [error] 
> [error] - jackson-databind: 2.17.2
> [error] - jackson-module-scala_2.13: 2.14.3
> [error]       
> [error] (rule-manager / checkJackson) Found conflicting jackson-databind and jackson-module scala versions, which will break at runtime:
> [error] 
> [error] - jackson-databind: 2.17.2
> [error] - jackson-module-scala_2.13: 2.14.3

I think no further testing should be required, beyond seeing that CI is now succeeding on this PR.