### PR TITLE
Drive search and selection state from the URL

### DIFF
--- a/apps/rule-manager/client/src/ts/components/RuleFormBatchEdit.tsx
+++ b/apps/rule-manager/client/src/ts/components/RuleFormBatchEdit.tsx
@@ -26,7 +26,7 @@ export const RuleFormBatchEdit = ({
 	onClose,
 	onUpdate,
 }: {
-	ruleIds: number[];
+	ruleIds: Set<number>;
 	onClose: () => void;
 	onUpdate: () => void;
 }) => {

--- a/apps/rule-manager/client/src/ts/components/hooks/useBatchRules.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useBatchRules.ts
@@ -3,7 +3,7 @@ import { errorToString } from '../../utils/error';
 import { DraftRule, RuleData } from './useRule';
 import { ErrorIResponse, responseHandler } from '../../utils/api';
 
-export function useBatchRules(ruleIds: number[] | undefined) {
+export function useBatchRules(ruleIds: Set<number> | undefined) {
 	const [isLoading, setIsLoading] = useState(false);
 	const [errors, setErrors] = useState<string | undefined>(undefined);
 	const [rules, setRules] = useState<RuleData[] | undefined>(undefined);
@@ -97,7 +97,7 @@ export function useBatchRules(ruleIds: number[] | undefined) {
 
 	useEffect(() => {
 		if (ruleIds) {
-			fetchRules(ruleIds);
+			fetchRules([...ruleIds]);
 		} else {
 			setRules([]);
 		}

--- a/apps/rule-manager/client/src/ts/components/hooks/useRuleSearchParams.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRuleSearchParams.ts
@@ -1,99 +1,120 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { isEqual } from 'lodash';
+import { isEqual, identity } from 'lodash';
 
-type RuleSearchParams = {
-	queryStr: string;
-	tagIds: number[];
-	ruleTypeOptions: string[];
-	ruleSelection: Set<number>;
-};
-
-const queryStrParamKey = 'queryStr';
-const tagIdsParamKey = 'tagIds';
-const ruleTypeOptionsParamKey = 'ruleTypeOptions';
-const ruleSelectionParamKey = 'selectedRules';
-
-export const useRuleSearchParams = (): [
-	RuleSearchParams,
-	(rs: RuleSearchParams) => void,
-] => {
+export const useStringParam = (paramKey: string) => {
 	const [searchParams, setSearchParams] = useSearchParams();
 
-	/**
-	 * It's necessary to take care to preserve object identities here, as a
-	 * change to the query string should not change the identity of the tag or
-	 * ruleType options arrays.
-	 */
-	const [queryStr, setQueryStr] = useState('');
-	const [tagIds, setTagIds] = useState([] as number[]);
-	const [ruleTypeOptions, setRuleTypeOptions] = useState([] as string[]);
-	const [ruleSelection, setRuleSelection] = useState(new Set<number>());
-	useEffect(() => {
-		const incomingTagIds: number[] = [];
-		const incomingRuleTypeOptions: string[] = [];
-		const incomingRuleSelection = new Set<number>();
-		searchParams.forEach((val, key) => {
-			switch (key) {
-				case tagIdsParamKey: {
-					const tagId = Number(val);
-					if (!isNaN(tagId)) {
-						incomingTagIds.push(tagId);
-					}
-					break;
-				}
-				case ruleTypeOptionsParamKey: {
-					incomingRuleTypeOptions.push(val);
-					break;
-				}
-				case ruleSelectionParamKey: {
-					const ruleId = Number(val);
-					if (!isNaN(ruleId)) {
-						ruleSelection.add(ruleId);
-					}
-				}
-			}
-		});
+	const paramValue = useMemo(
+		() => searchParams.get(paramKey) || '',
+		[searchParams],
+	);
 
-		setQueryStr(searchParams.get('queryStr') ?? '');
-		if (!isEqual(incomingTagIds, tagIds)) {
-			setTagIds(incomingTagIds);
+	const setParamValue = useMemo(
+		() => (value: string) => {
+			searchParams.set(paramKey, value);
+			setSearchParams(searchParams);
+		},
+		[searchParams],
+	);
+
+	return [paramValue, setParamValue] as const;
+};
+
+const getArrayValuesFromSearchParams = <T>(
+	searchParams: URLSearchParams,
+	paramKey: string,
+	transformer: (paramVal: string) => T,
+) => {
+	const incomingValue: T[] = [];
+	searchParams.forEach((val, key) => {
+		if (key === paramKey) {
+			incomingValue.push(transformer(val));
 		}
-		if (!isEqual(incomingRuleTypeOptions, ruleTypeOptions)) {
-			setRuleTypeOptions(incomingRuleTypeOptions);
+	});
+	return incomingValue;
+};
+
+const getSetValuesFromSearchParams = <T>(
+	searchParams: URLSearchParams,
+	paramKey: string,
+	transformer: (paramVal: string) => T,
+) => {
+	const incomingValue = new Set<T>();
+	searchParams.forEach((val, key) => {
+		if (key === paramKey) {
+			incomingValue.add(transformer(val));
 		}
-		if (!isEqual(incomingRuleSelection, ruleSelection)) {
-			setRuleSelection(incomingRuleSelection);
+	});
+	return incomingValue;
+};
+
+const useCollectionParam = <I extends Set<T> | Array<T>, T = string>(
+	paramKey: string,
+	transformIn: (paramVal: string) => T = identity,
+	transformOut: (paramVal: T) => string = identity,
+	getValuesFromSearchParams: (
+		searchParams: URLSearchParams,
+		paramKey: string,
+		transformer: (paramVal: string) => T,
+	) => I,
+) => {
+	const [searchParams, setSearchParams] = useSearchParams();
+	const [localParamValue, setLocalParamValue] = useState<I>(() =>
+		getValuesFromSearchParams(searchParams, paramKey, transformIn),
+	);
+
+	useEffect(() => {
+		const incomingValue = getValuesFromSearchParams(
+			searchParams,
+			paramKey,
+			transformIn,
+		);
+
+		/**
+		 * We take care to preserve object identities here, as a change to the
+		 * query string should not change the identity of the tag or ruleType
+		 * options arrays.
+		 */
+		if (!isEqual(incomingValue, localParamValue)) {
+			setLocalParamValue(incomingValue);
 		}
 	}, [searchParams]);
 
-	const ruleSearchParams = useMemo(
-		() => ({
-			queryStr,
-			tagIds,
-			ruleTypeOptions,
-			ruleSelection,
-		}),
-		[queryStr, tagIds, ruleTypeOptions, ruleSelection],
-	);
-
-	const setRuleSearchParams = useMemo(
-		() => (rs: RuleSearchParams) => {
-			const params = new URLSearchParams();
-			params.append(queryStrParamKey, rs.queryStr);
-			for (const tagId of rs.tagIds) {
-				params.append(tagIdsParamKey, tagId.toString());
+	const setParamValue = useMemo(
+		() => (newValue: I) => {
+			searchParams.delete(paramKey);
+			for (const value of newValue) {
+				searchParams.append(paramKey, transformOut(value));
 			}
-			for (const ruleTypeOption of rs.ruleTypeOptions) {
-				params.append(ruleTypeOptionsParamKey, ruleTypeOption);
-			}
-			for (const ruleId of rs.ruleSelection) {
-				params.append(ruleSelectionParamKey, ruleId.toString());
-			}
-			setSearchParams(params);
+			setSearchParams(searchParams);
 		},
-		[setSearchParams],
+		[searchParams],
 	);
 
-	return [ruleSearchParams, setRuleSearchParams];
+	return [localParamValue, setParamValue] as const;
 };
+
+export const useArrayParam = <T = string>(
+	paramKey: string,
+	transformIn: (paramVal: string) => T = identity,
+	transformOut: (paramVal: T) => string = identity,
+) =>
+	useCollectionParam(
+		paramKey,
+		transformIn,
+		transformOut,
+		getArrayValuesFromSearchParams,
+	);
+
+export const useSetParam = <T = string>(
+	paramKey: string,
+	transformIn: (paramVal: string) => T = identity,
+	transformOut: (paramVal: T) => string = identity,
+) =>
+	useCollectionParam(
+		paramKey,
+		transformIn,
+		transformOut,
+		getSetValuesFromSearchParams,
+	);

--- a/apps/rule-manager/client/src/ts/components/hooks/useRuleSearchParams.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRuleSearchParams.ts
@@ -1,0 +1,80 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+type RuleSearchParams = {
+	queryStr: string;
+	tagIds: number[];
+	ruleTypeOptions: string[];
+};
+
+export const useRuleSearchParams = (): [
+	RuleSearchParams,
+	(rs: RuleSearchParams) => void,
+] => {
+	const [searchParams, setSearchParams] = useSearchParams();
+
+	/**
+	 * It's necessary to take care to preserve object identities here, as a
+	 * change to the query string should not change the identity of the tag or
+	 * ruleType options arrays.
+	 */
+	const [queryStr, setQueryStr] = useState('');
+	const [tagIds, setTagIds] = useState([] as number[]);
+	const [ruleTypeOptions, setRuleTypeOptions] = useState([] as string[]);
+	useEffect(() => {
+		const incomingTagIds: number[] = [];
+		const incomingRuleTypeOptions: string[] = [];
+		searchParams.forEach((val, key) => {
+			switch (key) {
+				case 'tagId': {
+					const tagId = Number(val);
+					if (!isNaN(tagId)) {
+						incomingTagIds.push(tagId);
+					}
+					break;
+				}
+				case 'ruleTypeOptions': {
+					incomingRuleTypeOptions.push(val);
+					break;
+				}
+			}
+		});
+
+		setQueryStr(searchParams.get('queryStr') ?? '');
+		if (JSON.stringify(incomingTagIds) !== JSON.stringify(tagIds)) {
+			setTagIds(incomingTagIds);
+		}
+		if (
+			JSON.stringify(incomingRuleTypeOptions) !==
+			JSON.stringify(ruleTypeOptions)
+		) {
+			setRuleTypeOptions(incomingRuleTypeOptions);
+		}
+	}, [searchParams]);
+
+	const ruleSearchParams = useMemo(
+		() => ({
+			queryStr,
+			tagIds,
+			ruleTypeOptions,
+		}),
+		[queryStr, tagIds, ruleTypeOptions],
+	);
+
+	const setRuleSearchParams = useMemo(
+		() => (rs: RuleSearchParams) => {
+			const params = new URLSearchParams();
+			params.append('queryStr', rs.queryStr);
+			for (const tagId of rs.tagIds) {
+				params.append('tagId', tagId.toString());
+			}
+			for (const ruleTypeOption of rs.ruleTypeOptions) {
+				params.append('ruleTypeOptions', ruleTypeOption);
+			}
+			setSearchParams(params);
+		},
+		[setSearchParams],
+	);
+
+	return [ruleSearchParams, setRuleSearchParams];
+};

--- a/apps/rule-manager/client/src/ts/components/hooks/useRuleSearchParams.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRuleSearchParams.ts
@@ -1,11 +1,18 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { isEqual } from 'lodash';
 
 type RuleSearchParams = {
 	queryStr: string;
 	tagIds: number[];
 	ruleTypeOptions: string[];
+	ruleSelection: Set<number>;
 };
+
+const queryStrParamKey = 'queryStr';
+const tagIdsParamKey = 'tagIds';
+const ruleTypeOptionsParamKey = 'ruleTypeOptions';
+const ruleSelectionParamKey = 'selectedRules';
 
 export const useRuleSearchParams = (): [
 	RuleSearchParams,
@@ -21,34 +28,42 @@ export const useRuleSearchParams = (): [
 	const [queryStr, setQueryStr] = useState('');
 	const [tagIds, setTagIds] = useState([] as number[]);
 	const [ruleTypeOptions, setRuleTypeOptions] = useState([] as string[]);
+	const [ruleSelection, setRuleSelection] = useState(new Set<number>());
 	useEffect(() => {
 		const incomingTagIds: number[] = [];
 		const incomingRuleTypeOptions: string[] = [];
+		const incomingRuleSelection = new Set<number>();
 		searchParams.forEach((val, key) => {
 			switch (key) {
-				case 'tagId': {
+				case tagIdsParamKey: {
 					const tagId = Number(val);
 					if (!isNaN(tagId)) {
 						incomingTagIds.push(tagId);
 					}
 					break;
 				}
-				case 'ruleTypeOptions': {
+				case ruleTypeOptionsParamKey: {
 					incomingRuleTypeOptions.push(val);
 					break;
+				}
+				case ruleSelectionParamKey: {
+					const ruleId = Number(val);
+					if (!isNaN(ruleId)) {
+						ruleSelection.add(ruleId);
+					}
 				}
 			}
 		});
 
 		setQueryStr(searchParams.get('queryStr') ?? '');
-		if (JSON.stringify(incomingTagIds) !== JSON.stringify(tagIds)) {
+		if (!isEqual(incomingTagIds, tagIds)) {
 			setTagIds(incomingTagIds);
 		}
-		if (
-			JSON.stringify(incomingRuleTypeOptions) !==
-			JSON.stringify(ruleTypeOptions)
-		) {
+		if (!isEqual(incomingRuleTypeOptions, ruleTypeOptions)) {
 			setRuleTypeOptions(incomingRuleTypeOptions);
+		}
+		if (!isEqual(incomingRuleSelection, ruleSelection)) {
+			setRuleSelection(incomingRuleSelection);
 		}
 	}, [searchParams]);
 
@@ -57,19 +72,23 @@ export const useRuleSearchParams = (): [
 			queryStr,
 			tagIds,
 			ruleTypeOptions,
+			ruleSelection,
 		}),
-		[queryStr, tagIds, ruleTypeOptions],
+		[queryStr, tagIds, ruleTypeOptions, ruleSelection],
 	);
 
 	const setRuleSearchParams = useMemo(
 		() => (rs: RuleSearchParams) => {
 			const params = new URLSearchParams();
-			params.append('queryStr', rs.queryStr);
+			params.append(queryStrParamKey, rs.queryStr);
 			for (const tagId of rs.tagIds) {
-				params.append('tagId', tagId.toString());
+				params.append(tagIdsParamKey, tagId.toString());
 			}
 			for (const ruleTypeOption of rs.ruleTypeOptions) {
-				params.append('ruleTypeOptions', ruleTypeOption);
+				params.append(ruleTypeOptionsParamKey, ruleTypeOption);
+			}
+			for (const ruleId of rs.ruleSelection) {
+				params.append(ruleSelectionParamKey, ruleId.toString());
 			}
 			setSearchParams(params);
 		},

--- a/apps/rule-manager/client/src/ts/components/hooks/useRuleSelection.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRuleSelection.ts
@@ -1,0 +1,40 @@
+import { useReducer } from 'react';
+import { PaginatedRuleData } from './useRules';
+
+export type RowState = Set<number>;
+export type RowAction =
+	| { type: 'add'; id: number }
+	| { type: 'delete'; id: number }
+	| { type: 'set'; id: number }
+	| { type: 'clear' }
+	| { type: 'selectAll' };
+
+export const useRuleSelection = (
+	initialRules: Set<number>,
+	ruleData: PaginatedRuleData | null,
+) =>
+	useReducer((selectedRows: RowState, action: RowAction): RowState => {
+		switch (action.type) {
+			case 'set': {
+				return new Set([action.id]);
+			}
+			case 'add': {
+				const nextRowSelection = new Set(selectedRows);
+				nextRowSelection.add(action.id);
+				return nextRowSelection;
+			}
+			case 'delete': {
+				const nextRowSelection = new Set(selectedRows);
+				nextRowSelection.delete(action.id);
+				return nextRowSelection;
+			}
+			case 'clear': {
+				return new Set();
+			}
+			case 'selectAll': {
+				return !ruleData?.data || selectedRows.size === ruleData.data.length
+					? new Set()
+					: new Set(ruleData.data.map((rule) => rule.id as number));
+			}
+		}
+	}, initialRules);

--- a/apps/rule-manager/client/src/ts/components/hooks/useRuleSelection.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRuleSelection.ts
@@ -5,7 +5,7 @@ export type RowState = Set<number>;
 export type RowAction =
 	| { type: 'add'; id: number }
 	| { type: 'delete'; id: number }
-	| { type: 'set'; id: number }
+	| { type: 'set'; ids: number[] }
 	| { type: 'clear' }
 	| { type: 'selectAll' };
 
@@ -16,7 +16,7 @@ export const useRuleSelection = (
 	useReducer((selectedRows: RowState, action: RowAction): RowState => {
 		switch (action.type) {
 			case 'set': {
-				return new Set([action.id]);
+				return new Set(action.ids);
 			}
 			case 'add': {
 				const nextRowSelection = new Set(selectedRows);

--- a/apps/rule-manager/client/src/ts/components/hooks/useRules.ts
+++ b/apps/rule-manager/client/src/ts/components/hooks/useRules.ts
@@ -24,7 +24,7 @@ export type SortColumns = Array<{
 export function useRules() {
 	const { location } = window;
 	const [ruleData, setRulesData] = useState<PaginatedRuleData | null>(null);
-	const [isLoading, setIsLoading] = useState(false);
+	const [isLoading, setIsLoading] = useState(true); // Assume that if we are using rules, we will be fetching immediately
 	const [error, setError] = useState<string | undefined>(undefined);
 	const [isRefreshing, setIsRefreshing] = useState(false);
 	const [abortController, setAbortController] = useState<AbortController>();

--- a/apps/rule-manager/client/src/ts/components/icons/index.ts
+++ b/apps/rule-manager/client/src/ts/components/icons/index.ts
@@ -39,6 +39,8 @@ import { icon as sortRight } from '@elastic/eui/src/components/icon/assets/sortR
 import { icon as fullScreenExit } from '@elastic/eui/src/components/icon/assets/fullScreenExit';
 import { icon as tokenString } from '@elastic/eui/src/components/icon/assets/tokenString';
 import { icon as beaker } from '@elastic/eui/src/components/icon/assets/beaker';
+import { icon as menuLeft } from '@elastic/eui/src/components/icon/assets/menuLeft';
+import { icon as menuRight } from '@elastic/eui/src/components/icon/assets/menuRight';
 
 const cachedIcons = {
 	apps,
@@ -81,6 +83,8 @@ const cachedIcons = {
 	expandMini,
 	tokenString,
 	beaker,
+	menuLeft,
+	menuRight,
 };
 
 appendIconComponentCache(cachedIcons);

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -23,6 +23,7 @@ import { TagsContext } from '../context/tags';
 import { ruleTypeOptions } from '../RuleContent';
 import { css } from '@emotion/react';
 import { useRuleSearchParams } from '../hooks/useRuleSearchParams';
+import { useRuleSelection } from '../hooks/useRuleSelection';
 
 export const useCreateEditPermissions = () => {
 	const permissions = useContext(PageContext).permissions;
@@ -36,8 +37,9 @@ const ruleTypeOptionsWithId = ruleTypeOptions.map((opt) => ({
 }));
 
 export const Rules = () => {
-	const { tags } = useContext(TagsContext);
 	const [params, setParams] = useRuleSearchParams();
+	const { tags } = useContext(TagsContext);
+
 	const selectedRuleTypeOptions = useMemo(
 		() =>
 			params.ruleTypeOptions.flatMap((optionValue) =>
@@ -45,6 +47,7 @@ export const Rules = () => {
 			),
 		[ruleTypeOptionsWithId, params.ruleTypeOptions],
 	);
+
 	const selectedTags = useMemo(
 		() =>
 			params.tagIds.flatMap((optionValue) =>
@@ -59,7 +62,9 @@ export const Rules = () => {
 			Object.values(tags).map((tag) => ({ label: tag.name, value: tag.id })),
 		[tags],
 	);
+
 	const debouncedQueryStr = useDebouncedValue(params.queryStr, 200);
+
 	const {
 		ruleData,
 		isLoading,
@@ -71,6 +76,10 @@ export const Rules = () => {
 		refreshDictionaryRules,
 	} = useRules();
 
+	const [ruleSelection, setRuleSelection] = useRuleSelection(
+		params.ruleSelection,
+		ruleData,
+	);
 	const [formMode, setFormMode] = useState<'closed' | 'create' | 'edit'>(
 		'closed',
 	);
@@ -79,7 +88,6 @@ export const Rules = () => {
 	const [currentRuleId, setCurrentRuleId] = useState<number | undefined>(
 		undefined,
 	);
-	const [rowSelection, setRowSelection] = useState<Set<number>>(new Set());
 	const { getFeatureSwitchValue } = useContext(FeatureSwitchesContext);
 	const hasCreatePermissions = useCreateEditPermissions();
 
@@ -105,12 +113,23 @@ export const Rules = () => {
 	]);
 
 	useEffect(() => {
-		if (rowSelection.size === 0) {
+		if (params.ruleSelection.size === 0) {
 			setFormMode('closed');
 		}
-	}, [rowSelection]);
+	}, [params.ruleSelection]);
 
-	const rowSelectionArray = useMemo(() => [...rowSelection], [rowSelection]);
+	useEffect(() => {
+		setParams({ ...params, ruleSelection });
+		if (ruleSelection.size === 1) {
+			setCurrentRuleId([...ruleSelection].pop());
+		}
+		setFormMode('edit');
+	}, [ruleSelection]);
+
+	const rowSelectionArray = useMemo(
+		() => [...params.ruleSelection],
+		[params.ruleSelection],
+	);
 
 	const tableHeader = (
 		<div>
@@ -236,13 +255,8 @@ export const Rules = () => {
 					isLoading={isLoading}
 					ruleData={ruleData}
 					canEditRule={hasCreatePermissions}
-					onSelectionChanged={(rows) => {
-						setRowSelection(rows);
-						if (rows.size === 1) {
-							setCurrentRuleId([...rows].pop());
-						}
-						setFormMode('edit');
-					}}
+					ruleSelection={ruleSelection}
+					setRuleSelection={setRuleSelection}
 					pageIndex={pageIndex}
 					setPageIndex={setPageIndex}
 					sortColumns={sortColumns}
@@ -282,7 +296,7 @@ export const Rules = () => {
 							padding-left: 8px;
 						`}
 					>
-						{rowSelection.size > 1 ? (
+						{params.ruleSelection.size > 1 ? (
 							<RuleFormBatchEdit
 								onClose={() => {
 									setFormMode('closed');
@@ -297,14 +311,14 @@ export const Rules = () => {
 							<StandaloneRuleForm
 								onClose={() => {
 									setFormMode('closed');
-									fetchRules(pageIndex, params.queryStr, sortColumns);
+									fetchRules(pageIndex, debouncedQueryStr, sortColumns);
 								}}
 								onUpdate={(id) => {
 									if (id === currentRuleId) {
 										return;
 									}
 
-									fetchRules(pageIndex, params.queryStr, sortColumns);
+									fetchRules(pageIndex, debouncedQueryStr, sortColumns);
 									setCurrentRuleId(id);
 									if (formMode === 'create') {
 										setFormMode('edit');

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -7,6 +7,7 @@ import {
 	EuiToolTip,
 	EuiSpacer,
 	EuiComboBox,
+	EuiResizableContainer,
 } from '@elastic/eui';
 import { SortColumns, useRules } from '../hooks/useRules';
 import { StandaloneRuleForm } from '../RuleForm';
@@ -20,6 +21,7 @@ import { useDebouncedValue } from '../hooks/useDebounce';
 import { FullHeightContentWithFixedHeader } from '../layout/FullHeightContentWithFixedHeader';
 import { Tag, TagsContext } from '../context/tags';
 import { ruleTypeOptions } from '../RuleContent';
+import { css } from '@emotion/react';
 
 export const useCreateEditPermissions = () => {
 	const permissions = useContext(PageContext).permissions;
@@ -229,45 +231,68 @@ export const Rules = () => {
 		</>
 	);
 
-	return (
-		<EuiFlexGroup direction="row" style={{ height: '100%' }}>
-			<FullHeightContentWithFixedHeader
-				header={tableHeader}
-				content={tableContent}
-			/>
-			{formMode !== 'closed' && (
-				<EuiFlexItem>
-					{rowSelection.size > 1 ? (
-						<RuleFormBatchEdit
-							onClose={() => {
-								setFormMode('closed');
-								fetchRules(pageIndex, queryStr, sortColumns);
-							}}
-							onUpdate={() => fetchRules(pageIndex, queryStr, sortColumns)}
-							ruleIds={rowSelectionArray}
-						/>
-					) : (
-						<StandaloneRuleForm
-							onClose={() => {
-								setFormMode('closed');
-								fetchRules(pageIndex, queryStr, sortColumns);
-							}}
-							onUpdate={(id) => {
-								if (id === currentRuleId) {
-									return;
-								}
+	const formIsOpen = formMode !== 'closed';
 
-								fetchRules(pageIndex, queryStr, sortColumns);
-								setCurrentRuleId(id);
-								if (formMode === 'create') {
-									setFormMode('edit');
-								}
-							}}
-							ruleId={currentRuleId}
+	return (
+		<EuiResizableContainer style={{ height: '100%' }}>
+			{(EuiResizablePanel, EuiResizableButton) => (
+				<>
+					<EuiResizablePanel
+						initialSize={formIsOpen ? 60 : 100}
+						minSize="300px"
+						mode={'collapsible'}
+						paddingSize="none"
+						css={css`
+							padding-right: 8px;
+						`}
+					>
+						<FullHeightContentWithFixedHeader
+							header={tableHeader}
+							content={tableContent}
 						/>
-					)}
-				</EuiFlexItem>
+					</EuiResizablePanel>
+					{...formIsOpen ? [<EuiResizableButton />] : []}
+					<EuiResizablePanel
+						initialSize={formIsOpen ? 40 : 0}
+						minSize="300px"
+						mode="main"
+						paddingSize="none"
+						css={css`
+							padding-left: 8px;
+						`}
+					>
+						{rowSelection.size > 1 ? (
+							<RuleFormBatchEdit
+								onClose={() => {
+									setFormMode('closed');
+									fetchRules(pageIndex, queryStr, sortColumns);
+								}}
+								onUpdate={() => fetchRules(pageIndex, queryStr, sortColumns)}
+								ruleIds={rowSelectionArray}
+							/>
+						) : (
+							<StandaloneRuleForm
+								onClose={() => {
+									setFormMode('closed');
+									fetchRules(pageIndex, queryStr, sortColumns);
+								}}
+								onUpdate={(id) => {
+									if (id === currentRuleId) {
+										return;
+									}
+
+									fetchRules(pageIndex, queryStr, sortColumns);
+									setCurrentRuleId(id);
+									if (formMode === 'create') {
+										setFormMode('edit');
+									}
+								}}
+								ruleId={currentRuleId}
+							/>
+						)}
+					</EuiResizablePanel>
+				</>
 			)}
-		</EuiFlexGroup>
+		</EuiResizableContainer>
 	);
 };

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -19,9 +19,10 @@ import { EuiFieldSearch } from '@elastic/eui/src/components/form/field_search';
 import { PaginatedRulesTable } from '../table/PaginatedRulesTable';
 import { useDebouncedValue } from '../hooks/useDebounce';
 import { FullHeightContentWithFixedHeader } from '../layout/FullHeightContentWithFixedHeader';
-import { Tag, TagsContext } from '../context/tags';
+import { TagsContext } from '../context/tags';
 import { ruleTypeOptions } from '../RuleContent';
 import { css } from '@emotion/react';
+import { useRuleSearchParams } from '../hooks/useRuleSearchParams';
 
 export const useCreateEditPermissions = () => {
 	const permissions = useContext(PageContext).permissions;
@@ -35,20 +36,30 @@ const ruleTypeOptionsWithId = ruleTypeOptions.map((opt) => ({
 }));
 
 export const Rules = () => {
-	const [queryStr, setQueryStr] = useState<string>('');
-	const [selectedRuleTypeOptions, setSelectedRuleTypeOptions] = useState<
-		{ label: string; value: string }[]
-	>([]);
-	const [selectedTags, setSelectedTags] = useState<
-		{ label: string; value: number }[]
-	>([]);
 	const { tags } = useContext(TagsContext);
+	const [params, setParams] = useRuleSearchParams();
+	const selectedRuleTypeOptions = useMemo(
+		() =>
+			params.ruleTypeOptions.flatMap((optionValue) =>
+				ruleTypeOptionsWithId.filter(({ value }) => value == optionValue),
+			),
+		[ruleTypeOptionsWithId, params.ruleTypeOptions],
+	);
+	const selectedTags = useMemo(
+		() =>
+			params.tagIds.flatMap((optionValue) =>
+				tags[optionValue]
+					? [{ value: optionValue, label: tags[optionValue].name }]
+					: [],
+			),
+		[tags, params.tagIds],
+	);
 	const tagOptions = useMemo(
 		() =>
 			Object.values(tags).map((tag) => ({ label: tag.name, value: tag.id })),
 		[tags],
 	);
-	const debouncedQueryStr = useDebouncedValue(queryStr, 200);
+	const debouncedQueryStr = useDebouncedValue(params.queryStr, 200);
 	const {
 		ruleData,
 		isLoading,
@@ -82,15 +93,15 @@ export const Rules = () => {
 			pageIndex,
 			debouncedQueryStr,
 			sortColumns,
-			selectedTags.map((_) => _.value),
-			selectedRuleTypeOptions.map((_) => _.value),
+			params.tagIds,
+			params.ruleTypeOptions,
 		);
 	}, [
 		pageIndex,
 		debouncedQueryStr,
 		sortColumns,
-		selectedTags,
-		selectedRuleTypeOptions,
+		params.tagIds,
+		params.ruleTypeOptions,
 	]);
 
 	useEffect(() => {
@@ -161,8 +172,10 @@ export const Rules = () => {
 							<EuiFieldSearch
 								placeholder="Search tag description, pattern, or replacement"
 								fullWidth
-								value={queryStr}
-								onChange={(e) => setQueryStr(e.target.value)}
+								value={params.queryStr}
+								onChange={(e) =>
+									setParams({ ...params, queryStr: e.target.value })
+								}
 							/>
 						</EuiFlexItem>
 						<EuiComboBox<string>
@@ -170,10 +183,13 @@ export const Rules = () => {
 							placeholder="Filter by rule type"
 							options={ruleTypeOptionsWithId}
 							selectedOptions={selectedRuleTypeOptions}
-							onChange={(ids) =>
-								setSelectedRuleTypeOptions(
-									ids as { label: string; value: string }[],
-								)
+							onChange={(ruleTypeOptions) =>
+								setParams({
+									...params,
+									ruleTypeOptions: ruleTypeOptions.flatMap(({ value }) =>
+										value ? [value] : [],
+									),
+								})
 							}
 						/>
 						<EuiComboBox<number>
@@ -181,8 +197,13 @@ export const Rules = () => {
 							placeholder="Filter by tag"
 							options={tagOptions}
 							selectedOptions={selectedTags}
-							onChange={(ids) =>
-								setSelectedTags(ids as { label: string; value: number }[])
+							onChange={(tagOptions) =>
+								setParams({
+									...params,
+									tagIds: tagOptions.flatMap(({ value }) =>
+										value ? [value] : [],
+									),
+								})
 							}
 						/>
 					</EuiFlexGroup>
@@ -265,23 +286,25 @@ export const Rules = () => {
 							<RuleFormBatchEdit
 								onClose={() => {
 									setFormMode('closed');
-									fetchRules(pageIndex, queryStr, sortColumns);
+									fetchRules(pageIndex, debouncedQueryStr, sortColumns);
 								}}
-								onUpdate={() => fetchRules(pageIndex, queryStr, sortColumns)}
+								onUpdate={() =>
+									fetchRules(pageIndex, debouncedQueryStr, sortColumns)
+								}
 								ruleIds={rowSelectionArray}
 							/>
 						) : (
 							<StandaloneRuleForm
 								onClose={() => {
 									setFormMode('closed');
-									fetchRules(pageIndex, queryStr, sortColumns);
+									fetchRules(pageIndex, params.queryStr, sortColumns);
 								}}
 								onUpdate={(id) => {
 									if (id === currentRuleId) {
 										return;
 									}
 
-									fetchRules(pageIndex, queryStr, sortColumns);
+									fetchRules(pageIndex, params.queryStr, sortColumns);
 									setCurrentRuleId(id);
 									if (formMode === 'create') {
 										setFormMode('edit');

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -254,7 +254,7 @@ export const Rules = () => {
 					{...formIsOpen ? [<EuiResizableButton />] : []}
 					<EuiResizablePanel
 						initialSize={formIsOpen ? 40 : 0}
-						minSize="300px"
+						minSize="400px"
 						mode="main"
 						paddingSize="none"
 						css={css`

--- a/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
+++ b/apps/rule-manager/client/src/ts/components/pages/Rules.tsx
@@ -22,7 +22,11 @@ import { FullHeightContentWithFixedHeader } from '../layout/FullHeightContentWit
 import { TagsContext } from '../context/tags';
 import { ruleTypeOptions } from '../RuleContent';
 import { css } from '@emotion/react';
-import { useRuleSearchParams } from '../hooks/useRuleSearchParams';
+import {
+	useArrayParam,
+	useSetParam,
+	useStringParam,
+} from '../hooks/useRuleSearchParams';
 import { useRuleSelection } from '../hooks/useRuleSelection';
 
 export const useCreateEditPermissions = () => {
@@ -36,26 +40,41 @@ const ruleTypeOptionsWithId = ruleTypeOptions.map((opt) => ({
 	value: opt.id,
 }));
 
+const queryStrParamKey = 'queryStr';
+const tagIdsParamKey = 'tagIds';
+const ruleTypeOptionsParamKey = 'ruleTypeOptions';
+const ruleSelectionParamKey = 'selectedRules';
+
 export const Rules = () => {
-	const [params, setParams] = useRuleSearchParams();
+	const [queryStr, setQueryStr] = useStringParam(queryStrParamKey);
+	const [ruleTypeOptions, setRuleTypeOptions] = useArrayParam(
+		ruleTypeOptionsParamKey,
+	);
+	const [tagIds, setTagIds] = useArrayParam(tagIdsParamKey, Number, String);
+	const [selectedRules, setSelectedRules] = useSetParam(
+		ruleSelectionParamKey,
+		Number,
+		String,
+	);
+
 	const { tags } = useContext(TagsContext);
 
 	const selectedRuleTypeOptions = useMemo(
 		() =>
-			params.ruleTypeOptions.flatMap((optionValue) =>
+			ruleTypeOptions.flatMap((optionValue) =>
 				ruleTypeOptionsWithId.filter(({ value }) => value == optionValue),
 			),
-		[ruleTypeOptionsWithId, params.ruleTypeOptions],
+		[ruleTypeOptionsWithId, ruleTypeOptions],
 	);
 
 	const selectedTags = useMemo(
 		() =>
-			params.tagIds.flatMap((optionValue) =>
+			tagIds.flatMap((optionValue) =>
 				tags[optionValue]
 					? [{ value: optionValue, label: tags[optionValue].name }]
 					: [],
 			),
-		[tags, params.tagIds],
+		[tags, tagIds],
 	);
 	const tagOptions = useMemo(
 		() =>
@@ -63,7 +82,7 @@ export const Rules = () => {
 		[tags],
 	);
 
-	const debouncedQueryStr = useDebouncedValue(params.queryStr, 200);
+	const debouncedQueryStr = useDebouncedValue(queryStr, 200);
 
 	const {
 		ruleData,
@@ -77,9 +96,23 @@ export const Rules = () => {
 	} = useRules();
 
 	const [ruleSelection, setRuleSelection] = useRuleSelection(
-		params.ruleSelection,
+		selectedRules,
 		ruleData,
 	);
+
+	useEffect(() => {
+		if (isLoading) {
+			return;
+		}
+
+		const selectedRuleIdsInMemory = [...selectedRules].filter((ruleId) =>
+			ruleData?.data.some((rule) => rule.id === ruleId),
+		);
+		if (selectedRuleIdsInMemory.length !== selectedRules.size) {
+			setRuleSelection({ type: 'set', ids: selectedRuleIdsInMemory  });
+		}
+	}, [ruleData, ruleSelection, isLoading]);
+
 	const [formMode, setFormMode] = useState<'closed' | 'create' | 'edit'>(
 		'closed',
 	);
@@ -101,35 +134,24 @@ export const Rules = () => {
 			pageIndex,
 			debouncedQueryStr,
 			sortColumns,
-			params.tagIds,
-			params.ruleTypeOptions,
+			tagIds,
+			ruleTypeOptions,
 		);
-	}, [
-		pageIndex,
-		debouncedQueryStr,
-		sortColumns,
-		params.tagIds,
-		params.ruleTypeOptions,
-	]);
+	}, [pageIndex, debouncedQueryStr, sortColumns, tagIds, ruleTypeOptions]);
 
 	useEffect(() => {
-		if (params.ruleSelection.size === 0) {
+		if (selectedRules.size === 0) {
 			setFormMode('closed');
 		}
-	}, [params.ruleSelection]);
+	}, [selectedRules]);
 
 	useEffect(() => {
-		setParams({ ...params, ruleSelection });
+		setSelectedRules(ruleSelection);
 		if (ruleSelection.size === 1) {
 			setCurrentRuleId([...ruleSelection].pop());
 		}
 		setFormMode('edit');
 	}, [ruleSelection]);
-
-	const rowSelectionArray = useMemo(
-		() => [...params.ruleSelection],
-		[params.ruleSelection],
-	);
 
 	const tableHeader = (
 		<div>
@@ -191,10 +213,8 @@ export const Rules = () => {
 							<EuiFieldSearch
 								placeholder="Search tag description, pattern, or replacement"
 								fullWidth
-								value={params.queryStr}
-								onChange={(e) =>
-									setParams({ ...params, queryStr: e.target.value })
-								}
+								value={queryStr}
+								onChange={(e) => setQueryStr(e.target.value)}
 							/>
 						</EuiFlexItem>
 						<EuiComboBox<string>
@@ -203,12 +223,11 @@ export const Rules = () => {
 							options={ruleTypeOptionsWithId}
 							selectedOptions={selectedRuleTypeOptions}
 							onChange={(ruleTypeOptions) =>
-								setParams({
-									...params,
-									ruleTypeOptions: ruleTypeOptions.flatMap(({ value }) =>
+								setRuleTypeOptions(
+									ruleTypeOptions.flatMap(({ value }) =>
 										value ? [value] : [],
 									),
-								})
+								)
 							}
 						/>
 						<EuiComboBox<number>
@@ -217,12 +236,9 @@ export const Rules = () => {
 							options={tagOptions}
 							selectedOptions={selectedTags}
 							onChange={(tagOptions) =>
-								setParams({
-									...params,
-									tagIds: tagOptions.flatMap(({ value }) =>
-										value ? [value] : [],
-									),
-								})
+								setTagIds(
+									tagOptions.flatMap(({ value }) => (value ? [value] : [])),
+								)
 							}
 						/>
 					</EuiFlexGroup>
@@ -296,7 +312,7 @@ export const Rules = () => {
 							padding-left: 8px;
 						`}
 					>
-						{params.ruleSelection.size > 1 ? (
+						{selectedRules.size > 1 ? (
 							<RuleFormBatchEdit
 								onClose={() => {
 									setFormMode('closed');
@@ -305,7 +321,7 @@ export const Rules = () => {
 								onUpdate={() =>
 									fetchRules(pageIndex, debouncedQueryStr, sortColumns)
 								}
-								ruleIds={rowSelectionArray}
+								ruleIds={selectedRules}
 							/>
 						) : (
 							<StandaloneRuleForm

--- a/apps/rule-manager/client/src/ts/components/table/PaginatedRulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/table/PaginatedRulesTable.tsx
@@ -1,10 +1,4 @@
-import React, {
-	useContext,
-	useEffect,
-	useMemo,
-	useReducer,
-	useState,
-} from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import { PaginatedRuleData, SortColumns } from '../hooks/useRules';
 import { BaseRule, DraftRule } from '../hooks/useRule';
 import {
@@ -28,17 +22,11 @@ import { EuiDataGridToolBarVisibilityOptions } from '@elastic/eui/src/components
 import { useEuiFontSize } from '@elastic/eui/src/global_styling/mixins/_typography';
 import { useNavigate } from 'react-router-dom';
 import { ruleTypeOptions } from '../RuleContent';
+import { RowAction } from '../hooks/useRuleSelection';
 
 type EditRuleButtonProps = {
 	editIsEnabled: boolean;
 };
-type RowState = Set<number>;
-type RowAction =
-	| { type: 'add'; id: number }
-	| { type: 'delete'; id: number }
-	| { type: 'set'; id: number }
-	| { type: 'clear' }
-	| { type: 'selectAll' };
 
 const TagWrapContainer = styled.div`
 	& > span {
@@ -165,47 +153,20 @@ export const PaginatedRulesTable = ({
 	setPageIndex,
 	sortColumns,
 	setSortColumns,
-	onSelectionChanged,
+	ruleSelection,
+	setRuleSelection,
 }: {
 	ruleData: PaginatedRuleData;
 	isLoading: boolean;
 	canEditRule: boolean;
-	onSelectionChanged: (rows: RowState) => void;
+	ruleSelection: Set<number>;
+	setRuleSelection: (action: RowAction) => void;
 	pageIndex: number;
 	setPageIndex: (index: number) => void;
 	sortColumns: SortColumns;
 	setSortColumns: (columns: SortColumns) => void;
 }) => {
 	const { tags } = useContext(TagsContext);
-
-	const [rowSelection, setRowSelection] = useReducer(
-		(selectedRows: RowState, action: RowAction): RowState => {
-			switch (action.type) {
-				case 'set': {
-					return new Set([action.id]);
-				}
-				case 'add': {
-					const nextRowSelection = new Set(selectedRows);
-					nextRowSelection.add(action.id);
-					return nextRowSelection;
-				}
-				case 'delete': {
-					const nextRowSelection = new Set(selectedRows);
-					nextRowSelection.delete(action.id);
-					return nextRowSelection;
-				}
-				case 'clear': {
-					return new Set();
-				}
-				case 'selectAll': {
-					return selectedRows.size === ruleData.data.length
-						? new Set()
-						: new Set(ruleData.data.map((rule) => rule.id as number));
-				}
-			}
-		},
-		new Set<number>(),
-	);
 
 	const getRuleAtRowIndex = (rowIndex: number) =>
 		ruleData.data[rowIndex - pagination.pageIndex * pagination.pageSize];
@@ -214,10 +175,6 @@ export const PaginatedRulesTable = ({
 		columns.map((_) => _.id),
 	);
 
-	useEffect(() => {
-		onSelectionChanged(rowSelection);
-	}, [rowSelection]);
-
 	const toolbarVisibility: EuiDataGridToolBarVisibilityOptions = useMemo(
 		() => ({
 			additionalControls: {
@@ -225,15 +182,15 @@ export const PaginatedRulesTable = ({
 					append: (
 						<ToolbarText>
 							{ruleData.data.length} of {ruleData.total.toLocaleString()} rules
-							{rowSelection.size > 1 && (
-								<span>, {rowSelection.size} selected</span>
+							{ruleSelection.size > 1 && (
+								<span>, {ruleSelection.size} selected</span>
 							)}
 						</ToolbarText>
 					),
 				},
 			},
 		}),
-		[rowSelection, ruleData],
+		[ruleSelection, ruleData],
 	);
 
 	const leadingColumns: EuiDataGridControlColumn[] = useMemo(
@@ -244,8 +201,8 @@ export const PaginatedRulesTable = ({
 				headerCellRender: () => (
 					<EuiCheckbox
 						id="select-all"
-						checked={rowSelection.size === ruleData.data.length}
-						onChange={() => setRowSelection({ type: 'selectAll' })}
+						checked={ruleSelection.size === ruleData.data.length}
+						onChange={() => setRuleSelection({ type: 'selectAll' })}
 					/>
 				),
 				headerCellProps: { className: 'eui-textCenter' },
@@ -255,13 +212,15 @@ export const PaginatedRulesTable = ({
 						return <EuiSkeletonText />;
 					}
 
-					const isSelected = !!rule.id && rowSelection.has(rule.id);
+					const isSelected = !!rule.id && ruleSelection.has(rule.id);
 					const type = isSelected ? 'delete' : 'add';
 					return (
 						<EuiCheckbox
 							id={`select-${rule.id}`}
 							checked={isSelected}
-							onChange={() => rule.id && setRowSelection({ type, id: rule.id })}
+							onChange={() =>
+								rule.id && setRuleSelection({ type, id: rule.id })
+							}
 						/>
 					);
 				},
@@ -269,7 +228,7 @@ export const PaginatedRulesTable = ({
 				footerCellProps: { className: 'eui-textCenter' },
 			},
 		],
-		[ruleData, rowSelection, setRowSelection],
+		[ruleData, ruleSelection, setRuleSelection],
 	);
 
 	const trailingColumns: EuiDataGridControlColumn[] = useMemo(
@@ -320,7 +279,7 @@ export const PaginatedRulesTable = ({
 							<EditRule
 								editIsEnabled={canEditRule}
 								editRule={() =>
-									setRowSelection({
+									setRuleSelection({
 										type: 'set',
 										id: getRuleAtRowIndex(rowIndex).id!,
 									})
@@ -336,7 +295,7 @@ export const PaginatedRulesTable = ({
 					),
 			},
 		],
-		[isLoading, ruleData, setRowSelection, pageIndex, canEditRule, tags],
+		[isLoading, ruleData, setRuleSelection, pageIndex, canEditRule, tags],
 	);
 
 	const renderCellValue = useMemo(
@@ -403,7 +362,7 @@ export const PaginatedRulesTable = ({
 		}
 
 		const rowClasses: Record<number, string> = {};
-		rowSelection.forEach((ruleId) => {
+		ruleSelection.forEach((ruleId) => {
 			const rowIndex =
 				ruleData.data.findIndex((rule) => rule?.id === ruleId) +
 				pagination.pageIndex * pagination.pageSize;
@@ -418,7 +377,7 @@ export const PaginatedRulesTable = ({
 		return {
 			rowClasses,
 		};
-	}, [rowSelection, pagination, isLoading]);
+	}, [ruleSelection, pagination, isLoading]);
 
 	return (
 		<PaginatedRulesTableContainer>

--- a/apps/rule-manager/client/src/ts/components/table/PaginatedRulesTable.tsx
+++ b/apps/rule-manager/client/src/ts/components/table/PaginatedRulesTable.tsx
@@ -281,7 +281,7 @@ export const PaginatedRulesTable = ({
 								editRule={() =>
 									setRuleSelection({
 										type: 'set',
-										id: getRuleAtRowIndex(rowIndex).id!,
+										ids: [getRuleAtRowIndex(rowIndex).id!],
 									})
 								}
 								rule={getRuleAtRowIndex(rowIndex)}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
