### PR TITLE
Add resizeable panel to rules table

### DIFF
--- a/apps/rule-manager/client/src/ts/components/icons/index.ts
+++ b/apps/rule-manager/client/src/ts/components/icons/index.ts
@@ -39,6 +39,8 @@ import { icon as sortRight } from '@elastic/eui/src/components/icon/assets/sortR
 import { icon as fullScreenExit } from '@elastic/eui/src/components/icon/assets/fullScreenExit';
 import { icon as tokenString } from '@elastic/eui/src/components/icon/assets/tokenString';
 import { icon as beaker } from '@elastic/eui/src/components/icon/assets/beaker';
+import { icon as menuLeft } from '@elastic/eui/src/components/icon/assets/menuLeft';
+import { icon as menuRight } from '@elastic/eui/src/components/icon/assets/menuRight';
 
 const cachedIcons = {
 	apps,
@@ -81,6 +83,8 @@ const cachedIcons = {
 	expandMini,
 	tokenString,
 	beaker,
+	menuLeft,
+	menuRight,
 };
 
 appendIconComponentCache(cachedIcons);

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -7,6 +7,7 @@ import {
 	EuiToolTip,
 	EuiSpacer,
 	EuiComboBox,
+	EuiResizableContainer,
 } from '@elastic/eui';
 import { SortColumns, useRules } from '../hooks/useRules';
 import { StandaloneRuleForm } from '../RuleForm';
@@ -20,6 +21,7 @@ import { useDebouncedValue } from '../hooks/useDebounce';
 import { FullHeightContentWithFixedHeader } from '../layout/FullHeightContentWithFixedHeader';
 import { Tag, TagsContext } from '../context/tags';
 import { ruleTypeOptions } from '../RuleContent';
+import { css } from '@emotion/react';
 
 export const useCreateEditPermissions = () => {
 	const permissions = useContext(PageContext).permissions;
@@ -229,45 +231,68 @@ export const Rules = () => {
 		</>
 	);
 
-	return (
-		<EuiFlexGroup direction="row" style={{ height: '100%' }}>
-			<FullHeightContentWithFixedHeader
-				header={tableHeader}
-				content={tableContent}
-			/>
-			{formMode !== 'closed' && (
-				<EuiFlexItem>
-					{rowSelection.size > 1 ? (
-						<RuleFormBatchEdit
-							onClose={() => {
-								setFormMode('closed');
-								fetchRules(pageIndex, queryStr, sortColumns);
-							}}
-							onUpdate={() => fetchRules(pageIndex, queryStr, sortColumns)}
-							ruleIds={rowSelectionArray}
-						/>
-					) : (
-						<StandaloneRuleForm
-							onClose={() => {
-								setFormMode('closed');
-								fetchRules(pageIndex, queryStr, sortColumns);
-							}}
-							onUpdate={(id) => {
-								if (id === currentRuleId) {
-									return;
-								}
+	const formIsOpen = formMode !== 'closed';
 
-								fetchRules(pageIndex, queryStr, sortColumns);
-								setCurrentRuleId(id);
-								if (formMode === 'create') {
-									setFormMode('edit');
-								}
-							}}
-							ruleId={currentRuleId}
+	return (
+		<EuiResizableContainer style={{ height: '100%' }}>
+			{(EuiResizablePanel, EuiResizableButton) => (
+				<>
+					<EuiResizablePanel
+						initialSize={formIsOpen ? 60 : 100}
+						minSize="300px"
+						mode={'collapsible'}
+						paddingSize="none"
+						css={css`
+							padding-right: 8px;
+						`}
+					>
+						<FullHeightContentWithFixedHeader
+							header={tableHeader}
+							content={tableContent}
 						/>
-					)}
-				</EuiFlexItem>
+					</EuiResizablePanel>
+					{...formIsOpen ? [<EuiResizableButton />] : []}
+					<EuiResizablePanel
+						initialSize={formIsOpen ? 40 : 0}
+						minSize="300px"
+						mode="main"
+						paddingSize="none"
+						css={css`
+							padding-left: 8px;
+						`}
+					>
+						{rowSelection.size > 1 ? (
+							<RuleFormBatchEdit
+								onClose={() => {
+									setFormMode('closed');
+									fetchRules(pageIndex, queryStr, sortColumns);
+								}}
+								onUpdate={() => fetchRules(pageIndex, queryStr, sortColumns)}
+								ruleIds={rowSelectionArray}
+							/>
+						) : (
+							<StandaloneRuleForm
+								onClose={() => {
+									setFormMode('closed');
+									fetchRules(pageIndex, queryStr, sortColumns);
+								}}
+								onUpdate={(id) => {
+									if (id === currentRuleId) {
+										return;
+									}
+
+									fetchRules(pageIndex, queryStr, sortColumns);
+									setCurrentRuleId(id);
+									if (formMode === 'create') {
+										setFormMode('edit');
+									}
+								}}
+								ruleId={currentRuleId}
+							/>
+						)}
+					</EuiResizablePanel>
+				</>
 			)}
-		</EuiFlexGroup>
+		</EuiResizableContainer>
 	);
 };

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -254,7 +254,7 @@ export const Rules = () => {
 					{...formIsOpen ? [<EuiResizableButton />] : []}
 					<EuiResizablePanel
 						initialSize={formIsOpen ? 40 : 0}
-						minSize="300px"
+						minSize="400px"
 						mode="main"
 						paddingSize="none"
 						css={css`


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
