### PR TITLE
bump pandaVersion and awsSdkVersion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,10 +25,10 @@ ThisBuild / scalacOptions := Seq(
 ThisBuild / asciiGraphWidth := 999999999
 
 val languageToolVersion = "6.8"
-val awsSdkVersion = "2.44.7"
+val awsSdkVersion = "2.46.6"
 val capiModelsVersion = "34.0.0"
 val capiClientVersion = "40.0.0"
-val pandaVersion = "19.0.0"
+val pandaVersion = "20.1.0"
 val circeVersion = "0.14.1"
 val scalikejdbcVersion = scalikejdbc.ScalikejdbcBuildInfo.version
 val scalikejdbcPlayVersion = "2.8.0-scalikejdbc-3.5"


### PR DESCRIPTION
## What does this change?

Bumps the pandaVersion and awsSdkVersion to address:

- [GHSA-rmj7-2vxq-3g9f](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f)
- [GHSA-j3rv-43j4-c7qm](https://github.com/advisories/GHSA-j3rv-43j4-c7qm)
- [GHSA-c653-97m9-rcg9](https://github.com/advisories/GHSA-c653-97m9-rcg9)
- [GHSA-3qp7-7mw8-wx86](https://github.com/advisories/GHSA-3qp7-7mw8-wx86)
- [GHSA-x4gw-5cx5-pgmh](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh)


## How has this change been tested?

Deployed to CODE and run a smoke test, creating a new rule and running a checker in Composer.

Run "sbt dependencyTree" to confirm the updated versions of Jackson and netty libraries are used.

## How can we measure success?

Vulnerabilities down

