### PR TITLE
Fix vulnerability in thrift library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,8 @@ val commonSettings = Seq(
     // The jackson-module-scala version below must be kept in sync with the
     // transitive dependency on jackson-databind introduced by our AWS
     // dependencies.
-    "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.0"
+    "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.0",
+    "org.apache.thrift" % "libthrift" % "0.23.0" // to override vulnerable version 0.22
   ),
   libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always,
   checkJackson := {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The pull request adds the thrift library as a direct dependency to bump it to v0.23.0 which fixes a high severity vulnerability:
- https://github.com/guardian/typerighter/security/dependabot/353

The libraries that pull in Thrift still depend on the vulnerable version of Thrift so we cannot bump them to fix it.

## How has this change been tested?

Deploy to CODE and run a smoke test, creating a new rule and running a checker in Composer.

Run "sbt dependencyTree" to confirm the updated version of Thrift library is used.
