### PR TITLE
Fix lz4 and okhttp3 vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,8 @@ ThisBuild / asciiGraphWidth := 999999999
 
 val languageToolVersion = "6.7"
 val awsSdkVersion = "2.36.3"
-val capiModelsVersion = "17.5.1"
-val capiClientVersion = "19.2.1"
+val capiModelsVersion = "34.0.0"
+val capiClientVersion = "40.0.0"
 val pandaVersion = "13.0.0"
 val circeVersion = "0.14.1"
 val scalikejdbcVersion = scalikejdbc.ScalikejdbcBuildInfo.version
@@ -79,7 +79,7 @@ val commonSettings = Seq(
     // The jackson-module-scala version below must be kept in sync with the
     // transitive dependency on jackson-databind introduced by our AWS
     // dependencies.
-    "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.0"
+    "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.0",
   ),
   libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always,
   checkJackson := {
@@ -134,7 +134,21 @@ def playProject(
         s"-J-Dlogs.home=/var/log/${packageName.value}",
         s"-J-Xloggc:/var/log/${packageName.value}/gc.log"
       ),
-      commonSettings
+      commonSettings,
+      libraryDependencies ++= Seq(
+        // we use this fork of lz4-java just to fix the vulnerability issue 
+        // in the link below.  Once Play picked up a fixed version of lz4-java
+        // officially, it can be removed together with the excludeDependencies
+        // below
+        "at.yawk.lz4" % "lz4-java" % "1.8.1" % Runtime
+      ),    
+      excludeDependencies ++= Seq(
+        // https://github.com/guardian/typerighter/security/dependabot/267
+        ExclusionRule(
+          organization = "org.lz4",
+          name = "lz4-java"
+        )
+      ),
     )
 
 val checker = playProject(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Paired with @emdash-ie 

This pull request bumps the `lz4-java` and content-api-models to fix these two vulnerabilities:
- https://github.com/guardian/typerighter/security/dependabot/267
- https://github.com/guardian/typerighter/security/dependabot/266

The `lz4-java` fixes the vulnerability by redirecting the version 1.8.1 to a fork (also version 1.8.1) of the library by "yawk".  For this reason, we cannot fix it by just pulling it in as a direct dependency.  Here we followed the approach taken in https://github.com/guardian/janus-app/pull/719, where we replace the lz4 library in the debian package.

It updates the two content-api-models libraries which pull in a fixed version of `okhttp3` library.

## How to test

All test passed.  We checked the debian package locally to confirm that the "yawk" fork of `lz4-java` v1.8.1 was bundled instead of the version 1.8.0.

We ran a smoke test on CODE:
- we could edit an existing rule in manager
- we could create and publish a new rule in manager

<img width="1105" height="150" alt="Screenshot 2025-12-04 at 16 38 30" src="https://github.com/user-attachments/assets/42e19b11-b46c-4ea6-a53d-4c2e32b5f468" />

- we could run checker in composer

<img width="556" height="305" alt="Screenshot 2025-12-04 at 16 39 37" src="https://github.com/user-attachments/assets/33e8e241-508c-4905-b3b8-f75e82940312" />

## How can we measure success?

The two vulnerabilities on `typerighter` are removed from dependency vulnerabilities dashboard.
