### PR TITLE
Bump CAPI related dependencies to pull in patched version of thrift

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,8 @@ ThisBuild / asciiGraphWidth := 999999999
 
 val languageToolVersion = "6.8"
 val awsSdkVersion = "2.53.1"
-val capiModelsVersion = "34.0.0"
-val capiClientVersion = "40.0.0"
+val capiModelsVersion = "50.0.0"
+val capiClientVersion = "49.1.1"
 val pandaVersion = "20.1.0"
 val circeVersion = "0.14.1"
 val scalikejdbcVersion = scalikejdbc.ScalikejdbcBuildInfo.version


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Should resolve the following alert:

https://github.com/guardian/typerighter/security/dependabot/450

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

Have run `sbt dependencyTree` to check that the vulnerable dependencies are no longer pulled in.

Will also deploy to CODE and do a basic smoke test (will create a new rule and check that it works  in Composer)

edit—all is well, will merge:

<img width="366" height="235" alt="Screenshot 2026-09-10 at 11 51 35" src="https://github.com/user-attachments/assets/7c83c3e9-f0da-47ca-8d64-64a61f2f3125" />